### PR TITLE
fix: judge a hold against each cover's own position (#1174)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -258,6 +258,15 @@ _MANUAL_OVERRIDE_SKIP_LABEL = "manual_override"
 # is the arithmetic mean of every bound cover.  Dispatching it would break the
 # hold AND drive each cover to a number that is nobody's position.
 #
+# The mean hazard is unchanged for MOTION: that handler publishes its hold
+# through ``PipelineResult.position``, sets no ``held_position``, and is
+# therefore never judged per cover.  What issue #1174 changed is narrower —
+# for a GROUP_LOCK or MANUAL hold the registry now decides *per cover* whether
+# each one is released to a clamping bound (``PipelineResult.hold_clamp_verdicts``,
+# judged on that cover's own position), and ``_dispatch_to_cover`` records each
+# skip with that cover's own position rather than the mean.  The dispatched
+# target is still ONE instance-wide value; only the release verdict is plural.
+#
 # ``ControlMethod.MANUAL`` is deliberately NOT a member and must not be added.
 # The manual-override handler's position is ``compute_solar_position`` /
 # ``compute_default_position`` (``pipeline/handlers/manual_override.py:39,:51``)
@@ -2307,6 +2316,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             climate_temp_flags=self._climate_smoothing_mgr.resolved_flags,
             in_time_window=self.check_adaptive_time,
             current_cover_position=self._compute_mean_cover_position(),
+            # Same read the mean summarises — the registry needs the per-entity
+            # dict to judge each held cover's clamp verdict on its own position
+            # instead of on that mean (#1174).
+            cover_positions=self._live_cover_positions,
             is_glare_zone_enabled=self._is_glare_zone_enabled,
             effective_default=effective_default,
             is_sunset_active=is_sunset_active,
@@ -2589,18 +2602,38 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             position_forecast=self._position_forecast,
         )
 
+    @property
+    def _live_cover_positions(self) -> Mapping[str, int | None] | None:
+        """This cycle's per-entity RAW cover-frame positions, or None.
+
+        One read serves both consumers: ``_compute_mean_cover_position`` (which
+        summarises it) and ``PipelineSnapshot.cover_positions`` (which the
+        registry judges each held cover against, #1174). None before the first
+        update cycle has built a ``CoverStateSnapshot``.
+        """
+        snapshot = getattr(self, "_snapshot", None)
+        return snapshot.cover_positions if snapshot is not None else None
+
     def _compute_mean_cover_position(self) -> int | None:
         """Return integer mean of current entity positions, or None if none are available.
 
-        Used to populate PipelineSnapshot.current_cover_position so the
-        MotionTimeoutHandler can hold covers at their current physical position
-        in hold_position mode.
+        Populates ``PipelineSnapshot.current_cover_position``, which serves two
+        roles, both of them summaries or fallbacks — never a per-cover decision:
+
+        * ``MotionTimeoutHandler`` holds covers at it in hold_position mode
+          (the instance-mean hazard ``_INSTANCE_MEAN_POSITION_HOLDS`` documents
+          still applies there in full);
+        * the manual-override / group-lock holds publish it as the "Target
+          Position" sensor's scalar, and the registry falls back to it for a
+          cover that reports no position of its own.
+
+        Whether each held cover is released to a clamping bound is judged
+        against that cover's own entry in ``_live_cover_positions`` (#1174),
+        never against this mean.
         """
-        if self._snapshot is None:
-            return None
         positions = [
             p
-            for p in self._snapshot.cover_positions.values()
+            for p in (self._live_cover_positions or {}).values()
             if isinstance(p, int | float)
         ]
         if not positions:
@@ -2709,9 +2742,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         opts back in via ``_async_force_send_pipeline_position(honor_holds=True)``
         and is routed here only for the ``_INSTANCE_MEAN_POSITION_HOLDS``
         winners, never for a manual-override hold.
+
+        When the winner is a hold and the registry judged each bound cover
+        individually (``hold_clamp_verdicts``, issue #1174), *this* cover's
+        verdict decides: released means the clamp target reaches it, held means
+        the skip record is written — and written with the cover's own position,
+        not the instance mean the singular ``held_position`` carries. Without
+        verdicts (a computed winner, a motion hold, a legacy snapshot) the
+        singular ``skip_command`` answers for every cover, exactly as before.
         """
-        if self._pipeline_result is not None and self._pipeline_result.skip_command:
-            result = self._pipeline_result
+        result = self._pipeline_result
+        verdict = (result.hold_clamp_verdicts or {}).get(cover) if result else None
+        skip_this = (
+            not verdict.released
+            if verdict is not None
+            else (result is not None and result.skip_command)
+        )
+        if skip_this:
             label = _HOLD_SKIP_LABEL.get(result.control_method, "hold")
             # Where the cover is actually sitting, in the COVER frame — one
             # frame for every hold type, never "logical when motion won and
@@ -2728,7 +2775,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # keeps every hold type's ``held_position`` in one frame, the
             # cover's own (#534 / #809). The registry converts it to logical
             # itself, at the one site that compares it against a floor (#1036).
-            held = result.held_position
+            #
+            # A per-cover verdict carries THIS cover's raw read, in that same
+            # cover frame; the singular ``held_position`` is the instance mean
+            # and is only the fallback for holds the registry did not judge
+            # per cover (#1174).
+            held = (
+                verdict.held_position if verdict is not None else result.held_position
+            )
             if held is None:
                 held = flip_if(result.position, inverted=self.position_axis_inverted)
             self._cmd_svc.record_skipped_action(
@@ -2759,7 +2813,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Per-entity dispatch target for this cover (identity for most types).
 
         The pipeline resolves ONE position per cycle, which is then sent to
-        every bound entity. A cover type that drives several physical entities
+        every bound entity *the cycle's hold verdict releases* (#1174: a hold
+        judges each cover's release against its own position, but a released
+        cover always lands on the same bound edge, so there is still exactly
+        one target value). A cover type that drives several physical entities
         to different positions from that one value — the Model C day/night
         shade with a separate middle-rail entity, the dual panel's blackout
         panel — remaps here via its polymorphic ``resolve_entity_target`` hook.
@@ -3864,6 +3921,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             climate_temp_flags=self._climate_smoothing_mgr.resolved_flags,
             in_time_window=self.check_adaptive_time,
             current_cover_position=self._compute_mean_cover_position(),
+            # Same read the mean summarises — see the update-cycle build (#1174).
+            cover_positions=self._live_cover_positions,
             is_glare_zone_enabled=self._is_glare_zone_enabled,
             cover_capabilities=getattr(
                 getattr(self, "_snapshot", None), "cover_capabilities", None

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -260,13 +260,15 @@ _MANUAL_OVERRIDE_SKIP_LABEL = "manual_override"
 #
 # The mean hazard is unchanged for MOTION: that handler publishes its hold
 # through ``PipelineResult.position``, sets no ``held_position``, and is
-# therefore never judged per cover.  For a GROUP_LOCK or MANUAL hold, issue
-# #1174 moved the whole dispatch decision off the mean and onto
-# ``PipelineResult.hold_clamp_verdicts``: each bound cover is judged on its own
-# position, commanded (or held) on its own verdict, sent to its own resolved
-# target, and its skip record written with its own position.  ``position``
-# remains the shared summary the trace and the singular surfaces carry — it is
-# no longer what reaches a judged cover.
+# therefore never judged per cover.  For a GROUP_LOCK or MANUAL hold on a cover
+# type whose entities move independently, issue #1174 moved the whole dispatch
+# decision off the mean and onto ``PipelineResult.hold_clamp_verdicts``: each
+# bound cover is judged on its own position, commanded (or held) on its own
+# verdict, sent to its own resolved target, and its skip record written with its
+# own position.  ``position`` remains the shared summary the trace and the
+# singular surfaces carry — it is no longer what reaches a judged cover.  A
+# coupled cover type (its rails are one geometry, not N opinions) produces no
+# verdicts and keeps the shared target, mean hazard and all.
 #
 # ``ControlMethod.MANUAL`` is deliberately NOT a member and must not be added.
 # The manual-override handler's position is ``compute_solar_position`` /
@@ -2755,8 +2757,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         means the skip record is written — with the cover's own position, not
         the instance mean the singular ``held_position`` carries. Without a
         verdict (a computed winner, a motion hold, a legacy snapshot, a cover
-        absent from the dict) the singular ``skip_command`` and ``state`` answer
-        for every cover, exactly as before.
+        absent from the dict, or a cover type whose entities do not move
+        independently) the singular ``skip_command`` and ``state`` answer for
+        every cover, exactly as before.
         """
         result = self._pipeline_result
         verdict = (result.hold_clamp_verdicts or {}).get(cover) if result else None
@@ -2824,17 +2827,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     ) -> int:
         """Per-entity dispatch target for this cover (identity for most types).
 
-        The pipeline resolves ONE position per cycle and it is sent to every
-        bound entity, EXCEPT under a hold that was judged per cover — there each
-        cover is commanded (or not) on its own verdict, and to that verdict's
-        own target, which need not be the shared one (#1174). Either way the
-        number reaching this hook is already resolved for the entity being
-        dispatched. A cover type that drives several physical entities
+        The pipeline resolves ONE position per cycle, which is then sent to
+        every bound entity. A cover type that drives several physical entities
         to different positions from that one value — the Model C day/night
         shade with a separate middle-rail entity, the dual panel's blackout
         panel — remaps here via its polymorphic ``resolve_entity_target`` hook.
         Every other cover type's hook is identity, so this seam never branches
         on the cover type.
+
+        A hold judged per cover (#1174) hands this hook that cover's OWN target
+        rather than the shared one — which is safe precisely because overriding
+        ``resolve_entity_target`` is one of the three signals
+        ``CoverTypePolicy.entities_move_independently`` reads: a remapping
+        policy is never judged per cover, so the value arriving here is a shared
+        position for exactly the types that transform it, and already
+        entity-resolved for the identity ones.
 
         ``inverted`` and ``interpolated`` name the dispatch frame of ``state``
         so a remapping policy reproduces or undoes it correctly. The main
@@ -3411,8 +3418,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 else "solar"
             )
         # Name the number and frame this loop fans out so the ordering view can
-        # tell a raise from a lower (issue #1118) — the same pair
-        # ``_entity_target`` gets below.
+        # tell a raise from a lower (issue #1118). A per-cover hold verdict can
+        # send an individual cover somewhere else (#1174), but only for a policy
+        # whose ``dispatch_order_key`` is the constant default — overriding that
+        # hook is one of the signals which switch per-cover judging off — so for
+        # every cover type that actually reads this argument, ``state`` is still
+        # exactly what each entity receives.
         for cover in self._policy.order_for_dispatch(self.entities, position=state):
             ctx = self._build_position_context(
                 cover,
@@ -3606,8 +3617,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         sun_just_appeared = self._check_sun_validity_transition()
         # Name the number and frame this loop fans out so the ordering view can
-        # tell a raise from a lower (issue #1118) — the same pair
-        # ``_entity_target`` gets below.
+        # tell a raise from a lower (issue #1118). A per-cover hold verdict can
+        # send an individual cover somewhere else (#1174), but only for a policy
+        # whose ``dispatch_order_key`` is the constant default — overriding that
+        # hook is one of the signals which switch per-cover judging off — so for
+        # every cover type that actually reads this argument, ``state`` is still
+        # exactly what each entity receives.
         for cover in self._policy.order_for_dispatch(self.entities, position=state):
             if self.manager.is_cover_manual(cover):
                 self.logger.debug(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -260,12 +260,13 @@ _MANUAL_OVERRIDE_SKIP_LABEL = "manual_override"
 #
 # The mean hazard is unchanged for MOTION: that handler publishes its hold
 # through ``PipelineResult.position``, sets no ``held_position``, and is
-# therefore never judged per cover.  What issue #1174 changed is narrower —
-# for a GROUP_LOCK or MANUAL hold the registry now decides *per cover* whether
-# each one is released to a clamping bound (``PipelineResult.hold_clamp_verdicts``,
-# judged on that cover's own position), and ``_dispatch_to_cover`` records each
-# skip with that cover's own position rather than the mean.  The dispatched
-# target is still ONE instance-wide value; only the release verdict is plural.
+# therefore never judged per cover.  For a GROUP_LOCK or MANUAL hold, issue
+# #1174 moved the whole dispatch decision off the mean and onto
+# ``PipelineResult.hold_clamp_verdicts``: each bound cover is judged on its own
+# position, commanded (or held) on its own verdict, sent to its own resolved
+# target, and its skip record written with its own position.  ``position``
+# remains the shared summary the trace and the singular surfaces carry — it is
+# no longer what reaches a judged cover.
 #
 # ``ControlMethod.MANUAL`` is deliberately NOT a member and must not be added.
 # The manual-override handler's position is ``compute_solar_position`` /
@@ -2745,16 +2746,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         When the winner is a hold and the registry judged each bound cover
         individually (``hold_clamp_verdicts``, issue #1174), *this* cover's
-        verdict decides: released means the clamp target reaches it, held means
-        the skip record is written — and written with the cover's own position,
-        not the instance mean the singular ``held_position`` carries. Without
-        verdicts (a computed winner, a motion hold, a legacy snapshot, or a
-        command the TILT axis forced) the singular ``skip_command`` answers for
-        every cover, exactly as before.
-
-        Those verdicts are the skip authority for the POSITION axis only — a
-        tilt clamp is a separate reason to command and the registry publishes no
-        verdicts on that path, so nothing here can veto it.
+        verdict is the whole answer — both halves of it. Released means a
+        command goes out, and it goes to the verdict's own resolved target
+        rather than the shared ``state``: the two diverge whenever a floor and a
+        ceiling bind different covers, and whenever the TILT axis is what forced
+        the dispatch, in which case every cover is commanded to where it already
+        is so the slats reach the hardware without moving the carriage. Held
+        means the skip record is written — with the cover's own position, not
+        the instance mean the singular ``held_position`` carries. Without a
+        verdict (a computed winner, a motion hold, a legacy snapshot, a cover
+        absent from the dict) the singular ``skip_command`` and ``state`` answer
+        for every cover, exactly as before.
         """
         result = self._pipeline_result
         verdict = (result.hold_clamp_verdicts or {}).get(cover) if result else None
@@ -2803,8 +2805,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 },
             )
             return None
+        # ``verdict.target`` is logical, exactly like the ``PipelineResult.position``
+        # that produced ``state``, so it crosses to the wire through the same
+        # single seam — no second frame rule, and a cover with no verdict keeps
+        # the value the caller already resolved.
+        target = self._to_cover_frame(verdict.target) if verdict is not None else state
         return await self._cmd_svc.apply_position(
-            cover, self._entity_target(cover, state), reason, context=ctx
+            cover, self._entity_target(cover, target), reason, context=ctx
         )
 
     def _entity_target(
@@ -2817,11 +2824,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     ) -> int:
         """Per-entity dispatch target for this cover (identity for most types).
 
-        The pipeline resolves ONE position per cycle, which is then sent to
-        every bound entity *the cycle's hold verdict releases* (#1174: a hold
-        judges each cover's release against its own position, but a released
-        cover always lands on the same bound edge, so there is still exactly
-        one target value). A cover type that drives several physical entities
+        The pipeline resolves ONE position per cycle and it is sent to every
+        bound entity, EXCEPT under a hold that was judged per cover — there each
+        cover is commanded (or not) on its own verdict, and to that verdict's
+        own target, which need not be the shared one (#1174). Either way the
+        number reaching this hook is already resolved for the entity being
+        dispatched. A cover type that drives several physical entities
         to different positions from that one value — the Model C day/night
         shade with a separate middle-rail entity, the dual panel's blackout
         panel — remaps here via its polymorphic ``resolve_entity_target`` hook.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2748,8 +2748,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         verdict decides: released means the clamp target reaches it, held means
         the skip record is written — and written with the cover's own position,
         not the instance mean the singular ``held_position`` carries. Without
-        verdicts (a computed winner, a motion hold, a legacy snapshot) the
-        singular ``skip_command`` answers for every cover, exactly as before.
+        verdicts (a computed winner, a motion hold, a legacy snapshot, or a
+        command the TILT axis forced) the singular ``skip_command`` answers for
+        every cover, exactly as before.
+
+        Those verdicts are the skip authority for the POSITION axis only — a
+        tilt clamp is a separate reason to command and the registry publishes no
+        verdicts on that path, so nothing here can veto it.
         """
         result = self._pipeline_result
         verdict = (result.hold_clamp_verdicts or {}).get(cover) if result else None

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -641,8 +641,11 @@ class CoverTypePolicy(ABC):
     ) -> int:
         """Adjust the dispatched position for one specific entity.
 
-        The coordinator resolves a single ``position`` per update cycle, then
-        sends it to every bound entity. A cover type that drives *several*
+        The coordinator resolves a single ``position`` per update cycle and
+        sends it to every bound entity — except under a hold judged per cover,
+        where each cover is dispatched on its own verdict and to that verdict's
+        own target (#1174). Either way ``position`` is already resolved for
+        ``entity_id`` by the time it arrives. A cover type that drives *several*
         physical entities to *different* positions from that one resolved value
         overrides this hook (the Model C day/night shade remaps its middle-rail
         entity while the bottom rail passes through unchanged). The Liskov-safe

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -641,11 +641,8 @@ class CoverTypePolicy(ABC):
     ) -> int:
         """Adjust the dispatched position for one specific entity.
 
