### PR TITLE
fix: read the time window off HA's clock, not the host's (#1161)

### DIFF
--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -521,7 +521,7 @@ def get_last_updated(entity_id: str, hass: HomeAssistant):
 
 def check_time_passed(time: dt.datetime):
     """Check if time is passed for datetime."""
-    now = dt.datetime.now()
+    now = dt_util.now().replace(tzinfo=None)
     return now >= time
 
 

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -496,17 +496,48 @@ def get_timedelta_str(string: str):
         return pd.to_timedelta(string)
 
 
+def local_now_naive() -> dt.datetime:
+    """Return "now" in HA's configured timezone with tzinfo stripped.
+
+    The single home for this project's naive-**local** clock convention
+    (issue #1161). A bare ``dt.datetime.now()`` reads the *host OS* zone — HA
+    never calls ``time.tzset()`` — so on any install where the host zone
+    differs from ``hass.config.time_zone`` every wall-clock comparison is
+    silently offset by the zone delta, all day, every day.
+
+    Every consumer of :func:`get_datetime_from_str`'s naive-local output must
+    source its "now" (and its implied "today") from here, so both sides of the
+    comparison sit in the same frame. That includes the *implied date* of a
+    bare ``"HH:MM:SS"`` boundary — see :func:`get_datetime_from_str`.
+
+    Not to be confused with the deliberately self-consistent naive-**UTC**
+    convention in :func:`compute_effective_default` / :func:`resolve_sun_boundaries`,
+    which is timezone-safe by construction and does not use this.
+    """
+    return dt_util.now().replace(tzinfo=None)
+
+
 def get_datetime_from_str(string: str):
     """Convert a datetime string to a naive-local datetime.
 
     Tz-aware inputs (e.g., sun-sensor UTC values like "2026-04-18T04:46:00+00:00")
     are converted to HA's configured local timezone and then stripped of tzinfo so
     downstream naive comparisons work correctly in non-UTC installs.
-    Tz-naive inputs (e.g., static "06:30") are returned unchanged.
+    Tz-naive inputs (e.g., static "06:30") keep their wall-clock time.
+
+    Components the string omits — the whole date, for the ``"HH:MM:SS"`` static
+    window bounds — are filled from HA's local date via :func:`local_now_naive`.
+    ``dateutil`` would otherwise default them from its own ``datetime.now()``,
+    i.e. the *host* clock, putting the boundary on a different calendar day
+    from the HA-framed "now" it is compared against for ``|tz-offset|`` hours
+    of every day (issue #1161).
     """
     if string is None:
         return None
-    parsed = parser.parse(string)
+    parsed = parser.parse(
+        string,
+        default=local_now_naive().replace(hour=0, minute=0, second=0, microsecond=0),
+    )
     if parsed.tzinfo is not None:
         parsed = dt_util.as_local(parsed).replace(tzinfo=None)
     return parsed
@@ -521,7 +552,7 @@ def get_last_updated(entity_id: str, hass: HomeAssistant):
 
 def check_time_passed(time: dt.datetime):
     """Check if time is passed for datetime."""
-    now = dt_util.now().replace(tzinfo=None)
+    now = local_now_naive()
     return now >= time
 
 
@@ -890,7 +921,7 @@ def _read_time_entity(hass: HomeAssistant, entity_id: str | None) -> dt.datetime
         return None
     try:
         parsed = get_datetime_from_str(raw)
-        today_local = dt_util.now().date()
+        today_local = local_now_naive().date()
         return parsed.replace(
             year=today_local.year,
             month=today_local.month,

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -7,8 +7,6 @@ import time
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.util import dt as dt_util
-
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
@@ -19,7 +17,7 @@ from ..const import (
     DEFAULT_DAYTIME_GATE_GRACE_SECONDS,
     DEFAULT_TEMPLATE_COMBINE_MODE,
 )
-from ..helpers import get_datetime_from_str, get_safe_state
+from ..helpers import get_datetime_from_str, get_safe_state, local_now_naive
 from ..templates import (
     combine_with_mode,
     is_template_string,
@@ -279,7 +277,7 @@ class TimeWindowManager:
             otherwise unchanged.
 
         """
-        today = dt_util.now().date()
+        today = local_now_naive().date()
         if time.date() > today:
             return time.replace(year=today.year, month=today.month, day=today.day)
         return time
@@ -342,7 +340,7 @@ class TimeWindowManager:
         resolved = self._resolve_start_datetime()
         if resolved is None:
             return None
-        now = dt_util.now().replace(tzinfo=None)
+        now = local_now_naive()
         self.logger.debug(
             "Start time: %s, now: %s, now >= time: %s", resolved, now, now >= resolved
         )
@@ -412,7 +410,7 @@ class TimeWindowManager:
         """
         end = self.end_time
         if end is not None:
-            now = dt_util.now().replace(tzinfo=None)
+            now = local_now_naive()
             self.logger.debug(
                 "End time: %s, now: %s, now < time: %s",
                 end,

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -7,6 +7,8 @@ import time
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.util import dt as dt_util
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
@@ -277,7 +279,7 @@ class TimeWindowManager:
             otherwise unchanged.
 
         """
-        today = dt.date.today()
+        today = dt_util.now().date()
         if time.date() > today:
             return time.replace(year=today.year, month=today.month, day=today.day)
         return time
@@ -340,7 +342,7 @@ class TimeWindowManager:
         resolved = self._resolve_start_datetime()
         if resolved is None:
             return None
-        now = dt.datetime.now()
+        now = dt_util.now().replace(tzinfo=None)
         self.logger.debug(
             "Start time: %s, now: %s, now >= time: %s", resolved, now, now >= resolved
         )
@@ -410,7 +412,7 @@ class TimeWindowManager:
         """
         end = self.end_time
         if end is not None:
-            now = dt.datetime.now()
+            now = dt_util.now().replace(tzinfo=None)
             self.logger.debug(
                 "End time: %s, now: %s, now < time: %s",
                 end,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -343,22 +343,39 @@ def test_get_last_updated_returns_none_when_entity_id_none(mock_hass):
 
 @pytest.mark.unit
 def test_check_time_passed_returns_true_when_passed():
-    """Test check_time_passed returns True when time has passed."""
-    # Create a datetime that's definitely in the past
-    past_time = dt.datetime.now() - dt.timedelta(hours=1)
+    """Test check_time_passed returns True when time has passed.
 
-    result = check_time_passed(past_time)
+    Anchors "now" via a patched dt_util.now() sentinel rather than the host
+    clock (issue #1161) — check_time_passed reads dt_util.now() internally, so
+    building the fixture from the host clock would no longer track it.
+    """
+    past_time = dt.datetime(2030, 1, 1, 0, 0, 0)
+    sentinel = dt.datetime(2035, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.helpers.dt_util.now",
+        return_value=sentinel,
+    ):
+        result = check_time_passed(past_time)
 
     assert result is True
 
 
 @pytest.mark.unit
 def test_check_time_passed_returns_false_when_future():
-    """Test check_time_passed returns False when time is in future."""
-    # Create a datetime that's definitely in the future
-    future_time = dt.datetime.now() + dt.timedelta(hours=1)
+    """Test check_time_passed returns False when time is in future.
 
-    result = check_time_passed(future_time)
+    Anchors "now" via a patched dt_util.now() sentinel rather than the host
+    clock (issue #1161) — see test_check_time_passed_returns_true_when_passed.
+    """
+    future_time = dt.datetime(2024, 1, 1, 0, 0, 0)
+    sentinel = dt.datetime(2020, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.helpers.dt_util.now",
+        return_value=sentinel,
+    ):
+        result = check_time_passed(future_time)
 
     assert result is False
 
@@ -392,6 +409,29 @@ def test_dt_check_time_passed_returns_true_for_past_date():
     yesterday = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
 
     result = dt_check_time_passed(yesterday)
+
+    assert result is True
+
+
+@pytest.mark.unit
+def test_check_time_passed_uses_dt_util_now_not_host_clock():
+    """check_time_passed must read dt_util.now(), not the naive host clock.
+
+    Issue #1161: a bare ``dt.datetime.now()`` silently reads the host OS
+    timezone instead of HA's configured ``hass.config.time_zone``. Freezing
+    ``dt_util.now()`` to a sentinel far from the real host clock must move
+    the result — proving the code reads dt_util, not the host clock.
+    """
+    fixed_time = dt.datetime(2090, 1, 1, 0, 0, 0)
+    # Sentinel is AFTER fixed_time — only a fix reading dt_util.now() can
+    # make check_time_passed True here (the real host clock is in 2026).
+    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.helpers.dt_util.now",
+        return_value=sentinel,
+    ):
+        result = check_time_passed(fixed_time)
 
     assert result is True
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,7 @@ import zoneinfo
 from unittest.mock import MagicMock, patch
 
 import pytest
+from freezegun import freeze_time
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENTITIES,
@@ -296,6 +297,28 @@ def test_get_datetime_from_str_preserves_naive_static_time():
 
     assert result.hour == 6
     assert result.minute == 30
+    assert result.tzinfo is None
+
+
+@pytest.mark.unit
+def test_get_datetime_from_str_anchors_missing_date_on_ha_local_date():
+    """A bare "HH:MM:SS" gets HA's local date, not the host clock's (#1161).
+
+    ``dateutil`` fills components the string omits from its own
+    ``datetime.now()`` — the host clock. Here HA is in Pacific/Auckland while
+    the frozen instant is 2026-08-02 14:06 UTC, so the host is still on 08-02
+    and HA-local has already rolled to 08-03. The boundary must land on the
+    HA-local date, because that is the frame the "now" it gets compared
+    against comes from.
+    """
+    auckland = zoneinfo.ZoneInfo("Pacific/Auckland")
+    with (
+        freeze_time("2026-08-02 14:06:00"),
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", auckland),
+    ):
+        result = get_datetime_from_str("08:00:00")
+
+    assert result == dt.datetime(2026, 8, 3, 8, 0, 0)
     assert result.tzinfo is None
 
 

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -378,18 +378,26 @@ async def test_self_referencing_gate_template_refresh_is_bounded(
     with one, the *unguarded* loop is unbounded — measured at >9000 refreshes
     before the harness timed out, versus the five below.
 
-    A real start/end window is configured (10:00-20:00) around the frozen
-    17:00 UTC instant — safe since #1161 made ``TimeWindowManager`` read
-    ``dt_util.now()`` (frozen along with the rest of ``datetime`` by
-    ``freezer``) instead of the host clock, so the window's openness no
-    longer depends on the machine's local timezone.
+    A real start/end window is configured, with hours of slack on both sides:
+    the ``hass`` fixture puts HA in US/Pacific, so the frozen 17:00 UTC instant
+    is 10:00 local, two hours past the 08:00 start and ten short of the 20:00
+    end. The slack is the point — an exact boundary tie would leave the window
+    open only by ``>=``, and a fixture that drifts closed collapses the run to
+    ``per_window == [0, 0, 0, 0, 0]``, which reads as a coalescer regression
+    rather than a broken fixture.
+
+    Configuring a real window at all is only safe since #1161 made both sides
+    of the comparison HA-framed — ``TimeWindowManager`` reads HA's configured
+    zone rather than the host clock, and the boundary's implied date comes
+    from the same place — so the window's openness no longer depends on the
+    machine's local timezone.
     """
     freezer.move_to(dt.datetime(2026, 6, 15, 17, 0, 0, tzinfo=dt.UTC))
     entry = _make_entry(
         hass,
         "tt_loop_01",
         {
-            CONF_START_TIME: "10:00:00",
+            CONF_START_TIME: "08:00:00",
             CONF_END_TIME: "20:00:00",
             CONF_DAYTIME_GATE_TEMPLATE: _LOOPING_GATE_TEMPLATE,
         },

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -25,7 +25,6 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 from custom_components.adaptive_cover_pro.const import (
-    BLANK_TIME,
     CONF_DAYTIME_GATE_TEMPLATE,
     CONF_END_TIME,
     CONF_MOTION_TEMPLATE,
@@ -379,18 +378,19 @@ async def test_self_referencing_gate_template_refresh_is_bounded(
     with one, the *unguarded* loop is unbounded — measured at >9000 refreshes
     before the harness timed out, versus the five below.
 
-    The start/end clock is blanked so ``is_active`` reduces to the gate verdict
-    alone; otherwise the loop's existence would depend on the machine's local
-    timezone (``TimeWindowManager.before_end_time`` reads a naive
-    ``datetime.now()``).
+    A real start/end window is configured (10:00-20:00) around the frozen
+    17:00 UTC instant — safe since #1161 made ``TimeWindowManager`` read
+    ``dt_util.now()`` (frozen along with the rest of ``datetime`` by
+    ``freezer``) instead of the host clock, so the window's openness no
+    longer depends on the machine's local timezone.
     """
     freezer.move_to(dt.datetime(2026, 6, 15, 17, 0, 0, tzinfo=dt.UTC))
     entry = _make_entry(
         hass,
         "tt_loop_01",
         {
-            CONF_START_TIME: BLANK_TIME,
-            CONF_END_TIME: BLANK_TIME,
+            CONF_START_TIME: "10:00:00",
+            CONF_END_TIME: "20:00:00",
             CONF_DAYTIME_GATE_TEMPLATE: _LOOPING_GATE_TEMPLATE,
         },
     )

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -87,8 +87,7 @@ def test_after_start_time_entity_returns_false_when_future():
         end_time_entity=None,
     )
 
-    today = dt.date(2024, 6, 15)
-    now = dt.datetime(2024, 6, 15, 10, 0, 0)
+    now = dt.datetime(2024, 6, 15, 10, 0, 0, tzinfo=dt.UTC)
     future_time = dt.datetime(2024, 6, 15, 12, 0, 0)
 
     with (
@@ -101,12 +100,10 @@ def test_after_start_time_entity_returns_false_when_future():
             return_value=future_time,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt"
-        ) as mock_dt,
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=now,
+        ),
     ):
-        mock_dt.date.today.return_value = today
-        mock_dt.datetime.now.return_value = now
-        mock_dt.timedelta = dt.timedelta
         result = mgr.after_start_time
 
     assert result is False
@@ -449,6 +446,127 @@ async def test_check_transition_no_callback_on_window_open():
 
 
 # ---------------------------------------------------------------------------
+# HA-configured tz vs. host clock (issue #1161)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_start_has_passed_uses_dt_util_now_not_host_clock():
+    """_start_has_passed must read dt_util.now(), not the naive host clock.
+
+    Issue #1161: a bare ``dt.datetime.now()`` silently reads the host OS
+    timezone instead of HA's configured ``hass.config.time_zone``. Freezing
+    ``dt_util.now()`` to a sentinel far from the real host clock must move
+    the result — proving the code reads dt_util, not the host clock.
+    """
+    mgr = _make_manager()
+    mgr.update_config(
+        start_time="06:00:00",
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity=None,
+    )
+
+    # Resolved start is far in the future relative to the real host clock, so
+    # a host-clock read would find "now" is still before it (not yet passed).
+    resolved = dt.datetime(2090, 1, 1, 0, 0, 0)
+    # The dt_util sentinel is AFTER the resolved start — only a fix that reads
+    # dt_util.now() can make after_start_time True here.
+    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
+            return_value=resolved,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=sentinel,
+        ),
+    ):
+        result = mgr.after_start_time
+
+    assert result is True
+
+
+@pytest.mark.unit
+def test_before_end_time_uses_dt_util_now_not_host_clock():
+    """before_end_time must read dt_util.now(), not the naive host clock (#1161)."""
+    mgr = _make_manager()
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time="05:00:00",
+        end_time_entity=None,
+    )
+
+    # end resolves far in the future relative to the real host clock.
+    end = dt.datetime(2090, 1, 1, 5, 0, 0)
+    # The dt_util sentinel is AFTER end — only a fix that reads dt_util.now()
+    # can make before_end_time False here (a host-clock read would still be
+    # well before `end` and stay True).
+    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
+            return_value=end,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=sentinel,
+        ),
+    ):
+        result = mgr.before_end_time
+
+    assert result is False
+
+
+@pytest.mark.unit
+def test_normalize_to_today_uses_dt_util_now_date_not_host_clock():
+    """_normalize_to_today must anchor "today" on dt_util.now(), not the host clock.
+
+    Exercised via an entity-sourced start time (sun-entity date rollover,
+    #226's mechanism) so the assertion is on the resolved/cached start time —
+    which reveals which "today" was used to normalize — rather than on the
+    True/False comparison, keeping this test independent of wall-clock time-
+    of-day (#1161).
+    """
+    mgr = _make_manager()
+    mgr.update_config(
+        start_time=None,
+        start_time_entity="sensor.sun_next_rising",
+        end_time=None,
+        end_time_entity=None,
+    )
+
+    # dt_util sentinel's date is 2090-06-15.
+    sentinel = dt.datetime(2090, 6, 15, 12, 0, 0, tzinfo=dt.UTC)
+    # Entity reports "tomorrow" relative to the sentinel's date.
+    tomorrow_relative_to_sentinel = dt.datetime(2090, 6, 16, 6, 30, 0)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
+            return_value="irrelevant-raw-state",
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
+            return_value=tomorrow_relative_to_sentinel,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=sentinel,
+        ),
+    ):
+        mgr.after_start_time
+
+    # Normalized onto the dt_util sentinel's date (2090-06-15), not whatever
+    # the real host clock's date happens to be.
+    assert mgr._cached_start_time == dt.datetime(2090, 6, 15, 6, 30, 0)
+
+
+# ---------------------------------------------------------------------------
 # Sun entity rollover normalization (#226)
 # ---------------------------------------------------------------------------
 
@@ -468,11 +586,17 @@ def test_after_start_time_entity_normalizes_tomorrow_to_today():
         end_time_entity=None,
     )
 
-    today = dt.date(2024, 6, 15)
+    # Far-future year + a near-midnight time-of-day: this deliberately makes a
+    # host-clock evaluation land on the opposite side (real "now" is virtually
+    # never past 23:59:00 on whatever day it actually is), so a regression to
+    # the host clock is caught here rather than passing by date-order coincidence.
+    today = dt.date(2090, 6, 15)
     tomorrow = today + dt.timedelta(days=1)
-    now = dt.datetime(2024, 6, 15, 12, 0, 0)
-    # Simulate the sensor reporting tomorrow's sunrise (06:30 tomorrow)
-    tomorrow_sunrise = dt.datetime(tomorrow.year, tomorrow.month, tomorrow.day, 6, 30)
+    now = dt.datetime(2090, 6, 15, 23, 59, 0, tzinfo=dt.UTC)
+    # Simulate the sensor reporting tomorrow's sunrise (23:59 tomorrow)
+    tomorrow_sunrise = dt.datetime(
+        tomorrow.year, tomorrow.month, tomorrow.day, 23, 59, 0
+    )
 
     with (
         patch(
@@ -484,15 +608,13 @@ def test_after_start_time_entity_normalizes_tomorrow_to_today():
             return_value=tomorrow_sunrise,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt"
-        ) as mock_dt,
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=now,
+        ),
     ):