-        The coordinator resolves a single ``position`` per update cycle and
-        sends it to every bound entity — except under a hold judged per cover,
-        where each cover is dispatched on its own verdict and to that verdict's
-        own target (#1174). Either way ``position`` is already resolved for
-        ``entity_id`` by the time it arrives. A cover type that drives *several*
+        The coordinator resolves a single ``position`` per update cycle, then
+        sends it to every bound entity. A cover type that drives *several*
         physical entities to *different* positions from that one resolved value
         overrides this hook (the Model C day/night shade remaps its middle-rail
         entity while the bottom rail passes through unchanged). The Liskov-safe
@@ -727,8 +724,57 @@ class CoverTypePolicy(ABC):
         The Liskov-safe default is a constant, which makes ``sorted(...)`` a
         stable-sort no-op: the user's config-flow pick order survives verbatim
         for every cover type with independent entities.
+
+        The ``position`` a seam names is the one number that cycle fans out, and
+        that stays true for every policy which actually overrides this hook:
+        overriding it is one of the three signals
+        :meth:`entities_move_independently` reads, so such a policy is never
+        dispatched per entity in the first place (#1174).
         """
         return 0
+
+    def entities_move_independently(self) -> bool:
+        """Whether each bound entity's position may be decided on its own (#1174).
+
+        A hold (manual override, group lock) keeps every bound cover where
+        something authoritative already put it, and a composed floor/ceiling
+        then asks "does this cover still satisfy the bound?". On an instance of
+        N unrelated covers that question has N answers, and collapsing them into
+        one — the arithmetic mean of every cover's position — dragged compliant
+        covers to a floor they already satisfied and hid a lone violator behind
+        its siblings. So the registry judges and dispatches each cover
+        separately, but ONLY where doing so is meaningful.
+
+        It is not meaningful whenever this cover type's entities are not
+        independent, and the three hooks that express non-independence are
+        exactly the ones consulted here:
+
+        * :meth:`resolve_entity_target` — a per-entity REMAP. The value handed to
+          it is a shared position that the policy turns into this entity's own;
+          feeding it a value already resolved for that entity applies the remap
+          twice (the Model C middle rail derived from a middle-rail number).
+        * :meth:`post_pipeline_resolve` — a rewrite of ``PipelineResult.position``
+          that runs AFTER the registry. A per-cover target is computed before it
+          and therefore bypasses it: the Model B day/night shade folds coverage
+          and fabric into one wire there, so a cover released to its own raw
+          read carries neither.
+        * :meth:`dispatch_order_key` — physical COUPLING. Entities that have to
+          be commanded in a mandated order share a track; a bound that moves one
+          of them moves the geometry, not one opinion out of several.
+
+        Derived rather than declared, so a new cover type is safe by
+        construction: touch any of the three and the per-entity path switches
+        itself off, leaving that type on the shared-target behaviour it had
+        before #1174. A policy that overrides one of them harmlessly may say so
+        by overriding this predicate — and owes the argument for why, in its own
+        docstring, because nothing else here can check it.
+        """
+        cls = type(self)
+        return (
+            cls.resolve_entity_target is CoverTypePolicy.resolve_entity_target
+            and cls.post_pipeline_resolve is CoverTypePolicy.post_pipeline_resolve
+            and cls.dispatch_order_key is CoverTypePolicy.dispatch_order_key
+        )
 
     def order_for_dispatch(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -707,6 +707,34 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         )
         return {self.axes[1].name: tilt}
 
+    def entities_move_independently(self) -> bool:
+        """Venetian blinds on one instance are unrelated covers (#1174).
+
+        The base predicate derives its answer from three hooks, and this policy
+        trips one of them: it overrides ``post_pipeline_resolve``. That hook's
+        only write to ``PipelineResult.position`` is
+        :meth:`_pin_tilt_only_carriage`, and that pin is skipped for every
+        control method in ``_EXPLICIT_USER_POSITION_METHODS`` — which contains
+        both ``MANUAL`` and ``GROUP_LOCK``, the only two winners that ever set
+        ``held_position`` and so the only two the registry ever judges per
+        cover. Under a hold this hook resolves a tilt and leaves the position
+        exactly as the registry left it, which is the condition the base
+        predicate is really asking about.
+
+        Nothing else here is per-entity: ``resolve_entity_target`` is the
+        identity default (one slat angle and one carriage position per cover),
+        and ``dispatch_order_key`` is the constant default because two venetian
+        blinds share no track. That makes the per-cover path both safe and
+        worth having: a tilt bound that outranks a hold has to reach every
+        cover's slats without moving anybody's carriage, which is precisely
+        what one shared position cannot express.
+
+        ``tests/test_cover_types/test_venetian_post_pipeline.py`` locks the
+        premise — if the pin ever starts firing under a hold, that test fails
+        rather than this silently becoming wrong.
+        """
+        return True
+
     def post_pipeline_resolve(
         self,
         result: PipelineResult,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
@@ -37,10 +37,12 @@ class ManualOverrideHandler(OverrideHandler):
         #
         # On a multi-cover instance this is a SUMMARY: the mean of the covers
         # that reported a position, because the sensor is one entity per config
-        # entry. No decision consumes it — the registry judges each held cover
-        # against its own entry in ``snapshot.cover_positions`` (#1174), and its
-        # only other job here is the presence marker the #1170 priority gate
-        # and ``skip_command`` key on.
+        # entry. On a cover type whose entities move independently no decision
+        # consumes it — the registry judges each held cover against its own
+        # entry in ``snapshot.cover_positions`` (#1174). A coupled type is still
+        # judged on this scalar, because its entities describe one geometry. In
+        # both cases its other job here is the presence marker the #1170
+        # priority gate and ``skip_command`` key on.
         held_position: int | None = snapshot.current_cover_position
 
         if snapshot.cover.direct_sun_valid:

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
@@ -34,6 +34,13 @@ class ManualOverrideHandler(OverrideHandler):
         # has not reported a numeric position yet.  Used to populate held_position
         # so the "Target Position" sensor shows where the cover physically sits
         # rather than the solar value the override is shadowing.
+        #
+        # On a multi-cover instance this is a SUMMARY: the mean of the covers
+        # that reported a position, because the sensor is one entity per config
+        # entry. No decision consumes it — the registry judges each held cover
+        # against its own entry in ``snapshot.cover_positions`` (#1174), and its
+        # only other job here is the presence marker the #1170 priority gate
+        # and ``skip_command`` key on.
         held_position: int | None = snapshot.current_cover_position
 
         if snapshot.cover.direct_sun_valid:

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -875,6 +875,19 @@ class PipelineRegistry:
                 position_clamped=position_clamped,
                 effective_winner_pos=effective_winner_pos,
             )
+            # ``hold_clamp_verdicts`` is the skip authority for the POSITION
+            # axis ONLY: it answers "did a composed position bound release this
+            # cover", nothing else. A tilt clamp is a command, not a no-op
+            # (#1170 audit) — an independent reason to command every held cover
+            # — so the position axis's per-cover verdicts must not veto it.
+            # Dropping them puts this cycle back on the singular
+            # ``skip_command`` the tilt release just cleared, which is what
+            # every cover needs and exactly the pre-#1174 route. Without this a
+            # tilt-only release found every verdict at ``released=False`` (the
+            # position axis was inert, so nothing was released) and re-skipped
+            # the whole group, leaving the trace claiming a carried hold
+            # position for a dispatch that never happened.
+            hold_clamp_verdicts = None
         # The tilt-axis overlay (issue #514) is how a FIXED contribution
         # reaches the result's tilt field. It can never collide with the
         # bound-clamp write above (the ``else: merged["tilt"] = bounded_tilt``
@@ -885,9 +898,10 @@ class PipelineRegistry:
         result = dataclasses.replace(
             winner,
             decision_trace=trace,
-            # Per-cover release verdicts for a hold (#1174); None for a computed
-            # winner and for a snapshot without per-entity positions, which is
-            # what keeps every pre-#1174 consumer on the singular path.
+            # Per-cover release verdicts for a hold (#1174) — the POSITION
+            # axis's skip authority. None for a computed winner, for a snapshot
+            # without per-entity positions, and for a tilt-forced command, each
+            # of which keeps that cycle on the singular path.
             hold_clamp_verdicts=hold_clamp_verdicts,
             default_position=snapshot.default_position,
             is_sunset_active=snapshot.is_sunset_active,

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -113,6 +113,27 @@ def _split_bounds_against_hold(
     return binding, yielded
 
 
+def _judges_per_cover(snapshot: PipelineSnapshot) -> bool:
+    """Whether this instance's covers may be judged one at a time (#1174).
+
+    Delegated whole to ``CoverTypePolicy.entities_move_independently`` — the
+    registry asks the polymorphic hook and never inspects a cover-type string
+    (CODING_GUIDELINES § "Cover Type Abstraction"). ``snapshot.policy or
+    get_policy(snapshot.cover_type)`` is the same resolution the glare-zone,
+    group-scene and climate handlers already use, so a snapshot built without a
+    policy object still gets its own cover type's answer rather than a default.
+
+    Local import: ``cover_types`` pulls in policies that import from
+    ``pipeline``, so a module-level import here would close the cycle — the same
+    reason ``axis_constraints.gather_axis_constraints`` imports its handler
+    locally.
+    """
+    from ..cover_types import get_policy
+
+    policy = snapshot.policy or get_policy(snapshot.cover_type)
+    return policy.entities_move_independently()
+
+
 def _judge_position_axis(
     winner,
     snapshot: PipelineSnapshot,
@@ -141,12 +162,22 @@ def _judge_position_axis(
     of the two edges.
 
     **Judged set** (holds only). ``snapshot.cover_positions`` when it carries
-    entries — a cover with an unknown position falls back to the summary
-    ``winner.held_position``, which is today's judgment kept exactly for the
-    covers where per-entity data is missing. Otherwise a single pseudo-entry
-    ``{None: winner.held_position}``, reproducing the legacy singular
-    comparison byte-for-byte; ``verdicts`` is ``None`` on that path so every
-    pre-#1174 consumer stays on the singular ``skip_command`` route.
+    entries AND this cover type's entities move independently — a cover with an
+    unknown position falls back to the summary ``winner.held_position``, which
+    is today's judgment kept exactly for the covers where per-entity data is
+    missing. Otherwise a single pseudo-entry ``{None: winner.held_position}``,
+    reproducing the legacy singular comparison byte-for-byte; ``verdicts`` is
+    ``None`` on that path so every pre-#1174 consumer stays on the singular
+    ``skip_command`` route.
+
+    **The independence gate** is the policy's own
+    ``entities_move_independently`` (``cover_types/base.py``), never a
+    cover-type test here — CODING_GUIDELINES § "Cover Type Abstraction". A type
+    that remaps a shared position per entity, rewrites it after the pipeline, or
+    orders physically coupled entities has no per-cover question to answer: its
+    entities express ONE geometry, and judging them apart both double-applies
+    the remap and bypasses the rewrite. Those instances keep the shared target
+    they had before #1174.
 
     **Frames.** Held positions are RAW cover-frame reads and the bounds are
     logical user values, so each is converted before comparing — the #1036
@@ -158,18 +189,26 @@ def _judge_position_axis(
     For a hold, ``effective_winner_pos`` names the *violating* cover — the
     lowest judged position when a floor raised, the highest when a ceiling
     lowered — so the clamp step's ``from_pos`` reads as a real cover's position
-    rather than a mean nobody sits at. Same ReasonCodes, same trace shape.
+    rather than a mean nobody sits at. ``raise_from`` / ``lower_from`` keep both
+    of those, because a floor and a ceiling can bind different covers in the
+    same cycle and each clamp step then owes its own honest starting point.
     """
     if winner.held_position is None:
         final = clamp_to_bounds(winner.position, floor_pos, ceiling_pos)
+        raised = final > winner.position
+        lowered = final < winner.position
         return PositionAxisJudgment(
             effective_winner_pos=winner.position,
             final_pos=final,
-            raised=final > winner.position,
-            lowered=final < winner.position,
+            raised=raised,
+            lowered=lowered,
+            raise_from=winner.position if raised else None,
+            lower_from=winner.position if lowered else None,
             verdicts=None,
         )
     per_entity = snapshot.cover_positions or None
+    if per_entity is not None and not _judges_per_cover(snapshot):
+        per_entity = None
     judged: Mapping[str | None, int | None] = (
         per_entity if per_entity is not None else {None: winner.held_position}
     )
@@ -205,6 +244,8 @@ def _judge_position_axis(
         final_pos=clamp_to_bounds(effective_winner_pos, floor_pos, ceiling_pos),
         raised=raised,
         lowered=lowered,
+        raise_from=min(effective_positions) if raised else None,
+        lower_from=max(effective_positions) if lowered else None,
         verdicts=verdicts if per_entity is not None else None,
     )
 
@@ -279,20 +320,126 @@ def _release_hold_for_tilt_clamp(
     return dataclasses.replace(winner, position=effective_winner_pos)
 
 
-def _iter_nonbinding_bounds(constraints: list, axis: str, binding):
+def _clamp_step(
+    constraints: list,
+    *,
+    low: bool,
+    from_pos: int,
+    to_pos: int,
+    code: ReasonCode,
+    extra: dict | None = None,
+):
+    """Build one matched position-clamp step, plus the bound that produced it.
+
+    ``low`` selects the direction — the floor edge (True) or the ceiling edge
+    (False) — and drives BOTH the ``bounding_constraint`` lookup and the step's
+    handler name, so the trace can never credit one slot while the inactive
+    sweep treats a different one as binding. Returning the constraint alongside
+    the step is what lets a two-sided clamp (#1174: a floor and a ceiling
+    binding different covers) hand the sweep both bounds without restating the
+    lookup (CODING_GUIDELINES § No Duplication).
+    """
+    binding = bounding_constraint(constraints, AXIS_NAME_POSITION, to_pos, low=low)
+    label = (
+        binding.label
+        if binding is not None
+        else constraint_label(constraints, AXIS_NAME_POSITION)
+    )
+    # Both endpoints are logical now that the judged positions are converted
+    # up front, so "floor raised from X% to Y%" no longer mixes a motor reading
+    # with a user-typed bound (#1036).
+    params: dict = {"from_pos": from_pos, "to_pos": to_pos, "label": label}
+    if extra:
+        params.update(extra)
+    step = DecisionStep(
+        handler="floor_clamp" if low else "ceiling_clamp",
+        matched=True,
+        reason_payload=Reason(code, params),
+        position=to_pos,
+    )
+    return step, binding
+
+
+def _position_clamp_steps(
+    constraints: list,
+    judgment: PositionAxisJudgment,
+    *,
+    floor_pos: int | None,
+    ceiling_pos: int | None,
+    floor_wins: bool,
+    two_sided: bool,
+) -> tuple[list[DecisionStep], list]:
+    """Emit the matched position-clamp step(s), plus the bound(s) behind them.
+
+    One step for the ordinary single-direction clamp, and TWO when a floor and
+    a ceiling each bound a different cover in the same cycle (#1174) — a shape
+    only per-cover judging can produce, and one the shared ``final_pos`` cannot
+    describe on its own. Returns an empty pair when nothing clamped.
+
+    The bounds come back with the steps because the inactive-bound sweep has to
+    skip exactly the ones that bound; resolving them twice is how a bound ends
+    up both credited with a clamp and reported as having done nothing.
+    """
+    if two_sided:
+        floor_step, floor_binding = _clamp_step(
+            constraints,
+            low=True,
+            from_pos=judgment.raise_from,
+            to_pos=floor_pos,
+            code=ReasonCode.REGISTRY_FLOOR_RAISED,
+        )
+        ceiling_step, ceiling_binding = _clamp_step(
+            constraints,
+            low=False,
+            from_pos=judgment.lower_from,
+            to_pos=ceiling_pos,
+            code=ReasonCode.REGISTRY_CEILING_LOWERED,
+        )
+        return [floor_step, ceiling_step], [floor_binding, ceiling_binding]
+    if not (judgment.raised or judgment.lowered):
+        return [], []
+    extra: dict | None = None
+    if not floor_wins:
+        code = ReasonCode.REGISTRY_CEILING_LOWERED
+    elif judgment.raised:
+        code = ReasonCode.REGISTRY_FLOOR_RAISED
+    else:
+        # The floor won a conflict but the winner started above it: the net
+        # move is a lowering, so "floor raised from 80% to 60%" would
+        # contradict itself. A floor-wins step names the floor as the
+        # determining bound without implying a direction (audit finding C).
+        code = ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING
+        extra = {"ceiling_pos": ceiling_pos}
+    step, binding = _clamp_step(
+        constraints,
+        low=floor_wins,
+        from_pos=judgment.effective_winner_pos,
+        to_pos=judgment.final_pos,
+        code=code,
+        extra=extra,
+    )
+    return [step], [binding]
+
+
+def _iter_nonbinding_bounds(constraints: list, axis: str, bindings):
     """Yield the active bounded constraints on ``axis`` that did not bind.
 
     Shared by the position and tilt inactive-step passes so the axis filter,
-    the FIXED skip, and the ``binding``-by-identity skip live in one place
+    the FIXED skip, and the ``bindings``-by-identity skip live in one place
     (CODING_GUIDELINES § No Duplication). Skipping by *identity* rather than by
     value keeps a losing tie-bound visible — two slots at the same floor no
     longer collapse into one trace entry (audit finding 4b).
+
+    ``bindings`` is a collection because the position axis can have TWO bounds
+    bind in one cycle once covers are judged individually (#1174) — a floor on
+    one cover and a ceiling on another. Either of them left out of this set
+    would be re-reported as having done nothing, which is the opposite of true.
     """
     for c in constraints:
         if c.axis != axis or c.kind is AxisConstraintMode.FIXED:
             continue
-        if c is binding:
-            continue  # this bound *did* bind — already emitted as the clamp
+        if any(c is b for b in bindings):
+            continue  # this bound *did* bind — already emitted as a clamp
         yield c
 
 
@@ -302,7 +449,7 @@ def _inactive_position_steps(
     winner_pos: int,
     final_pos: int,
     floor_wins: bool,
-    binding,
+    bindings,
 ) -> list[DecisionStep]:
     """Explain every position bound that was active but did not bind.
 
@@ -310,9 +457,10 @@ def _inactive_position_steps(
     unhelpful ``describe_skip`` step (the registry drops those). Give each
     non-binding bound a step saying it was evaluated and why it did nothing.
 
-    ``binding`` is the single constraint that produced this cycle's clamp (None
-    when nothing clamped); it is skipped, since it was already emitted as the
-    matched clamp step.
+    ``bindings`` holds the constraints that produced this cycle's clamps (empty
+    when nothing clamped, two when a floor and a ceiling bound different
+    covers); each is skipped, since it was already emitted as a matched clamp
+    step.
 
     A ceiling the floor beat is reported as *overridden*, not *inactive*: when
     the floor won the conflict (``floor_wins``) it sits above that ceiling, so
@@ -328,7 +476,7 @@ def _inactive_position_steps(
     resolved position equals the winner's (audit finding ii).
     """
     steps: list[DecisionStep] = []
-    for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_POSITION, binding):
+    for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_POSITION, bindings):
         if c.low is not None:
             steps.append(
                 DecisionStep(
@@ -382,7 +530,7 @@ def _inactive_tilt_steps(
     claim when the tilt was really clamped elsewhere (audit finding i).
     """
     steps: list[DecisionStep] = []
-    for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_TILT, binding):
+    for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_TILT, (binding,)):
         steps.append(
             DecisionStep(
                 handler=c.source,
@@ -617,50 +765,28 @@ class PipelineRegistry:
         # Unchanged position keeps the winner's own value (today's behaviour:
         # an inert bound must not overwrite ``position`` with ``held_position``).
         clamped_position = final_pos if position_clamped else winner.position
-        # The single constraint that actually bound — resolved back from the
-        # composed value so the trace credits the one slot that produced the
-        # move, not the join of every active bound (audit finding 4a).
-        position_binding = (
-            bounding_constraint(
-                bound_constraints, AXIS_NAME_POSITION, final_pos, low=floor_wins
-            )
-            if position_clamped
-            else None
+        # Two bounds can bind in ONE cycle once each cover is judged on its own
+        # position (#1174): a floor lifting the low cover while a ceiling lowers
+        # the high one. ``final_pos`` is a single number and ``clamp_to_bounds``
+        # applies the floor last, so the shared field can only ever name the
+        # floor's edge — leaving the ceiling to fall through to the "did
+        # nothing" sweep and be reported as inactive while it was busy moving a
+        # cover to 70. So each side that really bound states itself. Excluded in
+        # a floor/ceiling CONFLICT, where the floor alone produced both
+        # directions and the ceiling bound nobody.
+        two_sided = raised and lowered and not floor_conflict
+        # The constraints that actually bound — resolved back from the composed
+        # values so the trace credits the slots that produced the moves, not the
+        # join of every active bound (audit finding 4a).
+        clamp_steps, position_bindings = _position_clamp_steps(
+            bound_constraints,
+            judgment,
+            floor_pos=floor_pos,
+            ceiling_pos=ceiling_pos,
+            floor_wins=floor_wins,
+            two_sided=two_sided,
         )
-        if position_clamped:
-            source = "floor_clamp" if floor_wins else "ceiling_clamp"
-            label = (
-                position_binding.label
-                if position_binding is not None
-                else constraint_label(bound_constraints, AXIS_NAME_POSITION)
-            )
-            # Both endpoints are logical now that ``effective_winner_pos`` is
-            # converted above, so "floor raised from X% to Y%" no longer mixes a
-            # motor reading with a user-typed bound (#1036).
-            params = {
-                "from_pos": effective_winner_pos,
-                "to_pos": final_pos,
-                "label": label,
-            }
-            if not floor_wins:
-                code = ReasonCode.REGISTRY_CEILING_LOWERED
-            elif raised:
-                code = ReasonCode.REGISTRY_FLOOR_RAISED
-            else:
-                # The floor won a conflict but the winner started above it: the
-                # net move is a lowering, so "floor raised from 80% to 60%" would
-                # contradict itself. A floor-wins step names the floor as the
-                # determining bound without implying a direction (finding C).
-                code = ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING
-                params["ceiling_pos"] = ceiling_pos
-            trace.append(
-                DecisionStep(
-                    handler=source,
-                    matched=True,
-                    reason_payload=Reason(code, params),
-                    position=final_pos,
-                )
-            )
+        trace.extend(clamp_steps)
         # Replace the deferral steps of the position-bound sources — those
         # steps came from the deferral path and carry an unhelpful describe_skip
         # reason. Only position sources are swept here so a tilt-only / tilt-
@@ -676,7 +802,7 @@ class PipelineRegistry:
                 winner_pos=effective_winner_pos,
                 final_pos=final_pos,
                 floor_wins=floor_wins,
-                binding=position_binding,
+                bindings=position_bindings,
             )
         )
         # A yielded bound must NOT fall through to the inactive steps above:

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+from collections.abc import Mapping
 
 from ..const import AxisConstraintMode, ReasonCode
 from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
@@ -22,7 +23,12 @@ from .axis_constraints import (
 )
 from .handler import OverrideHandler
 from .tilt_axis import resolve_tilt_axis_from
-from .types import DecisionStep, PipelineResult, PipelineSnapshot
+from .types import (
+    DecisionStep,
+    HoldClampVerdict,
+    PipelineResult,
+    PipelineSnapshot,
+)
 
 
 def _normalize_reason(value: str | Reason) -> tuple[str, Reason | None]:
@@ -104,6 +110,95 @@ def _split_bounds_against_hold(
         if id(c) not in binding_ids and c.kind is not AxisConstraintMode.FIXED
     ]
     return binding, yielded
+
+
+def _judge_position_axis(
+    winner,
+    snapshot: PipelineSnapshot,
+    floor_pos: int | None,
+    ceiling_pos: int | None,
+) -> tuple[int, bool, bool, dict[str, HoldClampVerdict] | None]:
+    """Return ``(effective_winner_pos, raised, lowered, verdicts)``.
+
+    The single site that asks "where will the cover actually end up, and did a
+    composed bound move it?" — for both kinds of winner, so the two answers
+    cannot drift apart.
+
+    **A computed winner** proposes ``winner.position``, already in the logical
+    frame, and is clamped unconditionally (#463). One position, no verdicts:
+    unchanged from before #1174, and the only path a non-hold winner takes.
+
+    **A hold winner** keeps physical positions rather than proposing a computed
+    one, and on a multi-cover instance ``winner.held_position`` is the group's
+    *mean* — nobody's position. Judging the bounds against that mean dragged
+    compliant covers to a floor they already satisfied and hid a lone violator
+    behind its compliant siblings (#1174). So the release question is asked per
+    cover, while the answer stays one shared target: a released cover always
+    lands exactly on the bound edge.
+
+    **Judged set** (holds only). ``snapshot.cover_positions`` when it carries
+    entries — a cover with an unknown position falls back to the summary
+    ``winner.held_position``, which is today's judgment kept exactly for the
+    covers where per-entity data is missing. Otherwise a single pseudo-entry
+    ``{None: winner.held_position}``, reproducing the legacy singular
+    comparison byte-for-byte; ``verdicts`` is ``None`` on that path so every
+    pre-#1174 consumer stays on the singular ``skip_command`` route.
+
+    **Frames.** Held positions are RAW cover-frame reads and the bounds are
+    logical user values, so each is converted before comparing — the #1036
+    conversion, now applied per cover instead of once to the mean.
+
+    **Mixed violations.** ``clamp_to_bounds`` applies the floor last, so a
+    floor above a ceiling still determines the target: a cover above the
+    ceiling is then released to the floor value. Today every cover receives
+    that same value regardless, so this is parity or better.
+
+    For a hold, ``effective_winner_pos`` names the *violating* cover — the
+    lowest judged position when a floor raised, the highest when a ceiling
+    lowered — so the clamp step's ``from_pos`` reads as a real cover's position
+    rather than a mean nobody sits at. Same ReasonCodes, same trace shape.
+    """
+    if winner.held_position is None:
+        final = clamp_to_bounds(winner.position, floor_pos, ceiling_pos)
+        return (
+            winner.position,
+            final > winner.position,
+            final < winner.position,
+            None,
+        )
+    per_entity = snapshot.cover_positions or None
+    judged: Mapping[str | None, int | None] = (
+        per_entity if per_entity is not None else {None: winner.held_position}
+    )
+    verdicts: dict[str, HoldClampVerdict] = {}
+    effective_positions: list[int] = []
+    raised = False
+    lowered = False
+    for entity_id, position in judged.items():
+        raw = position if position is not None else winner.held_position
+        eff = flip_if(raw, inverted=snapshot.position_axis_inverted)
+        fin = clamp_to_bounds(eff, floor_pos, ceiling_pos)
+        effective_positions.append(eff)
+        raised = raised or fin > eff
+        lowered = lowered or fin < eff
+        if entity_id is not None:
+            verdicts[entity_id] = HoldClampVerdict(
+                held_position=raw, released=fin != eff
+            )
+    if raised:
+        effective_winner_pos = min(effective_positions)
+    elif lowered:
+        effective_winner_pos = max(effective_positions)
+    else:
+        effective_winner_pos = flip_if(
+            winner.held_position, inverted=snapshot.position_axis_inverted
+        )
+    return (
+        effective_winner_pos,
+        raised,
+        lowered,
+        verdicts if per_entity is not None else None,
+    )
 
 
 def _release_hold_for_tilt_clamp(
@@ -445,22 +540,17 @@ class PipelineRegistry:
         # ``group_lock`` sets it too; every other handler leaves it None, so
         # this preserves the existing behaviour exactly for computed winners.
         #
-        # ``held_position`` is a RAW cover-frame read, deliberately so — the
-        # coordinator publishes it as a cover-frame diagnostic extra, "one
-        # frame for every hold type" (#1028). The bounds it is compared against
-        # are logical (pre-inversion canonical) user values, so convert HERE,
-        # at the one site that does the comparing, rather than re-framing the
-        # field itself. Without this the registry asks "is 25%-open above
-        # 75%-open?" on an inverse install and answers wrong in both
-        # directions: a compliant cover held at logical 80 gets *lowered* to a
-        # logical-25 floor (#1036). A no-op on non-inverse installs.
-        effective_winner_pos = (
-            flip_if(winner.held_position, inverted=snapshot.position_axis_inverted)
-            if winner.held_position is not None
-            else winner.position
-        )
-        final_pos = clamp_to_bounds(effective_winner_pos, floor_pos, ceiling_pos)
-        # A floor "raises" when it lifts the cover above where it would actually
+        # ONE evaluation per cycle still produces ONE shared result with ONE
+        # target value. What ``_judge_position_axis`` makes per-cover is only
+        # the *release verdict* — whether each held cover violates the surviving
+        # bounds and so receives that target (#1174) — because
+        # ``held_position`` is the instance MEAN and judging it clamped
+        # compliant covers while hiding lone violators. It also owns the #1036
+        # cover→logical frame conversion, now applied per cover rather than
+        # once to the mean. A computed winner keeps its own position and no
+        # verdicts, exactly as before.
+        #
+        # A floor "raises" when it lifts a cover above where it would actually
         # end up.  Key on the *effective* position — NOT on
         # ``clamped_position != winner.position`` — so the raise still fires on
         # the alignment edge where the floor equals the would-be ``position`` but
@@ -468,8 +558,13 @@ class PipelineRegistry:
         # held below it must still be lifted; issue #809).  Because
         # ``clamp_to_bounds`` applies the floor last, a floor above a ceiling
         # still reads as a raise — the deliberate conflict rule.
-        raised = final_pos > effective_winner_pos
-        lowered = final_pos < effective_winner_pos
+        (
+            effective_winner_pos,
+            raised,
+            lowered,
+            hold_clamp_verdicts,
+        ) = _judge_position_axis(winner, snapshot, floor_pos, ceiling_pos)
+        final_pos = clamp_to_bounds(effective_winner_pos, floor_pos, ceiling_pos)
         position_clamped = raised or lowered
         # In a floor/ceiling conflict ``clamp_to_bounds`` applies the floor last,
         # so the floor always determines the final value (== floor_pos) no matter
@@ -790,6 +885,10 @@ class PipelineRegistry:
         result = dataclasses.replace(
             winner,
             decision_trace=trace,
+            # Per-cover release verdicts for a hold (#1174); None for a computed
+            # winner and for a snapshot without per-entity positions, which is
+            # what keeps every pre-#1174 consumer on the singular path.
+            hold_clamp_verdicts=hold_clamp_verdicts,
             default_position=snapshot.default_position,
             is_sunset_active=snapshot.is_sunset_active,
             tilt_only_contribution_active=tilt_only_active,

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -28,6 +28,7 @@ from .types import (
     HoldClampVerdict,
     PipelineResult,
     PipelineSnapshot,
+    PositionAxisJudgment,
 )
 
 
@@ -117,8 +118,8 @@ def _judge_position_axis(
     snapshot: PipelineSnapshot,
     floor_pos: int | None,
     ceiling_pos: int | None,
-) -> tuple[int, bool, bool, dict[str, HoldClampVerdict] | None]:
-    """Return ``(effective_winner_pos, raised, lowered, verdicts)``.
+) -> PositionAxisJudgment:
+    """Resolve what the composed position bounds do to this cycle's winner.
 
     The single site that asks "where will the cover actually end up, and did a
     composed bound move it?" — for both kinds of winner, so the two answers
@@ -132,9 +133,12 @@ def _judge_position_axis(
     one, and on a multi-cover instance ``winner.held_position`` is the group's
     *mean* — nobody's position. Judging the bounds against that mean dragged
     compliant covers to a floor they already satisfied and hid a lone violator
-    behind its compliant siblings (#1174). So the release question is asked per
-    cover, while the answer stays one shared target: a released cover always
-    lands exactly on the bound edge.
+    behind its compliant siblings (#1174). So each cover is judged on its own
+    position and carries its own resolved target, because one shared number
+    cannot serve them all: a floor and a ceiling that both outrank the holder
+    bind different covers in opposite directions, and ``clamp_to_bounds``
+    applies the floor last, so the shared ``final_pos`` can only ever name one
+    of the two edges.
 
     **Judged set** (holds only). ``snapshot.cover_positions`` when it carries
     entries — a cover with an unknown position falls back to the summary
@@ -146,12 +150,10 @@ def _judge_position_axis(
 
     **Frames.** Held positions are RAW cover-frame reads and the bounds are
     logical user values, so each is converted before comparing — the #1036
-    conversion, now applied per cover instead of once to the mean.
-
-    **Mixed violations.** ``clamp_to_bounds`` applies the floor last, so a
-    floor above a ceiling still determines the target: a cover above the
-    ceiling is then released to the floor value. Today every cover receives
-    that same value regardless, so this is parity or better.
+    conversion, now applied per cover instead of once to the mean. Every
+    ``target`` is on the logical side of that conversion, matching
+    ``PipelineResult.position``, so the coordinator maps it to the wire through
+    the same ``_to_cover_frame`` seam it already uses for the shared value.
 
     For a hold, ``effective_winner_pos`` names the *violating* cover — the
     lowest judged position when a floor raised, the highest when a ceiling
@@ -160,11 +162,12 @@ def _judge_position_axis(
     """
     if winner.held_position is None:
         final = clamp_to_bounds(winner.position, floor_pos, ceiling_pos)
-        return (
-            winner.position,
-            final > winner.position,
-            final < winner.position,
-            None,
+        return PositionAxisJudgment(
+            effective_winner_pos=winner.position,
+            final_pos=final,
+            raised=final > winner.position,
+            lowered=final < winner.position,
+            verdicts=None,
         )
     per_entity = snapshot.cover_positions or None
     judged: Mapping[str | None, int | None] = (
@@ -177,13 +180,17 @@ def _judge_position_axis(
     for entity_id, position in judged.items():
         raw = position if position is not None else winner.held_position
         eff = flip_if(raw, inverted=snapshot.position_axis_inverted)
+        # This cover's own answer, and the only one that can be right for it:
+        # the edge that binds IT when a bound does, and where it already sits
+        # when none does — which is what a command forced by the other axis
+        # has to carry so the hold survives it.
         fin = clamp_to_bounds(eff, floor_pos, ceiling_pos)
         effective_positions.append(eff)
         raised = raised or fin > eff
         lowered = lowered or fin < eff
         if entity_id is not None:
             verdicts[entity_id] = HoldClampVerdict(
-                held_position=raw, released=fin != eff
+                held_position=raw, released=fin != eff, target=fin
             )
     if raised:
         effective_winner_pos = min(effective_positions)
@@ -193,12 +200,40 @@ def _judge_position_axis(
         effective_winner_pos = flip_if(
             winner.held_position, inverted=snapshot.position_axis_inverted
         )
-    return (
-        effective_winner_pos,
-        raised,
-        lowered,
-        verdicts if per_entity is not None else None,
+    return PositionAxisJudgment(
+        effective_winner_pos=effective_winner_pos,
+        final_pos=clamp_to_bounds(effective_winner_pos, floor_pos, ceiling_pos),
+        raised=raised,
+        lowered=lowered,
+        verdicts=verdicts if per_entity is not None else None,
     )
+
+
+def _command_every_held_cover(
+    verdicts: Mapping[str, HoldClampVerdict] | None,
+) -> Mapping[str, HoldClampVerdict] | None:
+    """Release every verdict, each to the target it already resolved (#1174).
+
+    A tilt clamp is a command, not a no-op (#1170 audit): it clears
+    ``skip_command`` for the whole group because the slats have to reach the
+    hardware, and a cover the position axis never released still has to receive
+    that command. What it must NOT receive is the position axis's clamp target
+    — a cover held above a floor is not a reason to close it 40 points, and
+    that is exactly what a shared value does here. Each verdict already carries
+    its own target: the bound edge for a cover a bound moved, and its own
+    position for one nothing moved, which the same-position gate turns into a
+    pure secondary-axis service call (#954).
+
+    ``None`` (a computed winner, or a snapshot with no per-entity positions)
+    passes straight through — those cycles are already on the singular path
+    ``_release_hold_for_tilt_clamp`` cleared.
+    """
+    if verdicts is None:
+        return None
+    return {
+        entity_id: dataclasses.replace(verdict, released=True)
+        for entity_id, verdict in verdicts.items()
+    }
 
 
 def _release_hold_for_tilt_clamp(
@@ -540,15 +575,16 @@ class PipelineRegistry:
         # ``group_lock`` sets it too; every other handler leaves it None, so
         # this preserves the existing behaviour exactly for computed winners.
         #
-        # ONE evaluation per cycle still produces ONE shared result with ONE
-        # target value. What ``_judge_position_axis`` makes per-cover is only
-        # the *release verdict* — whether each held cover violates the surviving
-        # bounds and so receives that target (#1174) — because
-        # ``held_position`` is the instance MEAN and judging it clamped
-        # compliant covers while hiding lone violators. It also owns the #1036
-        # cover→logical frame conversion, now applied per cover rather than
-        # once to the mean. A computed winner keeps its own position and no
-        # verdicts, exactly as before.
+        # ONE evaluation per cycle still produces ONE shared result, and every
+        # singular field below keeps the value it always had. What
+        # ``_judge_position_axis`` adds is a per-cover verdict for a hold
+        # (#1174) — whether each bound cover is moved at all, and to where —
+        # because ``held_position`` is the instance MEAN, and no single number
+        # can stand in for the group once a floor and a ceiling bind different
+        # covers in opposite directions. It also owns the #1036 cover→logical
+        # frame conversion, now applied per cover rather than once to the mean.
+        # A computed winner keeps its own position and no verdicts, exactly as
+        # before.
         #
         # A floor "raises" when it lifts a cover above where it would actually
         # end up.  Key on the *effective* position — NOT on
@@ -558,13 +594,12 @@ class PipelineRegistry:
         # held below it must still be lifted; issue #809).  Because
         # ``clamp_to_bounds`` applies the floor last, a floor above a ceiling
         # still reads as a raise — the deliberate conflict rule.
-        (
-            effective_winner_pos,
-            raised,
-            lowered,
-            hold_clamp_verdicts,
-        ) = _judge_position_axis(winner, snapshot, floor_pos, ceiling_pos)
-        final_pos = clamp_to_bounds(effective_winner_pos, floor_pos, ceiling_pos)
+        judgment = _judge_position_axis(winner, snapshot, floor_pos, ceiling_pos)
+        effective_winner_pos = judgment.effective_winner_pos
+        final_pos = judgment.final_pos
+        raised = judgment.raised
+        lowered = judgment.lowered
+        hold_clamp_verdicts = judgment.verdicts
         position_clamped = raised or lowered
         # In a floor/ceiling conflict ``clamp_to_bounds`` applies the floor last,
         # so the floor always determines the final value (== floor_pos) no matter
@@ -875,19 +910,11 @@ class PipelineRegistry:
                 position_clamped=position_clamped,
                 effective_winner_pos=effective_winner_pos,
             )
-            # ``hold_clamp_verdicts`` is the skip authority for the POSITION
-            # axis ONLY: it answers "did a composed position bound release this
-            # cover", nothing else. A tilt clamp is a command, not a no-op
-            # (#1170 audit) — an independent reason to command every held cover
-            # — so the position axis's per-cover verdicts must not veto it.
-            # Dropping them puts this cycle back on the singular
-            # ``skip_command`` the tilt release just cleared, which is what
-            # every cover needs and exactly the pre-#1174 route. Without this a
-            # tilt-only release found every verdict at ``released=False`` (the
-            # position axis was inert, so nothing was released) and re-skipped
-            # the whole group, leaving the trace claiming a carried hold
-            # position for a dispatch that never happened.
-            hold_clamp_verdicts = None
+            # The tilt clamp commands the whole group, so every verdict says so
+            # — each still to its OWN target, which is the only thing that
+            # keeps a cover the position axis never released where the user put
+            # it (#1174).
+            hold_clamp_verdicts = _command_every_held_cover(hold_clamp_verdicts)
         # The tilt-axis overlay (issue #514) is how a FIXED contribution
         # reaches the result's tilt field. It can never collide with the
         # bound-clamp write above (the ``else: merged["tilt"] = bounded_tilt``
@@ -898,10 +925,10 @@ class PipelineRegistry:
         result = dataclasses.replace(
             winner,
             decision_trace=trace,
-            # Per-cover release verdicts for a hold (#1174) — the POSITION
-            # axis's skip authority. None for a computed winner, for a snapshot
-            # without per-entity positions, and for a tilt-forced command, each
-            # of which keeps that cycle on the singular path.
+            # Per-cover dispatch verdicts for a hold (#1174) — which covers are
+            # commanded and where each one goes. None for a computed winner and
+            # for a snapshot without per-entity positions, both of which keep
+            # that cycle on the singular path.
             hold_clamp_verdicts=hold_clamp_verdicts,
             default_position=snapshot.default_position,
             is_sunset_active=snapshot.is_sunset_active,

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -724,6 +724,7 @@ class PipelineSnapshotBuilder:
         in_time_window: bool,
         current_cover_position: int | None,
         is_glare_zone_enabled: Callable[[int], bool],
+        cover_positions: Mapping[str, int | None] | None = None,
         cloud_suppression_active: bool = False,
         climate_temp_flags: ClimateTempFlags | None = None,
         effective_default: int | None = None,
@@ -756,6 +757,12 @@ class PipelineSnapshotBuilder:
         owns those switch attributes (``glare_zone_0``, ``glare_zone_1`` …);
         the builder reads them through this callable so it never reaches back
         into ``coordinator.self``.
+
+        ``cover_positions`` maps each bound entity_id to its current RAW
+        cover-frame position (``None`` when the entity reports none) — the
+        per-entity source ``current_cover_position`` is the mean of. The
+        registry judges each held cover's clamp verdict against its own entry
+        (issue #1174); omitting it leaves the pre-#1174 judgment on the scalar.
 
         ``cover_capabilities`` maps each bound entity_id to its
         ``CoverCapabilities``.  It drives the sun-tracking floor rollup
@@ -836,6 +843,7 @@ class PipelineSnapshotBuilder:
                 CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE
             ),
             current_cover_position=current_cover_position,
+            cover_positions=cover_positions,
             position_axis_inverted=axis_inverted(self._policy.axes[0], options),
             policy=self._policy,
             group_intent=group_intent,

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -427,8 +427,10 @@ class PipelineSnapshot:
     # Per-entity RAW cover-frame positions — the same frame and the same source
     # as ``current_cover_position``, which is the summary mean of these. The
     # registry judges a hold's per-cover clamp verdicts against this dict
-    # (#1174). ``None`` in legacy / test snapshots that predate the field: the
-    # registry then judges holds on the summary scalar exactly as before.
+    # (#1174) — but only for a cover type whose entities move independently; a
+    # coupled type's covers are judged as one, off the summary scalar. ``None``
+    # in legacy / test snapshots that predate the field: the registry then
+    # judges holds on the summary scalar exactly as before.
     cover_positions: Mapping[str, int | None] | None = None
 
     # Whether the position axis is effectively inverted for this install
@@ -554,6 +556,12 @@ class HoldClampVerdict:
       in *opposite* directions, so the released covers do not share one target;
     * a TILT clamp commands every held cover while the position axis released
       nobody, so "is a command going out" is not "did a bound move me".
+
+    Only built for a cover type whose entities move independently
+    (``CoverTypePolicy.entities_move_independently``). That is what makes
+    ``target`` safe to hand straight to ``coordinator._entity_target``: a policy
+    that would remap it per entity, or rewrite it after the pipeline, produces
+    no verdicts at all and keeps its shared-target path.
     """
 
     #: This cover's own position, a RAW cover-frame read (matching the frame
@@ -598,9 +606,19 @@ class PositionAxisJudgment:
     raised: bool
     #: A ceiling lowered at least one judged position.
     lowered: bool
-    #: Per-cover dispatch verdicts, or ``None`` for a computed winner and for a
-    #: snapshot carrying no per-entity positions — both of which keep the cycle
-    #: on the singular pre-#1174 path.
+    #: The LOWEST judged position when ``raised``, else ``None`` — the cover the
+    #: floor actually lifted, and the honest ``from_pos`` for a floor's clamp
+    #: step. Equals ``effective_winner_pos`` unless a ceiling bound a different
+    #: cover in the same cycle.
+    raise_from: int | None
+    #: The HIGHEST judged position when ``lowered``, else ``None`` — the mirror,
+    #: and the only starting point a ceiling's own clamp step can honestly name
+    #: once a floor has taken ``effective_winner_pos``.
+    lower_from: int | None
+    #: Per-cover dispatch verdicts, or ``None`` for a computed winner, for a
+    #: snapshot carrying no per-entity positions, and for a cover type whose
+    #: entities do not move independently — all of which keep the cycle on the
+    #: singular pre-#1174 path.
     verdicts: Mapping[str, HoldClampVerdict] | None
 
 
@@ -723,10 +741,15 @@ class PipelineResult:
 
     # Per-cover dispatch verdicts for a hold winner (#1174): the sole authority
     # on which bound covers are commanded this cycle and where each one is sent.
-    # Populated when ``held_position is not None`` AND the snapshot carried
-    # per-entity positions; ``None`` for every computed (non-hold) winner and
-    # for legacy snapshots without the dict, both of which keep the cycle on the
-    # singular ``skip_command`` / ``position`` path unchanged.
+    # Populated when ``held_position is not None``, the snapshot carried
+    # per-entity positions, AND this cover type's entities move independently
+    # (``CoverTypePolicy.entities_move_independently`` — a type that remaps its
+    # entities' targets, rewrites the position after the pipeline, or orders
+    # physically coupled rails expresses ONE geometry and has no per-cover
+    # question to answer). ``None`` otherwise — for every computed (non-hold)
+    # winner, for legacy snapshots without the dict, and for those coupled types
+    # — all of which keep the cycle on the singular ``skip_command`` /
+    # ``position`` path unchanged.
     #
     # A cover absent from the dict is likewise unjudged and falls back to that
     # singular path. ``position`` stays the shared summary the trace and the

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -537,14 +537,23 @@ class DecisionStep:
             object.__setattr__(self, "reason", render_en(self.reason_payload))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HoldClampVerdict:
-    """Whether ONE held cover is released to this cycle's clamp target (#1174).
+    """What happens to ONE held cover this cycle — moved, and where to (#1174).
 
     A hold winner keeps every bound cover where something authoritative already
-    put it. When a bound outranks the holder, the cover is released to the
-    bound's edge — but only the covers that actually violate the bound: judging
-    the group's mean dragged compliant covers along and hid lone violators.
+    put it. Whether that stops being true, and what replaces it, is a question
+    per cover and not per instance: ``PipelineResult.held_position`` is the
+    group's arithmetic MEAN, so judging it dragged compliant covers to a bound
+    they already satisfied and hid a lone violator behind its siblings.
+
+    The two fields answer the two halves of the dispatch question, and no single
+    instance-wide number can answer either:
+
+    * a floor and a ceiling that both outrank the holder bind *different* covers
+      in *opposite* directions, so the released covers do not share one target;
+    * a TILT clamp commands every held cover while the position axis released
+      nobody, so "is a command going out" is not "did a bound move me".
     """
 
     #: This cover's own position, a RAW cover-frame read (matching the frame
@@ -552,9 +561,47 @@ class HoldClampVerdict:
     #: diagnostic extras speak, #1028). Falls back to the summary
     #: ``PipelineResult.held_position`` when this cover reports no position.
     held_position: int | None
-    #: True when this cover's own position violates the surviving bounds, so it
-    #: receives the clamp target; False when it stays held where it is.
+    #: True when a command goes out to this cover this cycle: a composed
+    #: position bound moved it, or another axis forced a dispatch the whole
+    #: group has to carry. False means the hold stands and the coordinator
+    #: writes a hold-skip record instead.
     released: bool
+    #: Where that command sends this cover, as a LOGICAL (pre-inversion,
+    #: pre-interpolation) position — the same frame ``PipelineResult.position``
+    #: speaks, so the coordinator maps it through the one ``_to_cover_frame``
+    #: seam. Equals the bound edge that bound THIS cover when a position bound
+    #: moved it, and this cover's own position when none did — which is what
+    #: makes a tilt-forced command a positional no-op. Always resolved, and
+    #: read only while ``released``.
+    target: int
+
+
+@dataclass(frozen=True, slots=True)
+class PositionAxisJudgment:
+    """What the composed position bounds did to this cycle's winner (#1174).
+
+    One return value for :func:`pipeline.registry._judge_position_axis`, which
+    answers "where does the winner actually end up, did a bound move it, and —
+    for a hold — what happens to each cover individually" in a single pass so
+    those answers cannot drift apart.
+    """
+
+    #: The position the bounds were judged against, LOGICAL frame. A computed
+    #: winner's own ``position``; for a hold, the *violating* cover's position
+    #: (lowest when a floor raised, highest when a ceiling lowered) so the
+    #: clamp trace step reads as a real cover rather than a mean nobody sits at.
+    effective_winner_pos: int
+    #: ``effective_winner_pos`` after the composed bounds, i.e. the shared
+    #: clamp target the trace and ``PipelineResult.position`` carry.
+    final_pos: int
+    #: A floor lifted at least one judged position.
+    raised: bool
+    #: A ceiling lowered at least one judged position.
+    lowered: bool
+    #: Per-cover dispatch verdicts, or ``None`` for a computed winner and for a
+    #: snapshot carrying no per-entity positions — both of which keep the cycle
+    #: on the singular pre-#1174 path.
+    verdicts: Mapping[str, HoldClampVerdict] | None
 
 
 @dataclass(frozen=True)
@@ -674,14 +721,18 @@ class PipelineResult:
     # presence marker the #1170 priority gate keys on.
     held_position: int | None = None
 
-    # Per-cover release verdicts for a hold winner (#1174), and the skip
-    # authority for the POSITION axis ONLY. Populated when
-    # ``held_position is not None`` AND the snapshot carried per-entity
-    # positions; ``None`` for every computed (non-hold) winner, for legacy
-    # snapshots without the dict, and whenever a TILT clamp forced the command
-    # instead — a tilt bound is its own reason to command every held cover, so
-    # position verdicts must not veto it. Each ``None`` case keeps the cycle on
-    # the singular ``skip_command`` / ``held_position`` path unchanged.
+    # Per-cover dispatch verdicts for a hold winner (#1174): the sole authority
+    # on which bound covers are commanded this cycle and where each one is sent.
+    # Populated when ``held_position is not None`` AND the snapshot carried
+    # per-entity positions; ``None`` for every computed (non-hold) winner and
+    # for legacy snapshots without the dict, both of which keep the cycle on the
+    # singular ``skip_command`` / ``position`` path unchanged.
+    #
+    # A cover absent from the dict is likewise unjudged and falls back to that
+    # singular path. ``position`` stays the shared summary the trace and the
+    # singular surfaces carry; where a released cover actually goes is
+    # ``HoldClampVerdict.target``, which diverges from it whenever a floor and a
+    # ceiling bind different covers.
     hold_clamp_verdicts: Mapping[str, HoldClampVerdict] | None = None
 
     # Custom position slot diagnostics — populated only when CustomPositionHandler wins.

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -414,10 +415,21 @@ class PipelineSnapshot:
     #     the sun is active; falls through to default when sun leaves FOV or window closes.
     motion_timeout_mode: str = "return_to_default"
 
-    # Mean of current entity positions (int-rounded). None when no entity reports a
-    # numeric position. Read by MotionTimeoutHandler in hold_position mode only.
+    # Summary of the current entity positions: their int-rounded mean. None when
+    # no entity reports a numeric position. Read by MotionTimeoutHandler in
+    # hold_position mode, and copied into ``PipelineResult.held_position`` by the
+    # manual-override / group-lock holds as a presentation value. It is a
+    # *summary*: no per-cover decision consumes it — the registry judges each
+    # held cover against its own entry in ``cover_positions`` below (#1174).
     # This is a RAW cover-frame read — see position_axis_inverted below.
     current_cover_position: int | None = None
+
+    # Per-entity RAW cover-frame positions — the same frame and the same source
+    # as ``current_cover_position``, which is the summary mean of these. The
+    # registry judges a hold's per-cover clamp verdicts against this dict
+    # (#1174). ``None`` in legacy / test snapshots that predate the field: the
+    # registry then judges holds on the summary scalar exactly as before.
+    cover_positions: Mapping[str, int | None] | None = None
 
     # Whether the position axis is effectively inverted for this install
     # (inverse-state configured and not suppressed by interpolation, per
@@ -523,6 +535,26 @@ class DecisionStep:
         """Derive the English ``reason`` from ``reason_payload`` when unset."""
         if self.reason_payload is not None and not self.reason:
             object.__setattr__(self, "reason", render_en(self.reason_payload))
+
+
+@dataclass(frozen=True)
+class HoldClampVerdict:
+    """Whether ONE held cover is released to this cycle's clamp target (#1174).
+
+    A hold winner keeps every bound cover where something authoritative already
+    put it. When a bound outranks the holder, the cover is released to the
+    bound's edge — but only the covers that actually violate the bound: judging
+    the group's mean dragged compliant covers along and hid lone violators.
+    """
+
+    #: This cover's own position, a RAW cover-frame read (matching the frame
+    #: ``PipelineSnapshot.cover_positions`` and the coordinator's held-position
+    #: diagnostic extras speak, #1028). Falls back to the summary
+    #: ``PipelineResult.held_position`` when this cover reports no position.
+    held_position: int | None
+    #: True when this cover's own position violates the surviving bounds, so it
+    #: receives the clamp target; False when it stays held where it is.
+    released: bool
 
 
 @dataclass(frozen=True)
@@ -633,7 +665,21 @@ class PipelineResult:
     # None when override is inactive, when current position is unknown, or for
     # all other handlers.  Consumers must use explicit `is not None` checks
     # because 0% (fully closed) is a valid held position.
+    #
+    # On a multi-cover instance this is a SUMMARY — the mean of the covers that
+    # reported a position — because the "Target Position" sensor is one entity
+    # per config entry and a scalar has to stand for the group. No decision
+    # consumes it: the per-cover truth is ``hold_clamp_verdicts`` below (and the
+    # sensor's own ``actual_positions`` attribute). It also remains the
+    # presence marker the #1170 priority gate keys on.
     held_position: int | None = None
+
+    # Per-cover release verdicts for a hold winner (#1174). Populated only when
+    # ``held_position is not None`` AND the snapshot carried per-entity
+    # positions; ``None`` for every computed (non-hold) winner and for legacy
+    # snapshots without the dict, which keeps every pre-#1174 caller on the
+    # singular ``skip_command`` / ``held_position`` path unchanged.
+    hold_clamp_verdicts: Mapping[str, HoldClampVerdict] | None = None
 
     # Custom position slot diagnostics — populated only when CustomPositionHandler wins.
     # custom_position_active_slot: 1-based slot number of the winning custom position handler; None otherwise.

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -674,11 +674,14 @@ class PipelineResult:
     # presence marker the #1170 priority gate keys on.
     held_position: int | None = None
 
-    # Per-cover release verdicts for a hold winner (#1174). Populated only when
+    # Per-cover release verdicts for a hold winner (#1174), and the skip
+    # authority for the POSITION axis ONLY. Populated when
     # ``held_position is not None`` AND the snapshot carried per-entity
-    # positions; ``None`` for every computed (non-hold) winner and for legacy
-    # snapshots without the dict, which keeps every pre-#1174 caller on the
-    # singular ``skip_command`` / ``held_position`` path unchanged.
+    # positions; ``None`` for every computed (non-hold) winner, for legacy
+    # snapshots without the dict, and whenever a TILT clamp forced the command
+    # instead — a tilt bound is its own reason to command every held cover, so
+    # position verdicts must not veto it. Each ``None`` case keeps the cycle on
+    # the singular ``skip_command`` / ``held_position`` path unchanged.
     hold_clamp_verdicts: Mapping[str, HoldClampVerdict] | None = None
 
     # Custom position slot diagnostics — populated only when CustomPositionHandler wins.

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -453,3 +453,75 @@ def test_stub_policy_passes_capability_warning_with_stub_registered() -> None:
     with register_stub_policy(StubSingleAxisPolicy):
         policy = get_policy("cover_stub")
         assert policy.cover_capability_warnings(known={}) == []
+
+
+# ---- Per-entity hold dispatch is gated on entity independence (#1174) ----- #
+#
+# A hold's floor/ceiling verdict is decided per cover only where each bound
+# entity's position is genuinely its own. Three hooks say otherwise — a
+# per-entity remap, a post-pipeline position rewrite, and a mandated dispatch
+# order for physically coupled entities — and the base predicate derives its
+# answer from all three so that a NEW cover type is excluded automatically
+# rather than by someone remembering to say so.
+
+
+@pytest.mark.unit
+def test_entities_move_independently_is_true_for_an_untouched_policy(
+    policy: CoverTypePolicy,
+) -> None:
+    """Leave the three dispatch hooks alone and the per-cover path stays on."""
+    cls = type(policy)
+    untouched = (
+        cls.resolve_entity_target is CoverTypePolicy.resolve_entity_target
+        and cls.post_pipeline_resolve is CoverTypePolicy.post_pipeline_resolve
+        and cls.dispatch_order_key is CoverTypePolicy.dispatch_order_key
+    )
+    if untouched:
+        assert policy.entities_move_independently() is True
+
+
+@pytest.mark.unit
+def test_a_policy_that_overrides_a_dispatch_hook_opts_out_or_says_why() -> None:
+    """Overriding any of the three hooks turns per-cover judging off by default.
+
+    A policy may override the predicate back to ``True``, but then it owes the
+    argument in its own docstring — so this test demands one rather than
+    letting an opt-in be silent. ``VenetianPolicy`` is the shipped example: its
+    ``post_pipeline_resolve`` never rewrites the position under a hold.
+    """
+    from custom_components.adaptive_cover_pro.cover_types import POLICY_REGISTRY
+
+    for cover_type, policy_cls in POLICY_REGISTRY.items():
+        overrides = (
+            policy_cls.resolve_entity_target
+            is not CoverTypePolicy.resolve_entity_target
+            or policy_cls.post_pipeline_resolve
+            is not CoverTypePolicy.post_pipeline_resolve
+            or policy_cls.dispatch_order_key is not CoverTypePolicy.dispatch_order_key
+        )
+        if not overrides:
+            continue
+        if policy_cls().entities_move_independently():
+            own = policy_cls.entities_move_independently
+            assert own is not CoverTypePolicy.entities_move_independently, (
+                f"{cover_type} overrides a per-entity dispatch hook but still "
+                "reports independent entities via the derived default"
+            )
+            assert own.__doc__, (
+                f"{cover_type} opts back into per-cover hold dispatch — its "
+                "override must document why that is safe"
+            )
+
+
+@pytest.mark.unit
+def test_the_coupled_cover_types_are_judged_as_one_unit() -> None:
+    """The shipped answers, pinned: day/night and dual panel are coupled.
+
+    Both derive one entity's target from another's (or fold a second axis into
+    the position wire), so a floor that moves one of their entities moves the
+    whole geometry. Naming them explicitly keeps the derived predicate honest —
+    a refactor that made either look "untouched" would flip this.
+    """
+    assert get_policy("cover_day_night_shade").entities_move_independently() is False
+    assert get_policy("cover_dual_panel").entities_move_independently() is False
+    assert get_policy("cover_blind").entities_move_independently() is True

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -809,3 +809,48 @@ class TestEngineTiltBounds:
         _, low = self._resolve(monkeypatch, 10, tilt_low=40, tilt_high=80)
         _, high = self._resolve(monkeypatch, 95, tilt_low=40, tilt_high=80)
         assert (low.tilt, high.tilt) == (40, 80)
+
+
+class TestPerCoverHoldDispatchPremise:
+    """The proof behind ``VenetianPolicy.entities_move_independently`` (#1174).
+
+    Venetian is the one shipped policy that overrides a per-entity dispatch
+    hook and still opts INTO per-cover hold judging. It is allowed to because
+    its ``post_pipeline_resolve`` never touches ``PipelineResult.position``
+    under a hold — the only winner kind that is ever judged per cover. If that
+    ever stops being true, the per-cover targets would silently bypass a
+    position rewrite, which is the day/night Model B failure this gate exists
+    to prevent. So the premise is pinned here rather than left to a docstring.
+    """
+
+    #: Winners that carry ``held_position`` and therefore produce verdicts —
+    #: ``ManualOverrideHandler`` and ``GroupLockHandler`` are the only two
+    #: handlers that set it.
+    HOLD_METHODS = (ControlMethod.MANUAL, ControlMethod.GROUP_LOCK)
+
+    @pytest.mark.parametrize("method", HOLD_METHODS)
+    def test_tilt_only_pin_never_fires_under_a_hold(self, method):
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        out = policy.post_pipeline_resolve(
+            _make_result(method, position=80), **_non_solar_kwargs()
+        )
+        assert out.position == 80
+
+    @pytest.mark.parametrize("method", HOLD_METHODS)
+    def test_a_hold_with_a_handler_tilt_keeps_its_position(self, method):
+        """The handler-tilt branch is the one a clamped tilt bound arrives on."""
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+        from dataclasses import replace
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        held = replace(_make_result(method, position=35), tilt=60)
+        out = policy.post_pipeline_resolve(held, **_non_solar_kwargs())
+        assert out.position == 35
+        assert out.tilt == 60
+
+    def test_venetian_opts_into_per_cover_hold_dispatch(self):
+        assert _make_policy().entities_move_independently() is True

--- a/tests/test_manual_override_hold_skip.py
+++ b/tests/test_manual_override_hold_skip.py
@@ -20,14 +20,18 @@ from custom_components.adaptive_cover_pro.managers.cover_command import (
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     ManualOverrideHandler,
 )
-from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    HoldClampVerdict,
+    PipelineResult,
+)
 from custom_components.adaptive_cover_pro.state.cover_provider import CoverProvider
 
 from tests.test_pipeline.conftest import make_snapshot
 
 
-def _make_coordinator_with_manual_hold(*, position: int = 100, held: int = 0):
-    """Build a minimal coordinator whose _pipeline_result is a MANUAL hold."""
+def _coordinator_with(result: PipelineResult):
+    """Build a minimal coordinator around a ready-made pipeline result."""
+    from custom_components.adaptive_cover_pro.const import CONF_INVERSE_STATE
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
@@ -35,15 +39,14 @@ def _make_coordinator_with_manual_hold(*, position: int = 100, held: int = 0):
     coord = object.__new__(AdaptiveDataUpdateCoordinator)
     coord.logger = MagicMock()
     coord._inverse_state = False
-
-    coord._pipeline_result = PipelineResult(
-        position=position,
-        control_method=ControlMethod.MANUAL,
-        reason=f"manual override active — holding {held}% "
-        f"(default position would be {position}%)",
-        skip_command=True,
-        held_position=held,
-    )
+    # The real coordinator always has a config entry and a policy;
+    # ``position_axis_inverted`` derives from the options and the dispatch seam
+    # delegates to the policy, so give the fixture the same inputs rather than
+    # stubbing either out. A blind policy's per-entity target is identity.
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_INVERSE_STATE: False}
+    coord._policy = get_policy("cover_blind")
+    coord._pipeline_result = result
 
     cmd_svc = MagicMock()
     cmd_svc.apply_position = AsyncMock(return_value=("sent", None))
@@ -51,6 +54,20 @@ def _make_coordinator_with_manual_hold(*, position: int = 100, held: int = 0):
     coord._cmd_svc = cmd_svc
 
     return coord
+
+
+def _make_coordinator_with_manual_hold(*, position: int = 100, held: int = 0):
+    """Build a minimal coordinator whose _pipeline_result is a MANUAL hold."""
+    return _coordinator_with(
+        PipelineResult(
+            position=position,
+            control_method=ControlMethod.MANUAL,
+            reason=f"manual override active — holding {held}% "
+            f"(default position would be {position}%)",
+            skip_command=True,
+            held_position=held,
+        )
+    )
 
 
 @pytest.mark.unit
@@ -81,6 +98,128 @@ async def test_dispatch_manual_override_hold_does_not_mislabel_as_motion():
 
     args, _ = coord._cmd_svc.record_skipped_action.call_args
     assert args[1] != "motion_hold"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1174: the hold's release verdict is per cover, not the instance mean
+# ---------------------------------------------------------------------------
+#
+# ``held_position`` is the mean of every bound cover's position, so a group at
+# 40/40/0 reports 27. Dispatching off the singular ``skip_command`` sent that
+# one verdict to all three: either every cover moved or none did, and every
+# skip record claimed the cover was held at 27 % — a number nobody sits at.
+
+_MEAN_HELD = 27
+_A_HELD = 40
+_C_HELD = 0
+
+
+def _verdicts(*, a_released: bool, c_released: bool):
+    return {
+        "cover.a": HoldClampVerdict(_A_HELD, released=a_released),
+        "cover.c": HoldClampVerdict(_C_HELD, released=c_released),
+    }
+
+
+def _extras_for(coord, cover: str) -> dict:
+    """Return the extras of the skip record written for ``cover``."""
+    call = next(
+        c
+        for c in coord._cmd_svc.record_skipped_action.call_args_list
+        if c.args[0] == cover
+    )
+    return call.kwargs["extras"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_verdicts_route_dispatch_per_cover():
+    """A clamp that released only ``cover.c`` must not also move ``cover.a``.
+
+    The floor outranked the hold, so ``skip_command`` is cleared and the target
+    is dispatched — but only to the cover whose own position violated the
+    bound. ``cover.a`` was already sitting on 40 and stays held.
+    """
+    coord = _coordinator_with(
+        PipelineResult(
+            position=40,
+            control_method=ControlMethod.MANUAL,
+            skip_command=False,
+            position_constraint_applied=True,
+            held_position=_MEAN_HELD,
+            hold_clamp_verdicts=_verdicts(a_released=False, c_released=True),
+        )
+    )
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.a", 40, "custom_position_1", ctx)
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    args, _ = coord._cmd_svc.record_skipped_action.call_args
+    assert args[0] == "cover.a"
+    assert args[1] == "manual_override_hold"
+    assert _extras_for(coord, "cover.a")["held_position"] == _A_HELD
+
+    await coord._dispatch_to_cover("cover.c", 40, "custom_position_1", ctx)
+
+    coord._cmd_svc.apply_position.assert_called_once_with(
+        "cover.c", 40, "custom_position_1", context=ctx
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unclamped_hold_records_each_covers_own_position():
+    """Nothing clamped, so every cover is held — each at its OWN position."""
+    coord = _coordinator_with(
+        PipelineResult(
+            position=100,
+            control_method=ControlMethod.MANUAL,
+            skip_command=True,
+            held_position=_MEAN_HELD,
+            hold_clamp_verdicts=_verdicts(a_released=False, c_released=False),
+        )
+    )
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.a", 100, "manual_override", ctx)
+    await coord._dispatch_to_cover("cover.c", 100, "manual_override", ctx)
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    assert _extras_for(coord, "cover.a")["held_position"] == _A_HELD
+    assert _extras_for(coord, "cover.c")["held_position"] == _C_HELD
+    assert all(
+        c.kwargs["extras"]["held_position"] != _MEAN_HELD
+        for c in coord._cmd_svc.record_skipped_action.call_args_list
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_verdict_falls_back_to_singular_skip():
+    """No verdicts (a motion hold) → the singular ``skip_command`` path, verbatim.
+
+    ``MotionTimeoutHandler`` publishes its hold through ``position`` and leaves
+    ``held_position`` unset, so the record still falls back to the logical-frame
+    flip of the result position.
+    """
+    coord = _coordinator_with(
+        PipelineResult(
+            position=42,
+            control_method=ControlMethod.MOTION,
+            skip_command=True,
+            held_position=None,
+            hold_clamp_verdicts=None,
+        )
+    )
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.bedroom", 42, "solar", ctx)
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    args, kwargs = coord._cmd_svc.record_skipped_action.call_args
+    assert args[1] == "motion_hold"
+    assert kwargs["extras"]["held_position"] == 42
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_manual_override_hold_skip.py
+++ b/tests/test_manual_override_hold_skip.py
@@ -39,6 +39,7 @@ def _coordinator_with(result: PipelineResult):
     coord = object.__new__(AdaptiveDataUpdateCoordinator)
     coord.logger = MagicMock()
     coord._inverse_state = False
+    coord._use_interpolation = False
     # The real coordinator always has a config entry and a policy;
     # ``position_axis_inverted`` derives from the options and the dispatch seam
     # delegates to the policy, so give the fixture the same inputs rather than
@@ -112,12 +113,28 @@ async def test_dispatch_manual_override_hold_does_not_mislabel_as_motion():
 _MEAN_HELD = 27
 _A_HELD = 40
 _C_HELD = 0
+#: The bound edge a released cover is sent to in these fixtures.
+_CLAMP_TARGET = 40
 
 
 def _verdicts(*, a_released: bool, c_released: bool):
+    """Verdicts shaped the way the registry builds them (#1174).
+
+    A released cover carries the bound edge it was released to; a held one
+    carries its own position, which is dispatched only if another axis forces
+    the command.
+    """
     return {
-        "cover.a": HoldClampVerdict(_A_HELD, released=a_released),
-        "cover.c": HoldClampVerdict(_C_HELD, released=c_released),
+        "cover.a": HoldClampVerdict(
+            _A_HELD,
+            released=a_released,
+            target=_CLAMP_TARGET if a_released else _A_HELD,
+        ),
+        "cover.c": HoldClampVerdict(
+            _C_HELD,
+            released=c_released,
+            target=_CLAMP_TARGET if c_released else _C_HELD,
+        ),
     }
 
 

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from unittest.mock import MagicMock
 
 from custom_components.adaptive_cover_pro.pipeline.types import (
@@ -88,6 +89,7 @@ def make_snapshot(
     sun_tracking_gate_closed: bool = False,
     motion_timeout_mode: str = "return_to_default",
     current_cover_position: int | None = None,
+    cover_positions: Mapping[str, int | None] | None = None,
     position_axis_inverted: bool = False,
     default_tilt: int | None = None,
     sunset_tilt: int | None = None,
@@ -161,6 +163,7 @@ def make_snapshot(
         sun_tracking_gate_closed=sun_tracking_gate_closed,
         motion_timeout_mode=motion_timeout_mode,
         current_cover_position=current_cover_position,
+        cover_positions=cover_positions,
         position_axis_inverted=position_axis_inverted,
         default_tilt=default_tilt,
         sunset_tilt=sunset_tilt,

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -374,15 +374,21 @@ _TILT_FLOOR = 60
 _ABOVE_FLOOR_POSITIONS = {"cover.a": 80, "cover.b": 80, "cover.c": 0}
 
 
-def _dispatch_coordinator(result):
-    """Minimal coordinator around a ready-made result, for ``_dispatch_to_cover``."""
+def _dispatch_coordinator(result, policy=None):
+    """Minimal coordinator around a ready-made result, for ``_dispatch_to_cover``.
+
+    ``policy`` defaults to a venetian one — the cover type these tilt-clamp
+    tests are about. A coupled cover type's test passes the SAME policy
+    instance whose ``post_pipeline_resolve`` already ran, because that hook is
+    where the per-entity dispatch cache is filled.
+    """
     coord = object.__new__(AdaptiveDataUpdateCoordinator)
     coord.logger = MagicMock()
     coord._inverse_state = False
     coord._use_interpolation = False
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_INVERSE_STATE: False}
-    coord._policy = get_policy("cover_venetian")
+    coord._policy = policy if policy is not None else get_policy("cover_venetian")
     coord._pipeline_result = result
     cmd_svc = MagicMock()
     cmd_svc.apply_position = AsyncMock(return_value=("sent", None))
@@ -391,7 +397,9 @@ def _dispatch_coordinator(result):
     return coord
 
 
-async def _dispatch_targets(result, covers, reason) -> dict[str, int | None]:
+async def _dispatch_targets(
+    result, covers, reason, policy=None
+) -> dict[str, int | None]:
     """Fan ``result`` out over ``covers`` and report what each one received.
 
     The value is the position actually commanded, or ``None`` when the seam
@@ -400,7 +408,7 @@ async def _dispatch_targets(result, covers, reason) -> dict[str, int | None]:
     computes (``coordinator.state``), so any divergence in the result comes
     from the per-cover verdict and nothing else.
     """
-    coord = _dispatch_coordinator(result)
+    coord = _dispatch_coordinator(result, policy=policy)
     state = coord._to_cover_frame(result.position)
     for cover in covers:
         await coord._dispatch_to_cover(cover, state, reason, None)
@@ -554,3 +562,304 @@ async def test_a_ceiling_bound_cover_is_lowered_to_the_ceiling_not_the_floor() -
     targets = await _dispatch_targets(result, covers, "custom_position_1")
 
     assert targets == {"cover.low": _FLOOR, "cover.high": 70}
+
+
+# ---------------------------------------------------------------------------
+# The trace has to name the bound that actually moved a cover
+# ---------------------------------------------------------------------------
+#
+# With a floor and a ceiling binding two different covers, only ONE of them can
+# be the shared ``final_pos``'s binding constraint — and the other fell through
+# to the "did nothing" sweep, which reported it as *inactive* while it was busy
+# moving a cover. The decision trace is a user-facing surface (it backs the
+# Lovelace card), so a bound that moved something must say so.
+
+
+def test_a_ceiling_that_moved_a_cover_is_not_traced_as_inactive() -> None:
+    """Floor 40 + ceiling 70, covers at 20 and 90 — both bounds bound.
+
+    ``cover.high`` is dispatched to 70 by the ceiling in slot 2, so a step
+    reading "ceiling 70% inactive" is affirmatively false, and crediting only
+    the floor's slot for the cycle names the wrong slot for that cover.
+    """
+    result = _floor_and_ceiling_vs_hold(
+        cover_positions={"cover.low": 20, "cover.high": 90},
+        current_cover_position=55,
+        floor=_FLOOR,
+        ceiling=70,
+    )
+
+    steps = {s.handler: s for s in result.decision_trace}
+    assert "ceiling_clamp" in steps
+    assert steps["ceiling_clamp"].matched is True
+    assert steps["ceiling_clamp"].position == 70
+    # Each clamp step credits the slot whose bound produced it.
+    assert "slot2" in steps["ceiling_clamp"].reason
+    assert "slot1" in steps["floor_clamp"].reason
+    assert "inactive" not in " ".join(s.reason for s in result.decision_trace)
+
+
+def test_one_sided_clamp_keeps_its_single_trace_step() -> None:
+    """Only the ceiling binds → exactly one clamp step, as before this change."""
+    result = _floor_and_ceiling_vs_hold(
+        cover_positions={"cover.low": 50, "cover.high": 90},
+        current_cover_position=70,
+        floor=_FLOOR,
+        ceiling=70,
+    )
+
+    handlers = [s.handler for s in result.decision_trace]
+    assert handlers.count("ceiling_clamp") == 1
+    assert "floor_clamp" not in handlers
+
+
+# ---------------------------------------------------------------------------
+# Coupled cover types are judged as ONE unit, never per cover
+# ---------------------------------------------------------------------------
+#
+# Per-cover judging is only sound where each bound entity's position is decided
+# on its own. A cover type that REMAPS the resolved position per entity
+# (``resolve_entity_target``), REWRITES it after the pipeline
+# (``post_pipeline_resolve``) or orders its entities because they are
+# physically coupled (``dispatch_order_key``) breaks that premise in three
+# different ways, so those instances stay on the shared-target path.
+
+_DN_BOTTOM = "cover.bottom_rail"
+_DN_MIDDLE = "cover.middle_rail"
+_DN_SHADE = "cover.day_night"
+#: All-sheer-vs-all-blackout midpoint: middle rail halfway to the bottom rail.
+_DN_BLEND = 50
+
+
+def _day_night_options(model: str, **extra) -> dict:
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DAY_NIGHT_CONTROL_MODEL,
+    )
+
+    return {CONF_DAY_NIGHT_CONTROL_MODEL: model, **extra}
+
+
+def _resolve_through_policy(result, policy, options):
+    """Run the coordinator's post-pipeline policy hook exactly as the cycle does.
+
+    ``coordinator._update_cover_position`` calls this between
+    ``registry.evaluate`` and the dispatch loop, so a test that skips it is not
+    testing the production sequence at all.
+    """
+    return policy.post_pipeline_resolve(
+        result,
+        logger=MagicMock(),
+        sol_azi=180.0,
+        sol_elev=45.0,
+        sun_data=MagicMock(),
+        config=MagicMock(),
+        config_service=MagicMock(),
+        options=options,
+        cover=None,
+    )
+
+
+def _coupled_hold(
+    *,
+    cover_type: str,
+    cover_positions,
+    current_cover_position: int,
+    blend: int,
+    floor: int | None = None,
+    ceiling: int | None = None,
+    tilt_min: int | None = None,
+):
+    """Evaluate a manual hold on a dual-fabric shade with the named bounds active.
+
+    Slot 1 is a tilt-only contribution below the holder, which is how the
+    fabric blend reaches ``PipelineResult.tilt`` on a real day/night instance.
+    """
+    sensors = [_slot(1, tilt=blend, tilt_only=True, priority=BELOW_HOLDER)]
+    handlers = [
+        CustomPositionHandler(slot=1, position=None, priority=BELOW_HOLDER, tilt=blend),
+        ManualOverrideHandler(),
+    ]
+    if floor is not None:
+        sensors.append(_slot(2, position=floor, min_mode=True, priority=ABOVE_HOLDER))
+        handlers.append(_cp_handler(2, floor, priority=ABOVE_HOLDER))
+    if ceiling is not None:
+        sensors.append(_slot(3, position_max=ceiling, priority=ABOVE_HOLDER))
+        handlers.append(
+            CustomPositionHandler(slot=3, position=None, priority=ABOVE_HOLDER)
+        )
+    if tilt_min is not None:
+        sensors.append(_slot(4, tilt_min=tilt_min, priority=ABOVE_HOLDER))
+        handlers.append(
+            CustomPositionHandler(slot=4, position=None, priority=ABOVE_HOLDER)
+        )
+    registry = _registry_with_custom(handlers)
+    return registry.evaluate(
+        make_snapshot(
+            cover=_climate_cover(direct_sun_valid=False),
+            cover_type=cover_type,
+            manual_override_active=True,
+            current_cover_position=current_cover_position,
+            cover_positions=cover_positions,
+            default_position=100,
+            direct_sun_valid=False,
+            custom_position_sensors=sensors,
+        )
+    )
+
+
+def _model_c_policy():
+    from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
+        DayNightShadePolicy,
+    )
+
+    return DayNightShadePolicy()
+
+
+def test_a_coupled_cover_type_produces_no_verdicts_at_all() -> None:
+    """One question, asked of the policy, and its answer is total.
+
+    Same snapshot shape, same numbers, two cover types: the coupled one is
+    judged on the instance summary exactly as it was before #1174 (mean 55,
+    below the 60 floor, so the shared result is the floor), and the
+    independent one gets a verdict per cover. Nothing here reads a cover-type
+    string — ``entities_move_independently`` is the whole gate.
+    """
+    positions = {"cover.one": 40, "cover.two": 70}
+    kwargs = {
+        "cover_positions": positions,
+        "current_cover_position": 55,
+        "blend": _DN_BLEND,
+        "floor": 60,
+    }
+
+    coupled = _coupled_hold(cover_type="cover_day_night_shade", **kwargs)
+    assert coupled.hold_clamp_verdicts is None
+    assert coupled.position == 60
+    assert coupled.position_constraint_applied is True
+
+    independent = _coupled_hold(cover_type="cover_blind", **kwargs)
+    assert independent.hold_clamp_verdicts is not None
+    assert independent.hold_clamp_verdicts["cover.one"].released is True
+    assert independent.hold_clamp_verdicts["cover.two"].released is False
+
+
+@pytest.mark.asyncio
+async def test_model_c_rails_are_never_judged_apart() -> None:
+    """Model C's two rails share a track: one geometry, not two verdicts.
+
+    The bottom rail at 40 % with a 50 % blend puts the middle rail at 70 %. A
+    floor of 60 binds the bottom rail and a ceiling of 65 binds the middle one,
+    so judging them separately sends the bottom to 60 and the middle to its own
+    edge, 65 — which the middle-rail remap then treats as a bottom-rail value
+    and folds a SECOND time, driving the rail to 82: above the very ceiling
+    that bound it, and with the sheer band silently stretched.
+
+    Coupled: the pair resolves ONE position (60), and the remap derives the
+    middle rail from it exactly once → 80.
+    """
+    policy = _model_c_policy()
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+        DAY_NIGHT_MODEL_DUAL_ENTITY,
+    )
+
+    positions = {_DN_BOTTOM: 40, _DN_MIDDLE: 70}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        cover_positions=positions,
+        current_cover_position=55,
+        blend=_DN_BLEND,
+        floor=60,
+        ceiling=65,
+    )
+    resolved = _resolve_through_policy(
+        result,
+        policy,
+        _day_night_options(
+            DAY_NIGHT_MODEL_DUAL_ENTITY,
+            **{CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _DN_MIDDLE},
+        ),
+    )
+
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DN_BOTTOM: 60, _DN_MIDDLE: 80}
+
+
+@pytest.mark.asyncio
+async def test_model_c_middle_rail_follows_a_floor_that_binds_the_bottom() -> None:
+    """A floor that moves the bottom rail must move the middle rail with it.
+
+    Independently judged, the middle rail at 70 clears a 60 floor and is left
+    exactly where it is — which compresses the sheer band from 30 points to 20
+    the moment the bottom rail rises to 60. The rails are geometry, not two
+    opinions.
+    """
+    policy = _model_c_policy()
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+        DAY_NIGHT_MODEL_DUAL_ENTITY,
+    )
+
+    positions = {_DN_BOTTOM: 40, _DN_MIDDLE: 70}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        cover_positions=positions,
+        current_cover_position=55,
+        blend=_DN_BLEND,
+        floor=60,
+    )
+    resolved = _resolve_through_policy(
+        result,
+        policy,
+        _day_night_options(
+            DAY_NIGHT_MODEL_DUAL_ENTITY,
+            **{CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _DN_MIDDLE},
+        ),
+    )
+
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DN_BOTTOM: 60, _DN_MIDDLE: 80}
+
+
+@pytest.mark.asyncio
+async def test_model_b_fabric_change_still_reaches_the_hardware() -> None:
+    """Model B folds coverage AND fabric into one wire — so a hold's own read is stale.
+
+    ``split_range`` has no independent physical secondary axis: the tilt clamp's
+    new blend only reaches the motor through ``post_pipeline_resolve``'s
+    coverage+fabric fold, which runs AFTER the registry. Releasing the cover to
+    the raw position it is already sitting at makes the command a genuine no-op
+    and silently drops the clamp.
+
+    Carriage at wire 20 (blackout half, coverage 40); the tilt bound raises the
+    blend to 60, which is the sheer half → wire 60.
+    """
+    policy = _model_c_policy()
+    from custom_components.adaptive_cover_pro.const import DAY_NIGHT_MODEL_SPLIT_RANGE
+
+    positions = {_DN_SHADE: 20}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        cover_positions=positions,
+        current_cover_position=20,
+        blend=10,
+        tilt_min=60,
+    )
+    resolved = _resolve_through_policy(
+        result, policy, _day_night_options(DAY_NIGHT_MODEL_SPLIT_RANGE)
+    )
+
+    assert resolved.tilt == 60
+    assert resolved.position == 60
+
+    targets = await _dispatch_targets(
+        resolved, positions, "manual_override", policy=policy
+    )
+
+    assert targets == {_DN_SHADE: 60}

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -1,0 +1,233 @@
+"""A hold's clamp verdict is judged per cover, not against the instance mean (#1174).
+
+``PipelineSnapshot.current_cover_position`` is the arithmetic mean of every bound
+cover's position. ``ManualOverrideHandler`` / ``GroupLockHandler`` copy it into
+``PipelineResult.held_position``, and the registry's axis-constraint pass compared
+*that* single number against the composed floor/ceiling — so on a multi-cover
+instance the cover actually being commanded never entered the comparison. Three
+shades at 40/40/0 mean 27, and the whole group was judged against 27: the two
+compliant shades were dragged to a 40 floor they already satisfied, and the
+mirror case (100/100/0 → mean 67) hid a genuine violation entirely.
+
+Only the *release verdict* is per cover. The clamp target, the priority gate
+(#1170), the trace and every singular ``PipelineResult`` field stay shared — a
+clamped cover always lands exactly on the bound edge, so the dispatched value is
+still one instance-wide number; only *whether each cover receives it* is judged
+against that cover's own position.
+"""
+
+from __future__ import annotations
+
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.manual_override import (
+    ManualOverrideHandler,
+)
+
+from tests._helpers.priorities import ABOVE_HOLDER, BELOW_HOLDER
+from tests.test_pipeline.conftest import make_snapshot
+from tests.test_pipeline.test_axis_constraint_composition import _slot
+from tests.test_pipeline.test_floor_composition import (
+    _climate_cover,
+    _cp_handler,
+    _cp_state,
+    _registry_with_custom,
+)
+
+# The issue's own numbers: two shades sitting on the 40 % floor, one closed.
+# ``int(round((40 + 40 + 0) / 3)) == 27`` — the mean the registry used to judge.
+_ISSUE_POSITIONS = {"cover.a": 40, "cover.b": 40, "cover.c": 0}
+_ISSUE_MEAN = 27
+_FLOOR = 40
+
+
+def _floor_vs_hold(
+    *,
+    cover_positions=None,
+    current_cover_position: int,
+    floor: int = _FLOOR,
+    floor_priority: int = ABOVE_HOLDER,
+    position_axis_inverted: bool = False,
+):
+    """Evaluate a manual hold against one min-mode custom-position floor."""
+    registry = _registry_with_custom(
+        [_cp_handler(1, floor, priority=floor_priority), ManualOverrideHandler()]
+    )
+    return registry.evaluate(
+        make_snapshot(
+            cover=_climate_cover(direct_sun_valid=False),
+            manual_override_active=True,
+            current_cover_position=current_cover_position,
+            cover_positions=cover_positions,
+            default_position=100,
+            direct_sun_valid=False,
+            position_axis_inverted=position_axis_inverted,
+            custom_position_sensors=[
+                _cp_state(
+                    "binary_sensor.floor",
+                    is_on=True,
+                    position=floor,
+                    min_mode=True,
+                    sensor_name="Default",
+                    priority=floor_priority,
+                )
+            ],
+        )
+    )
+
+
+def _ceiling_vs_hold(
+    *,
+    cover_positions,
+    current_cover_position: int,
+    ceiling: int,
+    ceiling_priority: int = ABOVE_HOLDER,
+):
+    """Evaluate a manual hold against one ceiling-only custom-position slot."""
+    slot = _slot(1, position_max=ceiling, priority=ceiling_priority)
+    registry = _registry_with_custom(
+        [
+            CustomPositionHandler(slot=1, position=None, priority=ceiling_priority),
+            ManualOverrideHandler(),
+        ]
+    )
+    return registry.evaluate(
+        make_snapshot(
+            cover=_climate_cover(direct_sun_valid=False),
+            manual_override_active=True,
+            current_cover_position=current_cover_position,
+            cover_positions=cover_positions,
+            default_position=100,
+            direct_sun_valid=False,
+            custom_position_sensors=[slot],
+        )
+    )
+
+
+def test_floor_judges_each_cover_not_the_instance_mean() -> None:
+    """The verbatim #1174 repro: 40/40/0 against a 40 % floor.
+
+    The mean is 27, below the floor, so the pre-fix registry raised the whole
+    group — including the two shades already sitting exactly on 40.
+    """
+    result = _floor_vs_hold(
+        cover_positions=_ISSUE_POSITIONS, current_cover_position=_ISSUE_MEAN
+    )
+
+    # One shared target: the bound edge every released cover lands on.
+    assert result.position == _FLOOR
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.c"].released is True
+    assert verdicts["cover.a"].released is False
+    assert verdicts["cover.b"].released is False
+    # Each verdict reports that cover's OWN position, never the mean.
+    assert verdicts["cover.a"].held_position == 40
+    assert verdicts["cover.b"].held_position == 40
+    assert verdicts["cover.c"].held_position == 0
+
+
+def test_mean_would_have_hidden_the_violation() -> None:
+    """The counterfactual: 100/100/0 means 67, which clears the 40 % floor.
+
+    Averaging therefore under-clamps as readily as it over-clamps — the closed
+    shade violates the floor and nothing fired at all. Together with the repro
+    above this pins both failure directions.
+    """
+    result = _floor_vs_hold(
+        cover_positions={"cover.a": 100, "cover.b": 100, "cover.c": 0},
+        current_cover_position=67,
+    )
+
+    assert result.position_constraint_applied is True
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.c"].released is True
+    assert verdicts["cover.a"].released is False
+    assert verdicts["cover.b"].released is False
+
+
+# ---------------------------------------------------------------------------
+# Scope edges — what per-cover judging must NOT have changed
+# ---------------------------------------------------------------------------
+
+
+def test_priority_gate_stays_instance_wide() -> None:
+    """#1170's gate runs before any judging and is presence+priority only.
+
+    A floor at the shipped slot default (77) does not outrank the manual hold
+    (80), so ``_split_bounds_against_hold`` strips it and there is nothing left
+    to judge against. Per-cover judging must not leak past that gate and
+    release the closed shade anyway.
+    """
+    result = _floor_vs_hold(
+        cover_positions=_ISSUE_POSITIONS,
+        current_cover_position=_ISSUE_MEAN,
+        floor_priority=BELOW_HOLDER,
+    )
+
+    assert result.skip_command is True
+    assert result.position_constraint_applied is False
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert [v.released for v in verdicts.values()] == [False, False, False]
+
+
+def test_per_cover_judgment_converts_frames_like_the_scalar_did() -> None:
+    """#1036's cover→logical conversion now runs per cover, not once on the mean.
+
+    On an inverse install raw 20 IS logical 80 (compliant with a logical-25
+    floor) while raw 90 is logical 10 (violating). The mean of the two raws is
+    55 → logical 45, which clears the floor entirely: the scalar comparison saw
+    no violation at all.
+    """
+    result = _floor_vs_hold(
+        cover_positions={"cover.compliant": 20, "cover.violating": 90},
+        current_cover_position=55,
+        floor=25,
+        position_axis_inverted=True,
+    )
+
+    assert result.position == 25
+    assert result.position_constraint_applied is True
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.violating"].released is True
+    assert verdicts["cover.compliant"].released is False
+    # Verdicts stay in the RAW cover frame the coordinator's extras speak.
+    assert verdicts["cover.violating"].held_position == 90
+    assert verdicts["cover.compliant"].held_position == 20
+
+
+def test_ceiling_judges_each_cover() -> None:
+    """The ceiling mirror: only the cover above it is lowered to the bound."""
+    result = _ceiling_vs_hold(
+        cover_positions={"cover.high": 80, "cover.low": 50},
+        current_cover_position=65,
+        ceiling=60,
+    )
+
+    assert result.position == 60
+    assert result.position_constraint_applied is True
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.high"].released is True
+    assert verdicts["cover.low"].released is False
+
+
+def test_scalar_snapshot_without_cover_positions_is_byte_identical() -> None:
+    """No per-entity dict → the legacy singular comparison, and no verdicts.
+
+    Every caller that predates #1174 — and every snapshot a test builds
+    directly — lands here, which is what makes the change additive.
+    """
+    result = _floor_vs_hold(current_cover_position=_ISSUE_MEAN)
+
+    assert result.position == _FLOOR
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+    assert result.hold_clamp_verdicts is None

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -9,11 +9,13 @@ shades at 40/40/0 mean 27, and the whole group was judged against 27: the two
 compliant shades were dragged to a 40 floor they already satisfied, and the
 mirror case (100/100/0 → mean 67) hid a genuine violation entirely.
 
-Only the *release verdict* is per cover. The clamp target, the priority gate
-(#1170), the trace and every singular ``PipelineResult`` field stay shared — a
-clamped cover always lands exactly on the bound edge, so the dispatched value is
-still one instance-wide number; only *whether each cover receives it* is judged
-against that cover's own position.
+Both halves of the dispatch question are per cover: whether a command goes out
+to this cover, and where it sends it. One shared number could not answer either
+— a floor and a ceiling that both outrank the hold bind different covers in
+opposite directions, and a tilt clamp commands covers the position axis never
+released. The priority gate (#1170), the trace and every singular
+``PipelineResult`` field stay shared; ``hold_clamp_verdicts`` is the dispatch
+authority.
 """
 
 from __future__ import annotations
@@ -110,6 +112,38 @@ def _ceiling_vs_hold(
             default_position=100,
             direct_sun_valid=False,
             custom_position_sensors=[slot],
+        )
+    )
+
+
+def _floor_and_ceiling_vs_hold(
+    *,
+    cover_positions,
+    current_cover_position: int,
+    floor: int,
+    ceiling: int,
+):
+    """Evaluate a manual hold against a floor AND a ceiling, both outranking it."""
+    sensors = [
+        _slot(1, position=floor, min_mode=True, priority=ABOVE_HOLDER),
+        _slot(2, position_max=ceiling, priority=ABOVE_HOLDER),
+    ]
+    registry = _registry_with_custom(
+        [
+            _cp_handler(1, floor, priority=ABOVE_HOLDER),
+            CustomPositionHandler(slot=2, position=None, priority=ABOVE_HOLDER),
+            ManualOverrideHandler(),
+        ]
+    )
+    return registry.evaluate(
+        make_snapshot(
+            cover=_climate_cover(direct_sun_valid=False),
+            manual_override_active=True,
+            current_cover_position=current_cover_position,
+            cover_positions=cover_positions,
+            default_position=100,
+            direct_sun_valid=False,
+            custom_position_sensors=sensors,
         )
     )
 
@@ -320,21 +354,24 @@ async def test_a_cover_absent_from_the_dict_takes_the_instance_wide_answer() -> 
 
 
 # ---------------------------------------------------------------------------
-# A tilt clamp is a command, not a no-op (#1170 audit) — the position axis's
-# per-cover verdicts must not veto it
+# A tilt clamp is a command, not a no-op (#1170 audit) — and the command it
+# forces must not move the covers the position axis left alone
 # ---------------------------------------------------------------------------
 #
-# ``hold_clamp_verdicts`` answers ONE question — did a composed *position*
-# bound release this cover — so it is the skip authority for the position axis
-# alone. A tilt bound that outranks the holder is an independent reason to
-# command every held cover (``_release_hold_for_tilt_clamp``), and with the
-# position axis inert every verdict reads ``released=False``. Letting those
-# verdicts answer for the tilt axis re-skipped the whole group and the tilt
-# bound never reached the hardware, while the trace still reported a carried
-# hold position for a dispatch that never happened.
+# A tilt bound that outranks the holder clears ``skip_command`` for the whole
+# group: every held cover has to receive a command so the slats reach the
+# hardware. There is no single position that means "hold where you are AND take
+# this tilt", which is why each verdict carries its own target — a released
+# cover gets the bound edge, a held one gets its own position, a value the
+# same-position gate turns into a pure tilt service call.
 
 _TILT_FILL = 10
 _TILT_FLOOR = 60
+
+# Compliant covers parked well ABOVE the floor, so "held where it is" and
+# "commanded to the floor" are two different numbers. Judging with covers that
+# sit exactly ON the bound cannot tell the two apart.
+_ABOVE_FLOOR_POSITIONS = {"cover.a": 80, "cover.b": 80, "cover.c": 0}
 
 
 def _dispatch_coordinator(result):
@@ -342,6 +379,7 @@ def _dispatch_coordinator(result):
     coord = object.__new__(AdaptiveDataUpdateCoordinator)
     coord.logger = MagicMock()
     coord._inverse_state = False
+    coord._use_interpolation = False
     coord.config_entry = MagicMock()
     coord.config_entry.options = {CONF_INVERSE_STATE: False}
     coord._policy = get_policy("cover_venetian")
@@ -351,6 +389,26 @@ def _dispatch_coordinator(result):
     cmd_svc.record_skipped_action = MagicMock()
     coord._cmd_svc = cmd_svc
     return coord
+
+
+async def _dispatch_targets(result, covers, reason) -> dict[str, int | None]:
+    """Fan ``result`` out over ``covers`` and report what each one received.
+
+    The value is the position actually commanded, or ``None`` when the seam
+    wrote a hold-skip record instead — the two outcomes ``_dispatch_to_cover``
+    chooses between. Every cover is offered the same ``state`` the real cycle
+    computes (``coordinator.state``), so any divergence in the result comes
+    from the per-cover verdict and nothing else.
+    """
+    coord = _dispatch_coordinator(result)
+    state = coord._to_cover_frame(result.position)
+    for cover in covers:
+        await coord._dispatch_to_cover(cover, state, reason, None)
+    sent = {c.args[0]: c.args[1] for c in coord._cmd_svc.apply_position.call_args_list}
+    skipped = {c.args[0] for c in coord._cmd_svc.record_skipped_action.call_args_list}
+    assert sent.keys() | skipped == set(covers)
+    assert not sent.keys() & skipped
+    return {cover: sent.get(cover) for cover in covers}
 
 
 def _tilt_clamp_vs_hold(*, cover_positions=None, with_position_floor: bool = False):
@@ -402,66 +460,97 @@ def test_tilt_clamp_releases_the_hold_on_a_legacy_snapshot() -> None:
     assert result.hold_clamp_verdicts is None
 
 
-def test_tilt_clamp_leaves_no_position_verdicts_to_veto_it() -> None:
+def test_a_tilt_clamp_commands_every_held_cover() -> None:
     """The production snapshot shape: ``cover_positions`` present, tilt clamped.
 
     Every real cycle after the first carries the dict, and with the position
-    axis inert every verdict is ``released=False``. They must not survive as the
-    skip authority for a dispatch the *tilt* axis forced.
+    axis inert nothing there released anybody. The tilt bound releases the
+    group on its own, so every verdict has to say so — dropping the dict
+    instead put the whole group back on one instance-wide number.
     """
     result = _tilt_clamp_vs_hold(cover_positions=_ISSUE_POSITIONS)
 
     assert result.tilt == _TILT_FLOOR
     assert result.skip_command is False
     assert result.position_constraint_applied is False
-    assert result.hold_clamp_verdicts is None
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert all(v.released for v in verdicts.values())
 
 
 @pytest.mark.asyncio
-async def test_tilt_clamp_reaches_every_cover_on_a_production_snapshot() -> None:
-    """End to end: the tilt bound commands all three covers, skipping none.
+async def test_a_tilt_only_clamp_sends_each_cover_its_own_position() -> None:
+    """Nothing claimed the position axis, so nobody's position may change.
 
-    The registry-only assertion above cannot see the regression this pins —
-    the verdicts only bite at the dispatch seam, where a ``released=False``
-    entry turns the forced command back into a hold skip.
+    The command exists only to carry the slats, so each cover's target is its
+    own current position — a positional no-op the same-position gate turns into
+    a pure tilt service call. Sending one shared number instead drove all three
+    shades to the instance mean, 27, which is the literal number in the issue
+    title and nobody's position.
     """
     result = _tilt_clamp_vs_hold(cover_positions=_ISSUE_POSITIONS)
-    coord = _dispatch_coordinator(result)
 
-    for cover in _ISSUE_POSITIONS:
-        await coord._dispatch_to_cover(cover, result.position, "manual_override", None)
+    targets = await _dispatch_targets(result, _ISSUE_POSITIONS, "manual_override")
 
-    coord._cmd_svc.record_skipped_action.assert_not_called()
-    assert [c.args[0] for c in coord._cmd_svc.apply_position.call_args_list] == list(
-        _ISSUE_POSITIONS
-    )
+    assert targets == dict(_ISSUE_POSITIONS)
+    assert _ISSUE_MEAN not in targets.values()
 
 
 @pytest.mark.asyncio
-async def test_tilt_clamp_outranks_verdicts_when_position_clamps_too() -> None:
-    """Both axes clamp: the tilt bound still reaches the covers the floor spared.
+async def test_a_tilt_clamp_does_not_drag_a_compliant_cover_to_the_floor() -> None:
+    """Both axes clamp: the floor moves only the cover that violates it.
 
-    The narrower guard — drop the verdicts only when the position axis stayed
-    inert — leaves this case broken: ``cover.a`` and ``cover.b`` already satisfy
-    the floor, so their verdicts read ``released=False`` and the tilt bound that
-    outranks the hold never reaches them. A tilt clamp is a command for every
-    held cover or it is not a command at all.
+    ``cover.a`` and ``cover.b`` are held at 80, well above the 40 floor, and a
+    *tilt* bound is the only reason a command goes out to them at all. Letting
+    that tilt command carry the position axis's clamp target closed them by 40
+    points — worse than the mean-based behaviour #1174 set out to fix, which at
+    least sent 53.
     """
     result = _tilt_clamp_vs_hold(
-        cover_positions=_ISSUE_POSITIONS, with_position_floor=True
+        cover_positions=_ABOVE_FLOOR_POSITIONS, with_position_floor=True
     )
 
     assert result.tilt == _TILT_FLOOR
     assert result.position == _FLOOR
     assert result.position_constraint_applied is True
     assert result.skip_command is False
-    assert result.hold_clamp_verdicts is None
 
-    coord = _dispatch_coordinator(result)
-    for cover in _ISSUE_POSITIONS:
-        await coord._dispatch_to_cover(
-            cover, result.position, "custom_position_3", None
-        )
+    targets = await _dispatch_targets(
+        result, _ABOVE_FLOOR_POSITIONS, "custom_position_3"
+    )
 
-    coord._cmd_svc.record_skipped_action.assert_not_called()
-    assert coord._cmd_svc.apply_position.call_count == len(_ISSUE_POSITIONS)
+    assert targets == {"cover.a": 80, "cover.b": 80, "cover.c": _FLOOR}
+
+
+# ---------------------------------------------------------------------------
+# A floor and a ceiling bind different covers in opposite directions
+# ---------------------------------------------------------------------------
+#
+# ``PipelineResult.position`` can only carry one of the two edges — ``clamp_to_bounds``
+# applies the floor last, so the floor wins the shared field. Dispatching that
+# to every released cover sent the one the *ceiling* bound to the floor instead,
+# a move in the wrong direction and one the pre-#1174 code never made (the mean
+# sat between the bounds, so nothing clamped and the hold survived).
+
+
+@pytest.mark.asyncio
+async def test_a_ceiling_bound_cover_is_lowered_to_the_ceiling_not_the_floor() -> None:
+    """Floor 40 + ceiling 70, covers at 20 and 90: each goes to its own bound."""
+    covers = {"cover.low": 20, "cover.high": 90}
+    result = _floor_and_ceiling_vs_hold(
+        cover_positions=covers,
+        # The mean, 55, sits inside [40, 70] — the scalar comparison saw no
+        # violation at all and left the hold alone.
+        current_cover_position=55,
+        floor=_FLOOR,
+        ceiling=70,
+    )
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.low"].released is True
+    assert verdicts["cover.high"].released is True
+
+    targets = await _dispatch_targets(result, covers, "custom_position_1")
+
+    assert targets == {"cover.low": _FLOOR, "cover.high": 70}

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -18,6 +18,15 @@ against that cover's own position.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import CONF_INVERSE_STATE
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
@@ -231,3 +240,228 @@ def test_scalar_snapshot_without_cover_positions_is_byte_identical() -> None:
     assert result.position_constraint_applied is True
     assert result.skip_command is False
     assert result.hold_clamp_verdicts is None
+
+
+# ---------------------------------------------------------------------------
+# A cover the per-entity dict cannot speak for
+# ---------------------------------------------------------------------------
+#
+# ``cover_positions`` is ``dict[str, int | None]``: an entity that has not
+# reported a numeric position yet is present with a ``None`` value. That cover
+# still has to be judged — on the summary mean, which is the only thing anyone
+# knows about it — and still has to appear in the verdicts, or the coordinator
+# silently falls back to the instance-wide answer for it.
+
+
+def test_a_cover_with_no_position_is_judged_on_the_summary_mean() -> None:
+    """``None`` position + a violating mean → released, carrying that mean.
+
+    The reporting sibling sits exactly on the floor and is not released, so the
+    two covers diverge: a ``None`` entry is neither dropped from the dict nor
+    given its neighbour's answer.
+    """
+    result = _floor_vs_hold(
+        cover_positions={"cover.reporting": _FLOOR, "cover.silent": None},
+        current_cover_position=_ISSUE_MEAN,
+    )
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert set(verdicts) == {"cover.reporting", "cover.silent"}
+    assert verdicts["cover.silent"].held_position == _ISSUE_MEAN
+    assert verdicts["cover.silent"].released is True
+    assert verdicts["cover.reporting"].released is False
+
+
+def test_a_cover_with_no_position_rides_a_compliant_mean() -> None:
+    """The mirror: the mean clears the floor, so the silent cover is NOT released.
+
+    A genuine violator is released in the same cycle, so "not released" here is
+    a real judgment on the mean rather than a cycle where nothing clamped.
+    """
+    result = _floor_vs_hold(
+        # 100 and 0 average to 50, which clears the 40 floor.
+        cover_positions={"cover.high": 100, "cover.low": 0, "cover.silent": None},
+        current_cover_position=50,
+    )
+
+    assert result.position_constraint_applied is True
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.low"].released is True
+    assert verdicts["cover.silent"].held_position == 50
+    assert verdicts["cover.silent"].released is False
+
+
+@pytest.mark.asyncio
+async def test_a_cover_absent_from_the_dict_takes_the_instance_wide_answer() -> None:
+    """A cover with no entry at all is not judged, and must not blow up.
+
+    The registry judges exactly the covers the snapshot lists, so an entity the
+    dict never saw gets no verdict — and ``_dispatch_to_cover`` falls back to
+    the singular ``skip_command`` for it rather than raising ``KeyError``.
+    """
+    result = _floor_vs_hold(
+        cover_positions=_ISSUE_POSITIONS, current_cover_position=_ISSUE_MEAN
+    )
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert "cover.ghost" not in verdicts
+
+    coord = _dispatch_coordinator(result)
+    await coord._dispatch_to_cover("cover.ghost", _FLOOR, "custom_position_1", ctx=None)
+
+    # skip_command is False (the floor clamped), so the instance-wide answer is
+    # "command it" — the same value every released cover receives.
+    coord._cmd_svc.apply_position.assert_called_once_with(
+        "cover.ghost", _FLOOR, "custom_position_1", context=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# A tilt clamp is a command, not a no-op (#1170 audit) — the position axis's
+# per-cover verdicts must not veto it
+# ---------------------------------------------------------------------------
+#
+# ``hold_clamp_verdicts`` answers ONE question — did a composed *position*
+# bound release this cover — so it is the skip authority for the position axis
+# alone. A tilt bound that outranks the holder is an independent reason to
+# command every held cover (``_release_hold_for_tilt_clamp``), and with the
+# position axis inert every verdict reads ``released=False``. Letting those
+# verdicts answer for the tilt axis re-skipped the whole group and the tilt
+# bound never reached the hardware, while the trace still reported a carried
+# hold position for a dispatch that never happened.
+
+_TILT_FILL = 10
+_TILT_FLOOR = 60
+
+
+def _dispatch_coordinator(result):
+    """Minimal coordinator around a ready-made result, for ``_dispatch_to_cover``."""
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._inverse_state = False
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {CONF_INVERSE_STATE: False}
+    coord._policy = get_policy("cover_venetian")
+    coord._pipeline_result = result
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", None))
+    cmd_svc.record_skipped_action = MagicMock()
+    coord._cmd_svc = cmd_svc
+    return coord
+
+
+def _tilt_clamp_vs_hold(*, cover_positions=None, with_position_floor: bool = False):
+    """Evaluate a manual hold released by an outranking TILT bound.
+
+    A FIXED tilt-only slot below the holder fills the tilt (#514); a tilt floor
+    above the holder then clamps it (#943). By default nothing claims the
+    position axis, so the released command comes entirely from the tilt side —
+    the shape the #1170 audit named when it ruled that a tilt clamp is a
+    command. ``with_position_floor`` adds an outranking position floor so both
+    axes clamp in the same cycle.
+    """
+    sensors = [
+        _slot(1, tilt=_TILT_FILL, tilt_only=True, priority=BELOW_HOLDER),
+        _slot(2, tilt_min=_TILT_FLOOR, priority=ABOVE_HOLDER),
+    ]
+    handlers = [
+        CustomPositionHandler(
+            slot=1, position=None, priority=BELOW_HOLDER, tilt=_TILT_FILL
+        ),
+        CustomPositionHandler(slot=2, position=None, priority=ABOVE_HOLDER),
+        ManualOverrideHandler(),
+    ]
+    if with_position_floor:
+        sensors.append(_slot(3, position=_FLOOR, min_mode=True, priority=ABOVE_HOLDER))
+        handlers.append(_cp_handler(3, _FLOOR, priority=ABOVE_HOLDER))
+    registry = _registry_with_custom(handlers)
+    return registry.evaluate(
+        make_snapshot(
+            cover=_climate_cover(direct_sun_valid=False),
+            cover_type="cover_venetian",
+            manual_override_active=True,
+            current_cover_position=_ISSUE_MEAN,
+            cover_positions=cover_positions,
+            default_position=100,
+            direct_sun_valid=False,
+            custom_position_sensors=sensors,
+        )
+    )
+
+
+def test_tilt_clamp_releases_the_hold_on_a_legacy_snapshot() -> None:
+    """Baseline: no per-entity dict, so nothing has changed here since #1170."""
+    result = _tilt_clamp_vs_hold()
+
+    assert result.tilt == _TILT_FLOOR
+    assert result.skip_command is False
+    assert result.position_constraint_applied is False
+    assert result.hold_clamp_verdicts is None
+
+
+def test_tilt_clamp_leaves_no_position_verdicts_to_veto_it() -> None:
+    """The production snapshot shape: ``cover_positions`` present, tilt clamped.
+
+    Every real cycle after the first carries the dict, and with the position
+    axis inert every verdict is ``released=False``. They must not survive as the
+    skip authority for a dispatch the *tilt* axis forced.
+    """
+    result = _tilt_clamp_vs_hold(cover_positions=_ISSUE_POSITIONS)
+
+    assert result.tilt == _TILT_FLOOR
+    assert result.skip_command is False
+    assert result.position_constraint_applied is False
+    assert result.hold_clamp_verdicts is None
+
+
+@pytest.mark.asyncio
+async def test_tilt_clamp_reaches_every_cover_on_a_production_snapshot() -> None:
+    """End to end: the tilt bound commands all three covers, skipping none.
+
+    The registry-only assertion above cannot see the regression this pins —
+    the verdicts only bite at the dispatch seam, where a ``released=False``
+    entry turns the forced command back into a hold skip.
+    """
+    result = _tilt_clamp_vs_hold(cover_positions=_ISSUE_POSITIONS)
+    coord = _dispatch_coordinator(result)
+
+    for cover in _ISSUE_POSITIONS:
+        await coord._dispatch_to_cover(cover, result.position, "manual_override", None)
+
+    coord._cmd_svc.record_skipped_action.assert_not_called()
+    assert [c.args[0] for c in coord._cmd_svc.apply_position.call_args_list] == list(
+        _ISSUE_POSITIONS
+    )
+
+
+@pytest.mark.asyncio
+async def test_tilt_clamp_outranks_verdicts_when_position_clamps_too() -> None:
+    """Both axes clamp: the tilt bound still reaches the covers the floor spared.
+
+    The narrower guard — drop the verdicts only when the position axis stayed
+    inert — leaves this case broken: ``cover.a`` and ``cover.b`` already satisfy
+    the floor, so their verdicts read ``released=False`` and the tilt bound that
+    outranks the hold never reaches them. A tilt clamp is a command for every
+    held cover or it is not a command at all.
+    """
+    result = _tilt_clamp_vs_hold(
+        cover_positions=_ISSUE_POSITIONS, with_position_floor=True
+    )
+
+    assert result.tilt == _TILT_FLOOR
+    assert result.position == _FLOOR
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+    assert result.hold_clamp_verdicts is None
+
+    coord = _dispatch_coordinator(result)
+    for cover in _ISSUE_POSITIONS:
+        await coord._dispatch_to_cover(
+            cover, result.position, "custom_position_3", None
+        )
+
+    coord._cmd_svc.record_skipped_action.assert_not_called()
+    assert coord._cmd_svc.apply_position.call_count == len(_ISSUE_POSITIONS)

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -1421,7 +1421,7 @@ async def test_custom_position_slot_template_resolves_the_acp_namespace(hass):
 # ---------------------------------------------------------------------------
 
 
-def _build_minimal(builder, opts):
+def _build_minimal(builder, opts, **extra):
     """Run builder.build() with the minimum kwargs and return the snapshot."""
     cover_data = MagicMock()
     cover_data.config = MagicMock()
@@ -1440,6 +1440,7 @@ def _build_minimal(builder, opts):
         in_time_window=True,
         current_cover_position=None,
         is_glare_zone_enabled=lambda idx: True,
+        **extra,
     )
 
 
@@ -1518,3 +1519,59 @@ def test_build_falls_back_to_the_weather_class_default_priority():
     builder, _, _ = _make_builder()
     snapshot = _build_minimal(builder, {})
     assert snapshot.weather_override_priority == WeatherOverrideHandler.priority
+
+
+# ---------------------------------------------------------------------------
+# Per-entity cover positions reach the snapshot (issue #1174)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_snapshot_builder_threads_cover_positions():
+    """The per-entity dict the registry judges holds against must reach it.
+
+    ``current_cover_position`` is the mean of these; without the dict itself the
+    registry falls back to judging that scalar, which is the #1174 defect.
+    """
+    builder, _, _ = _make_builder()
+    positions = {"cover.a": 40, "cover.b": None}
+    snapshot = _build_minimal(builder, {}, cover_positions=positions)
+    assert snapshot.cover_positions == positions
+
+
+@pytest.mark.unit
+def test_snapshot_builder_defaults_cover_positions_to_none():
+    """Omitting the kwarg leaves the legacy scalar-only judgment in place."""
+    builder, _, _ = _make_builder()
+    assert _build_minimal(builder, {}).cover_positions is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_update_cycle_threads_cover_positions_into_build(hass):
+    """A full update cycle passes the live per-entity dict into build().
+
+    The scalar and the dict must come from the same read: the coordinator's
+    ``CoverStateSnapshot``. Asserting only the builder kwarg would leave the
+    coordinator free to never pass it.
+    """
+    from tests.ha_helpers import VERTICAL_OPTIONS, setup_integration
+
+    entry = await setup_integration(
+        hass, options=dict(VERTICAL_OPTIONS), entry_id="cover_positions_thread_01"
+    )
+    coord = entry.runtime_data
+
+    captured: dict = {}
+    real_build = coord._snapshot_builder.build
+
+    def _spy(*args, **kwargs):
+        captured["cover_positions"] = kwargs.get("cover_positions")
+        captured["live"] = dict(coord._snapshot.cover_positions)
+        return real_build(*args, **kwargs)
+
+    coord._snapshot_builder.build = _spy
+    await coord.async_refresh()
+
+    assert captured["cover_positions"] == captured["live"]
+    assert captured["cover_positions"]


### PR DESCRIPTION
## Summary

A hold's floor/ceiling verdict was decided against `_compute_mean_cover_position`, the arithmetic mean of every cover bound to the config entry, so whether a bound clamped a manually closed shade depended on where the unrelated shades happened to be parked. Three shades at 40/40/0 produced a mean of 27 and the whole group was judged against it.

The registry now judges each bound cover against its own position and resolves a clamp target per cover, published as `PipelineResult.hold_clamp_verdicts`; the coordinator dispatches on that rather than on one shared number. A snapshot without per-entity positions falls back to the previous singular path exactly, so single-cover instances are unchanged.

Per-cover judgment is gated on `CoverTypePolicy.entities_move_independently()`. The default is derived rather than declared: a policy qualifies only if it overrides none of `resolve_entity_target`, `post_pipeline_resolve`, or `dispatch_order_key`, so a new cover type is safe by construction. Day/night and dual panel stay on the shared-target path because their rails move together, and judging them independently compressed the band. Venetian opts back in, with a test pinning why its `post_pipeline_resolve` cannot fire under a hold.

Also fixes a tilt clamp being suppressed by position verdicts, and stops the decision trace reporting a bound as inactive when it did move a cover.

## Testing
- ✅ 12381 tests passing

## Related Issues
Refs #1174
Refs #1179