-        mock_dt.date.today.return_value = today
-        mock_dt.datetime.now.return_value = now
-        mock_dt.timedelta = dt.timedelta
         result = mgr.after_start_time
 
-    # Normalized to 2024-06-15 06:30 — which is before noon (now), so True
+    # Normalized to 2090-06-15 23:59 — equal to "now", so True
     assert result is True
 
 
@@ -507,10 +629,12 @@ def test_after_start_time_entity_no_normalize_when_today():
         end_time_entity=None,
     )
 
-    today = dt.date(2024, 6, 15)
-    now = dt.datetime(2024, 6, 15, 12, 0, 0)
+    # Far-future year + a near-midnight time-of-day: see
+    # test_after_start_time_entity_normalizes_tomorrow_to_today for why.
+    today = dt.date(2090, 6, 15)
+    now = dt.datetime(2090, 6, 15, 23, 59, 0, tzinfo=dt.UTC)
     # Sunrise already passed today — entity still shows today's date
-    past_today = dt.datetime(today.year, today.month, today.day, 6, 30)
+    past_today = dt.datetime(today.year, today.month, today.day, 23, 58, 0)
 
     with (
         patch(
@@ -522,12 +646,10 @@ def test_after_start_time_entity_no_normalize_when_today():
             return_value=past_today,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt"
-        ) as mock_dt,
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=now,
+        ),
     ):
-        mock_dt.date.today.return_value = today
-        mock_dt.datetime.now.return_value = now
-        mock_dt.timedelta = dt.timedelta
         result = mgr.after_start_time
 
     assert result is True
@@ -544,8 +666,7 @@ def test_after_start_time_entity_future_today_returns_false():
         end_time_entity=None,
     )
 
-    today = dt.date(2024, 6, 15)
-    now = dt.datetime(2024, 6, 15, 10, 0, 0)
+    now = dt.datetime(2024, 6, 15, 10, 0, 0, tzinfo=dt.UTC)
     future_today = dt.datetime(2024, 6, 15, 11, 0, 0)
 
     with (
@@ -558,12 +679,10 @@ def test_after_start_time_entity_future_today_returns_false():
             return_value=future_today,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt"
-        ) as mock_dt,
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=now,
+        ),
     ):
-        mock_dt.date.today.return_value = today
-        mock_dt.datetime.now.return_value = now
-        mock_dt.timedelta = dt.timedelta
         result = mgr.after_start_time
 
     assert result is False
@@ -922,9 +1041,13 @@ def test_after_start_time_with_utc_iso_sun_sensor_string():
     Regression: before the fix, "04:46 UTC" was compared as naive 04:46 in a
     non-UTC zone, causing the window to activate hours early.
 
-    Setup: local timezone America/New_York (UTC-4 DST). Sunrise UTC is 04:46,
-    which is 00:46 local. Freeze "now" at 01:00 local (after 00:46 local sunrise)
-    so after_start_time should be True.
+    Setup: local timezone America/New_York (DST). The sensor's UTC instant
+    converts to 23:59:58 local on a far-future date; "now" is frozen one
+    second later on the same local date, so after_start_time should be True.
+    A far-future year + a near-midnight time-of-day deliberately makes a
+    host-clock evaluation land on the opposite side (real "now" is virtually
+    never past 23:59:58 on whatever day it actually is), so a regression to
+    the host clock is caught here rather than passing by date-order coincidence.
     """
 
     mgr = _make_manager()
@@ -936,23 +1059,21 @@ def test_after_start_time_with_utc_iso_sun_sensor_string():
     )
 
     ny = zoneinfo.ZoneInfo("America/New_York")
-    # "now" is 01:00 local NY — after 00:46 local sunrise
-    frozen_now = dt.datetime(2026, 4, 18, 1, 0, 0)
+    # "now" is 23:59:59 local NY on 2090-04-18 — one second after the
+    # 23:59:58 local sunrise (03:59:58 UTC on 2090-04-19 converted).
+    frozen_now = dt.datetime(2090, 4, 18, 23, 59, 59, tzinfo=ny)
 
     with (
         patch(
             "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="2026-04-18T04:46:00+00:00",
+            return_value="2090-04-19T03:59:58+00:00",
         ),
         patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", ny),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt"
-        ) as mock_dt,
+            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            return_value=frozen_now,
+        ),
     ):
-        # "now" is 01:00 local NY — after 00:46 local sunrise (04:46 UTC converted)
-        mock_dt.datetime.now.return_value = frozen_now
-        mock_dt.date.today.return_value = dt.date(2026, 4, 18)
-        mock_dt.timedelta = dt.timedelta
         result = mgr.after_start_time
 
     assert result is True

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import zoneinfo
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +22,45 @@ def _make_manager(mock_hass=None):
     logger.info = MagicMock()
     logger.error = MagicMock()
     return TimeWindowManager(hass=hass, logger=logger)
+
+
+_TIME_WINDOW = "custom_components.adaptive_cover_pro.managers.time_window"
+
+# The fixed HA-local "now" every date-sensitive fixture in this module is built
+# from. Production anchors on ``local_now_naive()`` (HA's configured zone), so a
+# fixture built from ``dt.datetime.now()`` / ``dt.date.today()`` sits in the HOST
+# frame instead and the two dates diverge by the zone offset for part of every
+# day. While they diverge, a "tomorrow" fixture is really HA-today: normalization
+# never runs and the test quietly stops guarding rather than failing (#1161).
+_HA_NOW = dt.datetime(2090, 6, 15, 12, 0, 0)
+
+
+@contextmanager
+def _patch_time_window(parsed, *, now=_HA_NOW, safe_state="irrelevant-raw-state"):
+    """Patch time_window's entity reads and its clock to a fixed HA-local ``now``.
+
+    Args:
+        parsed: What ``get_datetime_from_str`` yields — a single datetime, or an
+            iterable of datetimes handed out in call order.
+        now: The value ``local_now_naive`` returns (defaults to ``_HA_NOW``).
+        safe_state: The raw entity state ``get_safe_state`` returns.
+
+    """
+    if isinstance(parsed, dt.datetime):
+        parsed_patch = patch(
+            f"{_TIME_WINDOW}.get_datetime_from_str", return_value=parsed
+        )
+    else:
+        values = iter(parsed)
+        parsed_patch = patch(
+            f"{_TIME_WINDOW}.get_datetime_from_str", side_effect=lambda _: next(values)
+        )
+    with (
+        patch(f"{_TIME_WINDOW}.get_safe_state", return_value=safe_state),
+        parsed_patch,
+        patch(f"{_TIME_WINDOW}.local_now_naive", return_value=now),
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -59,27 +99,13 @@ def test_after_start_time_entity_evaluates_correctly():
         end_time_entity=None,
     )
 
-    # Pin "now" to a fixed HA-local sentinel and build the fixture from it, so
-    # both sides of the comparison sit in the same frame on any host zone
-    # (#1161) — a host-clock fixture drifts out of frame by the zone offset.
-    now = dt.datetime(2090, 6, 15, 12, 0, 0)
+    # "now" is pinned to the fixed HA-local sentinel and the fixture is built
+    # from it, so both sides of the comparison sit in the same frame on any host
+    # zone (#1161) — a host-clock fixture drifts out of frame by the zone offset.
     # An hour before that sentinel, so now >= time is True.
-    past_time = now - dt.timedelta(hours=1)
+    past_time = _HA_NOW - dt.timedelta(hours=1)
 
-    with (
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="2024-01-01T07:00:00",
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
-            return_value=past_time,
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
-            return_value=now,
-        ),
-    ):
+    with _patch_time_window(past_time, safe_state="2024-01-01T07:00:00"):
         result = mgr.after_start_time
 
     assert result is True
@@ -551,25 +577,13 @@ def test_normalize_to_today_uses_ha_local_date_not_host_clock():
         end_time_entity=None,
     )
 
-    # The HA-local sentinel's date is 2090-06-15.
-    sentinel = dt.datetime(2090, 6, 15, 12, 0, 0)
-    # Entity reports "tomorrow" relative to the sentinel's date.
-    tomorrow_relative_to_sentinel = dt.datetime(2090, 6, 16, 6, 30, 0)
+    # The HA-local sentinel's date is 2090-06-15; the entity reports "tomorrow"
+    # relative to it.
+    tomorrow_relative_to_sentinel = dt.datetime.combine(
+        _HA_NOW.date() + dt.timedelta(days=1), dt.time(6, 30)
+    )
 
-    with (
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="irrelevant-raw-state",
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
-            return_value=tomorrow_relative_to_sentinel,
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
-            return_value=sentinel,
-        ),
-    ):
+    with _patch_time_window(tomorrow_relative_to_sentinel):
         mgr.after_start_time
 
     # Normalized onto the HA-local sentinel's date (2090-06-15), not whatever
@@ -780,31 +794,17 @@ def test_end_time_entity_normalizes_tomorrow_to_today():
         end_time_entity="sensor.sun_next_setting",
     )
 
-    # "Today" is pinned to a fixed HA-local sentinel rather than the host date,
+    # "Today" is pinned to the fixed HA-local sentinel rather than the host date,
     # so the entity value below is tomorrow *in the frame _normalize_to_today
     # anchors on* and normalization is exercised on every host zone. Deriving
     # it from dt.date.today() lets the two dates diverge, at which point the
     # value stops looking like "tomorrow" and this #226 guard silently stops
     # guarding instead of failing (#1161).
-    now = dt.datetime(2090, 6, 15, 12, 0, 0)
-    today = now.date()
+    today = _HA_NOW.date()
     tomorrow = today + dt.timedelta(days=1)
     tomorrow_sunset = dt.datetime(tomorrow.year, tomorrow.month, tomorrow.day, 20, 30)
 
-    with (
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="irrelevant-raw-state",
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
-            return_value=tomorrow_sunset,
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
-            return_value=now,
-        ),
-    ):
+    with _patch_time_window(tomorrow_sunset):
         result = mgr.end_time
 
     expected = dt.datetime(today.year, today.month, today.day, 20, 30)
@@ -825,24 +825,10 @@ def test_end_time_entity_no_normalize_when_today():
     # "Today" comes from the same fixed HA-local sentinel _normalize_to_today
     # anchors on; a dt.date.today() fixture sits in the host frame and the two
     # dates diverge by the zone offset for part of every day (#1161).
-    now = dt.datetime(2090, 6, 15, 12, 0, 0)
-    today = now.date()
+    today = _HA_NOW.date()
     today_sunset = dt.datetime(today.year, today.month, today.day, 20, 30)
 
-    with (
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="irrelevant-raw-state",
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
-            return_value=today_sunset,
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
-            return_value=now,
-        ),
-    ):
+    with _patch_time_window(today_sunset):
         result = mgr.end_time
 
     assert result == today_sunset
@@ -852,8 +838,17 @@ def test_end_time_entity_no_normalize_when_today():
 def test_is_active_with_sun_entities_after_rollover():
     """Both sun entities rolled to tomorrow — is_active returns True, no error logged.
 
-    Uses sunrise=00:01 and sunset=23:59 so the window is always active regardless
-    of when the test runs. Verifies normalization integrates correctly end-to-end.
+    "Today" is pinned to the fixed HA-local sentinel rather than
+    ``dt.date.today()``: production anchors ``_normalize_to_today`` on HA's
+    configured zone, so a host-clock fixture is only really "tomorrow" while the
+    two dates agree. Wherever HA's date leads the host's, the fixture's tomorrow
+    IS HA-today, normalization never runs, and the 00:01/23:59 extremes keep the
+    window open anyway — so this #226 guard passed vacuously instead of failing
+    (#1161).
+
+    Sunrise=00:01 and sunset=23:59 straddle the pinned midday "now"; the
+    assertions on the resolved start/end prove normalization actually fired
+    rather than letting the window extremes carry a skipped normalize.
     """
     mgr = _make_manager()
     mgr.update_config(
@@ -863,30 +858,25 @@ def test_is_active_with_sun_entities_after_rollover():
         end_time_entity="sensor.sun_next_setting",
     )
 
-    today = dt.date.today()
+    today = _HA_NOW.date()
     tomorrow = today + dt.timedelta(days=1)
-    # Use extreme times so the window is active regardless of when the test runs
     tomorrow_sunrise = dt.datetime(tomorrow.year, tomorrow.month, tomorrow.day, 0, 1)
     tomorrow_sunset = dt.datetime(tomorrow.year, tomorrow.month, tomorrow.day, 23, 59)
 
     # is_active evaluates before_end_time first (calls end_time → get_datetime_from_str),
-    # then after_start_time (calls get_datetime_from_str again). Iterator must match that order.
-    parsed_values = iter([tomorrow_sunset, tomorrow_sunrise])
-
-    with (
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="irrelevant-raw-state",
-        ),
-        patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
-            side_effect=lambda _: next(parsed_values),
-        ),
-    ):
+    # then after_start_time (calls get_datetime_from_str again); the trailing value
+    # serves the explicit end_time re-read below. Iterator must match that order.
+    with _patch_time_window([tomorrow_sunset, tomorrow_sunrise, tomorrow_sunset]):
         result = mgr.is_active
+        resolved_end = mgr.end_time
 
     assert result is True
     mgr.logger.error.assert_not_called()
+    # Both entity values were pinned back onto the HA-local date. A skipped
+    # normalize leaves them on `tomorrow` and fails here loudly, instead of
+    # riding the window extremes to a silent pass.
+    assert mgr.start_time_value == dt.datetime(today.year, today.month, today.day, 0, 1)
+    assert resolved_end == dt.datetime(today.year, today.month, today.day, 23, 59)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -7,7 +7,9 @@ import zoneinfo
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from freezegun import freeze_time
 
+from custom_components.adaptive_cover_pro.const import BLANK_TIME
 from custom_components.adaptive_cover_pro.managers.time_window import TimeWindowManager
 
 
@@ -87,7 +89,7 @@ def test_after_start_time_entity_returns_false_when_future():
         end_time_entity=None,
     )
 
-    now = dt.datetime(2024, 6, 15, 10, 0, 0, tzinfo=dt.UTC)
+    now = dt.datetime(2024, 6, 15, 10, 0, 0)
     future_time = dt.datetime(2024, 6, 15, 12, 0, 0)
 
     with (
@@ -100,7 +102,7 @@ def test_after_start_time_entity_returns_false_when_future():
             return_value=future_time,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=now,
         ),
     ):
@@ -451,13 +453,14 @@ async def test_check_transition_no_callback_on_window_open():
 
 
 @pytest.mark.unit
-def test_start_has_passed_uses_dt_util_now_not_host_clock():
-    """_start_has_passed must read dt_util.now(), not the naive host clock.
+def test_start_has_passed_uses_ha_local_now_not_host_clock():
+    """_start_has_passed must read ``local_now_naive``, not the naive host clock.
 
     Issue #1161: a bare ``dt.datetime.now()`` silently reads the host OS
     timezone instead of HA's configured ``hass.config.time_zone``. Freezing
-    ``dt_util.now()`` to a sentinel far from the real host clock must move
-    the result — proving the code reads dt_util, not the host clock.
+    ``local_now_naive`` (which wraps ``dt_util.now()``) to a sentinel far from
+    the real host clock must move the result — proving the code reads HA's
+    zone, not the host clock.
     """
     mgr = _make_manager()
     mgr.update_config(
@@ -470,9 +473,9 @@ def test_start_has_passed_uses_dt_util_now_not_host_clock():
     # Resolved start is far in the future relative to the real host clock, so
     # a host-clock read would find "now" is still before it (not yet passed).
     resolved = dt.datetime(2090, 1, 1, 0, 0, 0)
-    # The dt_util sentinel is AFTER the resolved start — only a fix that reads
-    # dt_util.now() can make after_start_time True here.
-    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    # The HA-local sentinel is AFTER the resolved start — only a fix that reads
+    # HA's zone can make after_start_time True here.
+    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0)
 
     with (
         patch(
@@ -480,7 +483,7 @@ def test_start_has_passed_uses_dt_util_now_not_host_clock():
             return_value=resolved,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=sentinel,
         ),
     ):
@@ -490,8 +493,8 @@ def test_start_has_passed_uses_dt_util_now_not_host_clock():
 
 
 @pytest.mark.unit
-def test_before_end_time_uses_dt_util_now_not_host_clock():
-    """before_end_time must read dt_util.now(), not the naive host clock (#1161)."""
+def test_before_end_time_uses_ha_local_now_not_host_clock():
+    """before_end_time must read ``local_now_naive``, not the host clock (#1161)."""
     mgr = _make_manager()
     mgr.update_config(
         start_time=None,
@@ -502,10 +505,10 @@ def test_before_end_time_uses_dt_util_now_not_host_clock():
 
     # end resolves far in the future relative to the real host clock.
     end = dt.datetime(2090, 1, 1, 5, 0, 0)
-    # The dt_util sentinel is AFTER end — only a fix that reads dt_util.now()
-    # can make before_end_time False here (a host-clock read would still be
-    # well before `end` and stay True).
-    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    # The HA-local sentinel is AFTER end — only a fix that reads HA's zone can
+    # make before_end_time False here (a host-clock read would still be well
+    # before `end` and stay True).
+    sentinel = dt.datetime(2095, 1, 1, 0, 0, 0)
 
     with (
         patch(
@@ -513,7 +516,7 @@ def test_before_end_time_uses_dt_util_now_not_host_clock():
             return_value=end,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=sentinel,
         ),
     ):
@@ -523,8 +526,8 @@ def test_before_end_time_uses_dt_util_now_not_host_clock():
 
 
 @pytest.mark.unit
-def test_normalize_to_today_uses_dt_util_now_date_not_host_clock():
-    """_normalize_to_today must anchor "today" on dt_util.now(), not the host clock.
+def test_normalize_to_today_uses_ha_local_date_not_host_clock():
+    """_normalize_to_today must anchor "today" on HA's local date, not the host clock.
 
     Exercised via an entity-sourced start time (sun-entity date rollover,
     #226's mechanism) so the assertion is on the resolved/cached start time —
@@ -540,8 +543,8 @@ def test_normalize_to_today_uses_dt_util_now_date_not_host_clock():
         end_time_entity=None,
     )
 
-    # dt_util sentinel's date is 2090-06-15.
-    sentinel = dt.datetime(2090, 6, 15, 12, 0, 0, tzinfo=dt.UTC)
+    # The HA-local sentinel's date is 2090-06-15.
+    sentinel = dt.datetime(2090, 6, 15, 12, 0, 0)
     # Entity reports "tomorrow" relative to the sentinel's date.
     tomorrow_relative_to_sentinel = dt.datetime(2090, 6, 16, 6, 30, 0)
 
@@ -555,15 +558,85 @@ def test_normalize_to_today_uses_dt_util_now_date_not_host_clock():
             return_value=tomorrow_relative_to_sentinel,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=sentinel,
         ),
     ):
         mgr.after_start_time
 
-    # Normalized onto the dt_util sentinel's date (2090-06-15), not whatever
+    # Normalized onto the HA-local sentinel's date (2090-06-15), not whatever
     # the real host clock's date happens to be.
     assert mgr._cached_start_time == dt.datetime(2090, 6, 15, 6, 30, 0)
+
+
+@pytest.mark.unit
+def test_blank_end_time_stays_open_when_ha_zone_is_ahead_of_host():
+    """A BLANK_TIME end must stay open all HA-local day, in HA's zone (#1161).
+
+    Under ``freeze_time`` the host's naive clock reads the frozen UTC instant;
+    HA's zone is Pacific/Auckland (UTC+12). At 2026-08-02 14:06 UTC it is
+    already 2026-08-03 02:06 in HA's zone while the host is still on 08-02.
+
+    ``end_time`` resolves ``BLANK_TIME`` through ``dateutil.parser.parse``,
+    which fills the missing *date* from its own ``datetime.now()`` — the HOST
+    clock. Anchored on the host's 08-02 the sentinel rolls to 08-03 00:00,
+    which HA-local "now" (02:06) is already past, so the window reports CLOSED
+    for the first 12 hours of every HA-local day and ``check_transition``
+    fires "End time reached" and reverts to the default position. Both sides
+    of the comparison must be framed on HA's local date.
+    """
+    mgr = _make_manager()
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=BLANK_TIME,
+        end_time_entity=None,
+    )
+
+    auckland = zoneinfo.ZoneInfo("Pacific/Auckland")
+    with (
+        freeze_time("2026-08-02 14:06:00"),
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", auckland),
+    ):
+        # Midnight anchored on HA's local date (08-03), rolled to tomorrow.
+        assert mgr.end_time == dt.datetime(2026, 8, 4, 0, 0)
+        assert mgr.before_end_time is True
+
+
+@pytest.mark.unit
+def test_static_window_uses_ha_local_date_when_host_date_is_ahead():
+    """A static start/end window must key on HA's local date, not the host's (#1161).
+
+    The canonical #1161 setup: a UTC host with HA configured for
+    America/Los_Angeles (UTC-7 in August). Under ``freeze_time`` the host's
+    naive clock reads the frozen UTC instant, so at 2026-08-03 02:06 UTC the
+    host has already rolled over to 08-03 while HA-local is still 2026-08-02
+    19:06 — inside an 08:00-20:00 window with an hour to spare.
+
+    ``dateutil.parser.parse`` fills the missing date of ``"08:00:00"`` from
+    its own ``datetime.now()``, i.e. the HOST clock, producing 2026-08-03
+    08:00 — an instant HA-local "now" has not reached. The window then reports
+    CLOSED for the last ``|tz-offset|`` hours of every HA-local day, which is
+    the reported "closes ~3h early every evening".
+    """
+    mgr = _make_manager()
+    mgr.update_config(
+        start_time="08:00:00",
+        start_time_entity=None,
+        end_time="20:00:00",
+        end_time_entity=None,
+    )
+
+    los_angeles = zoneinfo.ZoneInfo("America/Los_Angeles")
+    with (
+        freeze_time("2026-08-03 02:06:00"),
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", los_angeles),
+    ):
+        assert mgr.resolved_start_time == dt.datetime(2026, 8, 2, 8, 0)
+        assert mgr.end_time == dt.datetime(2026, 8, 2, 20, 0)
+        assert mgr.after_start_time is True
+        assert mgr.before_end_time is True
+        assert mgr.clock_window_open is True
 
 
 # ---------------------------------------------------------------------------
@@ -592,7 +665,7 @@ def test_after_start_time_entity_normalizes_tomorrow_to_today():
     # the host clock is caught here rather than passing by date-order coincidence.
     today = dt.date(2090, 6, 15)
     tomorrow = today + dt.timedelta(days=1)
-    now = dt.datetime(2090, 6, 15, 23, 59, 0, tzinfo=dt.UTC)
+    now = dt.datetime(2090, 6, 15, 23, 59, 0)
     # Simulate the sensor reporting tomorrow's sunrise (23:59 tomorrow)
     tomorrow_sunrise = dt.datetime(
         tomorrow.year, tomorrow.month, tomorrow.day, 23, 59, 0
@@ -608,7 +681,7 @@ def test_after_start_time_entity_normalizes_tomorrow_to_today():
             return_value=tomorrow_sunrise,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=now,
         ),
     ):
@@ -632,7 +705,7 @@ def test_after_start_time_entity_no_normalize_when_today():
     # Far-future year + a near-midnight time-of-day: see
     # test_after_start_time_entity_normalizes_tomorrow_to_today for why.
     today = dt.date(2090, 6, 15)
-    now = dt.datetime(2090, 6, 15, 23, 59, 0, tzinfo=dt.UTC)
+    now = dt.datetime(2090, 6, 15, 23, 59, 0)
     # Sunrise already passed today — entity still shows today's date
     past_today = dt.datetime(today.year, today.month, today.day, 23, 58, 0)
 
@@ -646,7 +719,7 @@ def test_after_start_time_entity_no_normalize_when_today():
             return_value=past_today,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=now,
         ),
     ):
@@ -666,7 +739,7 @@ def test_after_start_time_entity_future_today_returns_false():
         end_time_entity=None,
     )
 
-    now = dt.datetime(2024, 6, 15, 10, 0, 0, tzinfo=dt.UTC)
+    now = dt.datetime(2024, 6, 15, 10, 0, 0)
     future_today = dt.datetime(2024, 6, 15, 11, 0, 0)
 
     with (
@@ -679,7 +752,7 @@ def test_after_start_time_entity_future_today_returns_false():
             return_value=future_today,
         ),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=now,
         ),
     ):
@@ -1041,13 +1114,14 @@ def test_after_start_time_with_utc_iso_sun_sensor_string():
     Regression: before the fix, "04:46 UTC" was compared as naive 04:46 in a
     non-UTC zone, causing the window to activate hours early.
 
-    Setup: local timezone America/New_York (DST). The sensor's UTC instant
-    converts to 23:59:58 local on a far-future date; "now" is frozen one
-    second later on the same local date, so after_start_time should be True.
-    A far-future year + a near-midnight time-of-day deliberately makes a
-    host-clock evaluation land on the opposite side (real "now" is virtually
-    never past 23:59:58 on whatever day it actually is), so a regression to
-    the host clock is caught here rather than passing by date-order coincidence.
+    Setup: HA's zone is America/New_York (UTC-4 in April). The sensor reports
+    04:46 UTC, which is 00:46 local; "now" is 01:00 local, so the start has
+    passed by 14 minutes.
+
+    The load-bearing assertion is on the *resolved* start time, not the
+    boolean: a naive re-parse would resolve 04:46 and ``_normalize_to_today``
+    would happily leave a same-day value alone, so only the resolved value
+    distinguishes "converted through HA's zone" from "compared as naive".
     """
 
     mgr = _make_manager()
@@ -1059,23 +1133,24 @@ def test_after_start_time_with_utc_iso_sun_sensor_string():
     )
 
     ny = zoneinfo.ZoneInfo("America/New_York")
-    # "now" is 23:59:59 local NY on 2090-04-18 — one second after the
-    # 23:59:58 local sunrise (03:59:58 UTC on 2090-04-19 converted).
-    frozen_now = dt.datetime(2090, 4, 18, 23, 59, 59, tzinfo=ny)
+    # "now" is 01:00 local NY — after the 00:46 local sunrise.
+    frozen_now = dt.datetime(2026, 4, 18, 1, 0, 0)
 
     with (
         patch(
             "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
-            return_value="2090-04-19T03:59:58+00:00",
+            return_value="2026-04-18T04:46:00+00:00",
         ),
         patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", ny),
         patch(
-            "custom_components.adaptive_cover_pro.managers.time_window.dt_util.now",
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
             return_value=frozen_now,
         ),
     ):
         result = mgr.after_start_time
 
+    # 04:46 UTC → 00:46 local NY, not a naive 04:46.
+    assert mgr.start_time_value == dt.datetime(2026, 4, 18, 0, 46)
     assert result is True
 
 

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -59,8 +59,12 @@ def test_after_start_time_entity_evaluates_correctly():
         end_time_entity=None,
     )
 
-    # Use a time far in the past so now >= time is True
-    past_time = dt.datetime.now() - dt.timedelta(hours=1)
+    # Pin "now" to a fixed HA-local sentinel and build the fixture from it, so
+    # both sides of the comparison sit in the same frame on any host zone
+    # (#1161) — a host-clock fixture drifts out of frame by the zone offset.
+    now = dt.datetime(2090, 6, 15, 12, 0, 0)
+    # An hour before that sentinel, so now >= time is True.
+    past_time = now - dt.timedelta(hours=1)
 
     with (
         patch(
@@ -70,6 +74,10 @@ def test_after_start_time_entity_evaluates_correctly():
         patch(
             "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
             return_value=past_time,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
+            return_value=now,
         ),
     ):
         result = mgr.after_start_time
@@ -772,7 +780,14 @@ def test_end_time_entity_normalizes_tomorrow_to_today():
         end_time_entity="sensor.sun_next_setting",
     )
 
-    today = dt.date.today()
+    # "Today" is pinned to a fixed HA-local sentinel rather than the host date,
+    # so the entity value below is tomorrow *in the frame _normalize_to_today
+    # anchors on* and normalization is exercised on every host zone. Deriving
+    # it from dt.date.today() lets the two dates diverge, at which point the
+    # value stops looking like "tomorrow" and this #226 guard silently stops
+    # guarding instead of failing (#1161).
+    now = dt.datetime(2090, 6, 15, 12, 0, 0)
+    today = now.date()
     tomorrow = today + dt.timedelta(days=1)
     tomorrow_sunset = dt.datetime(tomorrow.year, tomorrow.month, tomorrow.day, 20, 30)
 
@@ -784,6 +799,10 @@ def test_end_time_entity_normalizes_tomorrow_to_today():
         patch(
             "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
             return_value=tomorrow_sunset,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
+            return_value=now,
         ),
     ):
         result = mgr.end_time
@@ -803,7 +822,11 @@ def test_end_time_entity_no_normalize_when_today():
         end_time_entity="sensor.sun_next_setting",
     )
 
-    today = dt.date.today()
+    # "Today" comes from the same fixed HA-local sentinel _normalize_to_today
+    # anchors on; a dt.date.today() fixture sits in the host frame and the two
+    # dates diverge by the zone offset for part of every day (#1161).
+    now = dt.datetime(2090, 6, 15, 12, 0, 0)
+    today = now.date()
     today_sunset = dt.datetime(today.year, today.month, today.day, 20, 30)
 
     with (
@@ -814,6 +837,10 @@ def test_end_time_entity_no_normalize_when_today():
         patch(
             "custom_components.adaptive_cover_pro.managers.time_window.get_datetime_from_str",
             return_value=today_sunset,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.local_now_naive",
+            return_value=now,
         ),
     ):
         result = mgr.end_time


### PR DESCRIPTION
## Summary

`TimeWindowManager` compared a naive `dt.datetime.now()` (the host machine's clock) against boundaries normalized into `hass.config.time_zone`. Home Assistant never calls `time.tzset()`, so on any install where the host OS zone differs from HA's configured zone the operational window silently shifted by the offset. Sun tracking started and stopped at the wrong wall-clock time. HAOS and most container installs derive the host zone from the HA config, which is why this went unnoticed; a Core install in a venv is the exposed case.

Fixing only the "now" side turned out to be half the bug. `get_datetime_from_str` parses a bare `"HH:MM:SS"` with `dateutil`, which fills the missing date from `datetime.now()` (the host clock again), so the two sides still sat on different calendar dates for the length of the offset every day. Both sides now share a frame: `get_datetime_from_str` parses with an explicit HA-local `default=`, and a new `helpers.local_now_naive()` is the single source for the naive-local contract across all six call sites. The naive-local return contract is unchanged, so `_local_naive_to_utc_naive` / `_eval_time_to_utc_naive` / `resolve_sun_boundaries` are untouched.

Verified with a 24 hour walk on a UTC host with HA in `America/Los_Angeles` and a static `08:00-20:00` window: 14 of 24 hours reported the wrong window state before, 0 of 24 after.

The test changes are larger than the production diff because four existing guards would have silently stopped guarding. Three built their expected values from the host clock while production had moved to HA's zone, which broke them outright on any zone ahead of UTC. A fourth, the `#226` rollover guard, kept passing while never exercising normalization at all, because its window extremes held it open either way. All four now pin the clock to a shared sentinel and hold on any host zone (checked under `Asia/Kolkata` and `Pacific/Kiritimati`).

## Testing

- ✅ 12025 tests passing

## Related Issues
Refs #1161