### PR TITLE
feat: measure cover travel time and animate the move

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -52,6 +52,7 @@ from .const import (
     CONF_SENSOR_TYPE,
     CONF_TEMP_ENTITY,
     CONF_TILT_SAFETY_MARGIN,
+    CONF_TRAVEL_TIME_CALIBRATION,
     CONF_VENETIAN_TILT_SAFETY_MARGIN,
     CONF_WEATHER_ENABLED,
     CONF_WEATHER_ENTITY,
@@ -1047,6 +1048,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 # the option-backed switches only persist the value and rely on the listener.
 _RUNTIME_APPLICABLE_OPTIONS: dict[str, str] = {
     CONF_ENABLE_SUN_TRACKING: "async_apply_sun_tracking_update",
+    # Derived measurement data, not a behaviour switch. It MUST be in this map:
+    # a calibration run rewrites it mid-pass, and a reload there would tear down
+    # the run that produced it.
+    CONF_TRAVEL_TIME_CALIBRATION: "async_apply_travel_calibration_update",
 }
 
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -6521,10 +6521,21 @@ class OptionsFlowHandler(OptionsFlow):
         takes minutes; awaiting it here would hold the config-flow dialog open
         for the duration. Returning to the menu (rather than aborting the flow)
         also preserves any edits made earlier in this session.
+
+        Scoped to the config entry, not to ``hass``: the run outlives this
+        dialog, and saving the flow can reload the entry. A bare
+        ``hass.async_create_task`` would survive that reload and keep driving
+        covers through the torn-down coordinator's command service — writing
+        options from a stale object while the new coordinator is already
+        automating. Entry-scoped, the reload cancels it.
         """
         coordinator = self._coordinator()
         if coordinator is not None:
-            self.hass.async_create_task(coordinator.async_run_travel_calibration())
+            self._config_entry.async_create_background_task(
+                self.hass,
+                coordinator.async_run_travel_calibration(),
+                name=f"acp_travel_calibration_{self._config_entry.entry_id}",
+            )
         return await self.async_step_travel_time()
 
     async def async_step_travel_time_cancel(

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -255,6 +255,7 @@ from .const import (
     TIME_STRING_RE,
     TRAVEL_CALIBRATION_SOURCE_MANUAL,
     TRAVEL_TIME_MAX_SECONDS,
+    TRAVEL_TIME_MIN_SECONDS,
     CoverType,
     GroupScene,
     TemplateCombineMode,
@@ -6435,8 +6436,28 @@ class OptionsFlowHandler(OptionsFlow):
         return getattr(self._config_entry, "runtime_data", None)
 
     def _travel_table(self) -> dict[str, dict[str, Any]]:
-        """Return the travel-time table as this flow session currently holds it."""
-        return dict(self.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {})
+        """Return the LIVE travel-time table with this session's edits on top.
+
+        Deliberately not ``self.options``. That is a snapshot taken when the flow
+        opened, and this is the one key written from outside the flow: a
+        measurement run started from the Travel Time menu keeps going after the
+        user navigates on and writes its results straight to the config entry.
+        Reading the snapshot would show every freshly-measured cover as "not
+        calibrated" on the very page that just ran the measurement, and would
+        pre-fill the manual form with stale numbers.
+
+        One definition serving four callers — the status block, the manual
+        form's suggested values, the manual write, and the save-time merge — so
+        the live-plus-edits rule cannot be applied inconsistently between them.
+        """
+        live = dict(self._config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {})
+        session = self.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
+        for entity_id in self._travel_time_edited:
+            if entity_id in session:
+                live[entity_id] = session[entity_id]
+            else:
+                live.pop(entity_id, None)
+        return live
 
     def _travel_time_status(self) -> str:
         """Markdown status block shown on the Travel Time menu.
@@ -6540,6 +6561,29 @@ class OptionsFlowHandler(OptionsFlow):
         """
         entities = list(self.options.get(CONF_ENTITIES) or [])
         if user_input is not None:
+            # 0 clears; anything between 0 and the floor is a typo, not a
+            # setting. Rejecting rather than clamping keeps the number the user
+            # sees the number that was stored, and holds the promise
+            # TRAVEL_TIME_MIN_SECONDS makes: a value the UI accepts is never one
+            # the calibrator would have discarded as implausible.
+            too_short = [
+                eid
+                for eid in entities
+                if user_input.get(eid)
+                and float(user_input[eid]) < TRAVEL_TIME_MIN_SECONDS
+            ]
+            if too_short:
+                return self.async_show_form(
+                    step_id="travel_time_manual",
+                    data_schema=self.add_suggested_values_to_schema(
+                        _travel_time_manual_schema(entities), user_input
+                    ),
+                    errors={"base": "travel_time_too_short"},
+                    description_placeholders={
+                        "cover_list": self._travel_time_status(),
+                        "min_seconds": f"{TRAVEL_TIME_MIN_SECONDS:g}",
+                    },
+                )
             table = self._travel_table()
             for entity_id in entities:
                 submitted = user_input.get(entity_id)
@@ -6579,6 +6623,7 @@ class OptionsFlowHandler(OptionsFlow):
             ),
             description_placeholders={
                 "cover_list": self._travel_time_status(),
+                "min_seconds": f"{TRAVEL_TIME_MIN_SECONDS:g}",
             },
         )
 
@@ -6760,25 +6805,17 @@ class OptionsFlowHandler(OptionsFlow):
         editing, and finishes by writing its results straight to the entry.
         Saving the snapshot as-is would silently erase everything it measured.
 
-        So the live table wins by default, and only the entities this session
-        actually touched are re-applied on top. Per-entity, not all-or-nothing:
-        a manual time typed for cover A and a measurement taken for cover B in
-        the same window must both survive.
-
-        Also drops rows for covers this instance no longer controls — the same
-        prune the calibrator does at run start, applied here so removing a cover
-        cleans up even without a run.
+        ``_travel_table`` already resolves live-plus-this-session's-edits, per
+        entity — a manual time typed for cover A and a measurement taken for
+        cover B in the same window both survive. All that is left here is to drop
+        rows for covers the instance no longer controls, the same prune the
+        calibrator applies, done here too so removing a cover cleans up even
+        without a run.
         """
-        live = dict(self._config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {})
-        session = self.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
-        for entity_id in self._travel_time_edited:
-            edited = session.get(entity_id)
-            if edited is None:
-                live.pop(entity_id, None)
-            else:
-                live[entity_id] = edited
         entities = set(self.options.get(CONF_ENTITIES) or [])
-        merged = {eid: row for eid, row in live.items() if eid in entities}
+        merged = {
+            eid: row for eid, row in self._travel_table().items() if eid in entities
+        }
         if merged:
             self.options[CONF_TRAVEL_TIME_CALIBRATION] = merged
         else:

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass, field
 from functools import cache
 from pathlib import Path
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import voluptuous as vol
@@ -21,6 +21,7 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ADAPTIVE_NAME_PREFIX,
@@ -241,6 +242,7 @@ from .const import (
     CONF_DEBUG_MODE,
     CONF_DRY_RUN,
     CONF_TRANSIT_TIMEOUT,
+    CONF_TRAVEL_TIME_CALIBRATION,
     DEBUG_CATEGORIES_ALL,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
@@ -251,13 +253,17 @@ from .const import (
     DOMAIN,
     TIME_OPTION_KEYS,
     TIME_STRING_RE,
+    TRAVEL_CALIBRATION_SOURCE_MANUAL,
+    TRAVEL_TIME_MAX_SECONDS,
     CoverType,
     GroupScene,
     TemplateCombineMode,
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
+from .managers.cover_command.state_store import TravelCalibration
 from .troubleshoot_i18n import load_troubleshoot_labels
+
 from .helpers import (
     bound_cover_capabilities,
     check_cover_capabilities,
@@ -266,6 +272,7 @@ from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_name,
     custom_position_slot_sensors,
+    is_assumed_state,
     manual_hold_is_unanchored,
     mirror_legacy_slot_sensor_keys,
     normalize_time_string,
@@ -1173,6 +1180,44 @@ WEATHER_OPTIONS = vol.Schema(
     }
 )
 
+
+def _travel_entity_label(hass: HomeAssistant, entity_id: str) -> str:
+    """``Living Room (cover.living_room)``, or the bare id if HA has no name."""
+    state = hass.states.get(entity_id)
+    name = state.attributes.get("friendly_name") if state else None
+    return f"{name} (`{entity_id}`)" if name else f"`{entity_id}`"
+
+
+def _travel_time_manual_schema(entities: Sequence[str]) -> vol.Schema:
+    """One seconds field per configured cover, keyed by entity id.
+
+    Keyed by entity id because the answer has to be mapped back to a cover, and
+    a positional key would silently rebind if the cover list changed between
+    rendering the form and submitting it. HA renders the key as the label; the
+    step's description carries the friendly names alongside, plus which covers
+    cannot be measured and therefore need this page.
+
+    ``0`` means "no travel time" — see ``async_step_travel_time_manual`` for why
+    the field is a BOX. The bounds are the same constants the calibrator clamps
+    its own measurements to, so the UI cannot accept a value the manager would
+    reject.
+    """
+    return vol.Schema(
+        {
+            vol.Optional(entity_id, default=0): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0,
+                    max=TRAVEL_TIME_MAX_SECONDS,
+                    step=0.5,
+                    mode=selector.NumberSelectorMode.BOX,
+                    unit_of_measurement="s",
+                )
+            )
+            for entity_id in entities
+        }
+    )
+
+
 INTERPOLATION_OPTIONS = vol.Schema(
     {
         vol.Optional(CONF_INTERP_START): selector.NumberSelector(
@@ -1733,8 +1778,15 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "limits.open_close_threshold": "Open/close threshold: {thresh}%",
     "limits.calibration": "Calibration {lo}→{hi}",
     "limits.calibration_on": "Position calibration on",
+    "limits.travel_time": "Travel time: {done}/{total} covers",
+    "limits.travel_time_manual": "Travel time: {done}/{total} covers ({manual} entered by hand)",
     "limits.sun_tracking_min": "Sun-tracking min: {pos}%",
     "limits.separator": " · ",
+    "warnings.travel_time_unmeasurable": (
+        "⚠️ {entities} report an assumed state, so their travel time cannot be "
+        "measured and none has been entered — dashboards will not show them "
+        "moving. Enter a time under Calibration → Travel Time."
+    ),
     "warnings.sun_track_min_below_floor": (
         "⚠️ Sun-tracking min {sun_min}% < min position {min_pos}% — "
         "always-on floor dominates; sun-tracking floor will be raised to "
@@ -3070,6 +3122,23 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             )
         else:
             limit_parts.append(L["limits.calibration_on"])
+    # Travel time sits beside the position curve because both answer "what did
+    # we measure about this hardware" — and because the two are the reason the
+    # options menu now groups them under one Calibration parent.
+    _travel_entities = list(config.get(CONF_ENTITIES) or [])
+    _travel_table = config.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
+    if _travel_entities and _travel_table:
+        _done = sum(1 for eid in _travel_entities if eid in _travel_table)
+        _manual = sum(
+            1
+            for eid in _travel_entities
+            if (_travel_table.get(eid) or {}).get("source")
+            == TRAVEL_CALIBRATION_SOURCE_MANUAL
+        )
+        _key = "limits.travel_time_manual" if _manual else "limits.travel_time"
+        limit_parts.append(
+            L[_key].format(done=_done, total=len(_travel_entities), manual=_manual)
+        )
     min_pos_sun_track = config.get(CONF_MIN_POSITION_SUN_TRACKING)
     if min_pos_sun_track is not None:
         limit_parts.append(L["limits.sun_tracking_min"].format(pos=min_pos_sun_track))
@@ -3077,6 +3146,24 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         lines.append("")
         lines.append(L["headers.position_limits"])
         lines.append(L["limits.separator"].join(limit_parts))
+
+    # Footgun: a cover whose state Home Assistant only assumes can never be
+    # measured, so leaving it without a hand-entered time silently means "this
+    # cover will never animate" — exactly the kind of quiet no-op the summary
+    # exists to surface. Needs hass: assumed_state is a live entity attribute,
+    # not config.
+    if hass is not None:
+        _unmeasurable = [
+            eid
+            for eid in _travel_entities
+            if eid not in _travel_table and is_assumed_state(hass.states.get(eid))
+        ]
+        if _unmeasurable:
+            lines.append(
+                L["warnings.travel_time_unmeasurable"].format(
+                    entities=", ".join(_unmeasurable)
+                )
+            )
 
     # Footgun: sun-tracking floor below always-on floor is a no-op (issue #467).
     # The always-on min_pos dominates, so min_pos_sun_tracking < min_pos is a
@@ -4738,6 +4825,9 @@ class OptionsFlowHandler(OptionsFlow):
         # step id so the translation block is authored once, so the area lives
         # here instead of in the step id.
         self._delete_area: str = ""
+        # Entities whose travel time THIS flow session edited. Everything else
+        # in the table is re-read live at save time — see ``_merge_travel_time``.
+        self._travel_time_edited: set[str] = set()
         # "Change Cover Type" (issue #1132). ``_pending_cover_type`` carries the
         # picked destination from the picker to the confirm screen. A switch is
         # pending whenever ``self.sensor_type`` has moved away from the stored
@@ -4894,8 +4984,12 @@ class OptionsFlowHandler(OptionsFlow):
         # ── Layer 2: Where can I go? / how do I behave? ──────────────
         keys.append("position")  # L2a positions (% values)
         keys.append("behavior")  # L2b timing & thresholds
-        if self.options.get(CONF_INTERP):
-            keys.append("interp")
+        # Calibration groups the two "measure the hardware, then store what we
+        # measured" surfaces: the position interpolation curve (conditional on
+        # CONF_INTERP, as it always was) and travel time. The parent owns the
+        # word "calibration" so its children can be told apart — this is why
+        # ``interp`` no longer sits at the top level.
+        keys.append("calibration")
 
         # ── Layer 3: How do I decide? (handlers, priority high → low) ─
         keys.extend(
@@ -6330,6 +6424,164 @@ class OptionsFlowHandler(OptionsFlow):
             },
         )
 
+    # ---- Calibration ---------------------------------------------------- #
+    #
+    # Two unrelated things are called "calibration" in this integration: the
+    # position INTERPOLATION curve (``interp``) and TRAVEL TIME. Grouping them
+    # under one parent is what lets each keep a name that says which it is.
+
+    def _coordinator(self):
+        """Return this entry's live coordinator, or None if it is not loaded."""
+        return getattr(self._config_entry, "runtime_data", None)
+
+    def _travel_table(self) -> dict[str, dict[str, Any]]:
+        """Return the travel-time table as this flow session currently holds it."""
+        return dict(self.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {})
+
+    def _travel_time_status(self) -> str:
+        """Markdown status block shown on the Travel Time menu.
+
+        Re-rendered every time the menu is entered, which is how a run in
+        progress is watched: back out and back in to see it advance.
+        """
+        entities = list(self.options.get(CONF_ENTITIES) or [])
+        table = self._travel_table()
+        coordinator = self._coordinator()
+        lines: list[str] = []
+        if coordinator is not None:
+            calibrator = coordinator.travel_calibration
+            lines.append(f"State: **{calibrator.state}**")
+            if calibrator.active_entity:
+                lines.append(f"Measuring: `{calibrator.active_entity}`")
+        for entity_id in entities:
+            row = table.get(entity_id)
+            label = _travel_entity_label(self.hass, entity_id)
+            if row:
+                lines.append(
+                    f"- {label}: **{row.get('full_travel_seconds')}s** "
+                    f"({row.get('source')})"
+                )
+            elif is_assumed_state(self.hass.states.get(entity_id)):
+                lines.append(f"- {label}: ⚠️ not measurable — enter a time manually")
+            else:
+                lines.append(f"- {label}: not calibrated")
+        return "\n".join(lines) or "(no covers configured)"
+
+    async def async_step_calibration(self, user_input: dict[str, Any] | None = None):
+        """Group the position-curve and travel-time calibration surfaces."""
+        menu_options = ["travel_time"]
+        # Same condition the top-level menu used before this step existed: the
+        # interpolation page is only meaningful once the feature is switched on.
+        if self.options.get(CONF_INTERP):
+            menu_options.append("interp")
+        menu_options.append("init")
+        return self.async_show_menu(step_id="calibration", menu_options=menu_options)
+
+    async def async_step_travel_time(self, user_input: dict[str, Any] | None = None):
+        """Travel-time calibration: measure, enter by hand, or clear."""
+        coordinator = self._coordinator()
+        running = coordinator is not None and coordinator.travel_calibration.is_running
+        # Never offer both: starting a second run is a no-op, and hiding the
+        # start entry is clearer than letting it be pressed and do nothing.
+        menu_options = ["travel_time_cancel"] if running else ["travel_time_run"]
+        menu_options += ["travel_time_manual", "travel_time_reset", "calibration"]
+        return self.async_show_menu(
+            step_id="travel_time",
+            menu_options=menu_options,
+            description_placeholders={"travel_time_status": self._travel_time_status()},
+        )
+
+    async def async_step_travel_time_run(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Start a measurement run in the background and return to the menu.
+
+        Fire-and-forget on purpose. The run drives every cover stop-to-stop and
+        takes minutes; awaiting it here would hold the config-flow dialog open
+        for the duration. Returning to the menu (rather than aborting the flow)
+        also preserves any edits made earlier in this session.
+        """
+        coordinator = self._coordinator()
+        if coordinator is not None:
+            self.hass.async_create_task(coordinator.async_run_travel_calibration())
+        return await self.async_step_travel_time()
+
+    async def async_step_travel_time_cancel(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Stop an in-flight run and send the covers back where they started."""
+        coordinator = self._coordinator()
+        if coordinator is not None:
+            coordinator.async_cancel_travel_calibration(restore=True)
+        return await self.async_step_travel_time()
+
+    async def async_step_travel_time_reset(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Clear every stored travel time for this instance."""
+        # Mark every affected entity edited so the save-time merge treats this
+        # session as authoritative for them — otherwise the live table would be
+        # merged straight back over the clear.
+        self._travel_time_edited.update(self._travel_table())
+        self._travel_time_edited.update(self.options.get(CONF_ENTITIES) or [])
+        self.options[CONF_TRAVEL_TIME_CALIBRATION] = {}
+        return await self.async_step_travel_time()
+
+    async def async_step_travel_time_manual(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Type a travel time per cover — the only path for unmeasurable covers.
+
+        ``0`` clears an entry. That is why the field is a BOX rather than the
+        SLIDER the guidelines prescribe for optional numerics: the rule exists
+        because BOX turns a cleared field into ``0``, and here ``0`` is *defined*
+        as cleared, so the ambiguity it guards against cannot arise — while a
+        0–300 s slider would make entering a value like 23.5 needlessly fiddly.
+        """
+        entities = list(self.options.get(CONF_ENTITIES) or [])
+        if user_input is not None:
+            table = self._travel_table()
+            for entity_id in entities:
+                submitted = user_input.get(entity_id)
+                submitted = float(submitted) if submitted else None
+                stored = (table.get(entity_id) or {}).get("full_travel_seconds")
+                stored = float(stored) if stored else None
+                # Only a value the user actually CHANGED counts as an edit. The
+                # form carries one field per cover and submits all of them, so
+                # marking every field edited would make opening this page to set
+                # one cover claim authority over the rest — and the save-time
+                # merge would then overwrite a concurrent measurement of a cover
+                # the user never touched, collapsing a per-entity merge into an
+                # all-or-nothing one.
+                if submitted == stored:
+                    continue
+                self._travel_time_edited.add(entity_id)
+                if submitted is None:
+                    table.pop(entity_id, None)
+                    continue
+                table[entity_id] = TravelCalibration(
+                    full_travel_seconds=submitted,
+                    calibrated_at=dt_util.utcnow().isoformat(),
+                    source=TRAVEL_CALIBRATION_SOURCE_MANUAL,
+                ).to_dict()
+            self.options[CONF_TRAVEL_TIME_CALIBRATION] = table
+            return await self.async_step_travel_time()
+
+        table = self._travel_table()
+        suggested = {
+            entity_id: (table.get(entity_id) or {}).get("full_travel_seconds") or 0
+            for entity_id in entities
+        }
+        return self.async_show_form(
+            step_id="travel_time_manual",
+            data_schema=self.add_suggested_values_to_schema(
+                _travel_time_manual_schema(entities), suggested
+            ),
+            description_placeholders={
+                "cover_list": self._travel_time_status(),
+            },
+        )
+
     async def async_step_interp(self, user_input: dict[str, Any] | None = None):
         """Show interpolation options."""
         if user_input is not None:
@@ -6349,7 +6601,7 @@ class OptionsFlowHandler(OptionsFlow):
                     },
                 )
             self.options.update(user_input)
-            return await self.async_step_init()
+            return await self.async_step_calibration()
         return self.async_show_form(
             step_id="interp",
             data_schema=self.add_suggested_values_to_schema(
@@ -6498,10 +6750,45 @@ class OptionsFlowHandler(OptionsFlow):
         """Save and exit the options flow."""
         return await self._update_options()
 
+    def _merge_travel_time(self) -> None:
+        """Rebase the travel-time table on the live entry before saving.
+
+        ``self.options`` is a snapshot taken when this flow opened, and
+        ``async_create_entry`` writes it back wholesale. The travel-time table is
+        the one key that is also written from OUTSIDE the flow: a calibration run
+        started from the Travel Time menu keeps going while the user carries on
+        editing, and finishes by writing its results straight to the entry.
+        Saving the snapshot as-is would silently erase everything it measured.
+
+        So the live table wins by default, and only the entities this session
+        actually touched are re-applied on top. Per-entity, not all-or-nothing:
+        a manual time typed for cover A and a measurement taken for cover B in
+        the same window must both survive.
+
+        Also drops rows for covers this instance no longer controls — the same
+        prune the calibrator does at run start, applied here so removing a cover
+        cleans up even without a run.
+        """
+        live = dict(self._config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {})
+        session = self.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
+        for entity_id in self._travel_time_edited:
+            edited = session.get(entity_id)
+            if edited is None:
+                live.pop(entity_id, None)
+            else:
+                live[entity_id] = edited
+        entities = set(self.options.get(CONF_ENTITIES) or [])
+        merged = {eid: row for eid, row in live.items() if eid in entities}
+        if merged:
+            self.options[CONF_TRAVEL_TIME_CALIBRATION] = merged
+        else:
+            self.options.pop(CONF_TRAVEL_TIME_CALIBRATION, None)
+
     async def _update_options(self) -> FlowResult:
         """Update config entry options."""
         self._recompute_profile_overrides()
         self._propagate_profile_clears()
+        self._merge_travel_time()
         if self._cover_type_changed:
             self._persist_entry(commit_cover_type=True)
         return self.async_create_entry(title="", data=self.options)  # type: ignore[return-value]

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1578,13 +1578,16 @@ DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 360  # seconds
 # restore, so per-move alone would let a jammed shade hold the covers for the
 # better part of an hour.
 #
-# It exists because ``CoverCommandService.calibrating`` is an ABSOLUTE gate: it
-# outranks is_safety and force, so for as long as a run holds the covers a
-# weather retract cannot reach them. That trade is only defensible while "as
-# long as a run holds the covers" is a short, known quantity — which is what
-# this constant makes it. Expiry stands the run down exactly as a cancel does,
-# restore included.
-TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS = 900  # seconds — 15 minutes
+# Sized to fit the band the manual field advertises: a day/night rail pair costs
+# two clearance parks plus six legs, so at TRAVEL_TIME_MAX_SECONDS apiece a
+# legitimate run of the slowest covers this integration claims to support needs
+# most of an hour. A tighter budget would make the top of that band impossible
+# to measure while still being offered.
+#
+# Affordable because ``calibrating`` is NOT an absolute gate: a safety target
+# stands the run down and proceeds, so a long budget delays ordinary automation
+# — which the user chose when they started the run — and never a storm.
+TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS = 3600  # seconds — 1 hour
 
 # Separate allowance for the go-home pass, granted when it starts rather than
 # taken out of whatever the measurement phase left over. The restore is the pass

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1572,6 +1572,20 @@ CONF_TRAVEL_TIME_CALIBRATION = "travel_time_calibration"
 # band the manual field advertises would be a range no measurement could reach.
 DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 360  # seconds
 
+# Ceiling on a WHOLE run, across every cover and every leg. The per-move budget
+# above bounds one stuck move; this bounds the run, and the two are not the same
+# number by a wide margin — a Model C pair costs up to eight moves plus a
+# restore, so per-move alone would let a jammed shade hold the covers for the
+# better part of an hour.
+#
+# It exists because ``CoverCommandService.calibrating`` is an ABSOLUTE gate: it
+# outranks is_safety and force, so for as long as a run holds the covers a
+# weather retract cannot reach them. That trade is only defensible while "as
+# long as a run holds the covers" is a short, known quantity — which is what
+# this constant makes it. Expiry stands the run down exactly as a cancel does,
+# restore included.
+TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS = 900  # seconds — 15 minutes
+
 # How long the seed leg waits for a no-position cover to publish a transit
 # state before declaring it unobservable. Covers the actuator start-up lag that
 # VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS exists for, with headroom — a
@@ -1621,6 +1635,7 @@ REASON_IMPLAUSIBLE_RESULT = "implausible_result"
 REASON_CLEARANCE_FAILED = "clearance_failed"
 # Dispatch label the go-home pass carries into the policy's clearance gate.
 REASON_RESTORE = "travel_calibration_restore"
+REASON_RUN_BUDGET_EXCEEDED = "run_budget_exceeded"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1586,6 +1586,15 @@ DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 360  # seconds
 # restore included.
 TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS = 900  # seconds — 15 minutes
 
+# Separate allowance for the go-home pass, granted when it starts rather than
+# taken out of whatever the measurement phase left over. The restore is the pass
+# that puts covers back, and it is the one pass that must never be cut short:
+# starved of time its waits return instantly, so a coupled cover the clearance
+# gate defers is never re-offered and is abandoned at a mechanical stop. It is
+# still bounded — the gate is held for its duration too — just not by the
+# leftovers of a budget the measurement phase may already have spent.
+TRAVEL_CALIBRATION_RESTORE_BUDGET_SECONDS = 300  # seconds — 5 minutes
+
 # How long the seed leg waits for a no-position cover to publish a transit
 # state before declaring it unobservable. Covers the actuator start-up lag that
 # VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS exists for, with headroom — a

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1568,7 +1568,9 @@ CONF_TRAVEL_TIME_CALIBRATION = "travel_time_calibration"
 # Per-move ceiling for one calibration leg. Generous: a slow patio awning can
 # take well over a minute, and the run aborts the ENTITY (not the batch) when
 # this expires, so an over-tight value silently drops covers from the results.
-DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 180  # seconds
+# Must exceed TRAVEL_TIME_MAX_SECONDS plus actuator dead time, or the top of the
+# band the manual field advertises would be a range no measurement could reach.
+DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 360  # seconds
 
 # How long the seed leg waits for a no-position cover to publish a transit
 # state before declaring it unobservable. Covers the actuator start-up lag that

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1584,9 +1584,11 @@ DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 360  # seconds
 # most of an hour. A tighter budget would make the top of that band impossible
 # to measure while still being offered.
 #
-# Affordable because ``calibrating`` is NOT an absolute gate: a safety target
-# stands the run down and proceeds, so a long budget delays ordinary automation
-# — which the user chose when they started the run — and never a storm.
+# The gate a run holds IS absolute — a safety target waits too — so this hour is
+# also the longest anything can be held off. Acceptable only because the run
+# says so the whole time it is happening: the control status reads
+# ``calibrating``, the options flow's Travel Time page shows the state and
+# offers Cancel, and this budget ends the run regardless.
 TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS = 3600  # seconds — 1 hour
 
 # Separate allowance for the go-home pass, granted when it starts rather than
@@ -1913,6 +1915,10 @@ class ControlStatus:
     """
 
     ACTIVE = "active"  # actively tracking the sun / running automation
+    # A travel-time calibration run owns the covers. Reported first, because
+    # while it holds them nothing else commands them — including safety — and
+    # "why is nothing moving?" has exactly one answer for the duration.
+    CALIBRATING = "calibrating"
     OUTSIDE_TIME_WINDOW = "outside_time_window"  # outside start/end window
     POSITION_DELTA_TOO_SMALL = "position_delta_too_small"  # < CONF_DELTA_POSITION
     TIME_DELTA_TOO_SMALL = "time_delta_too_small"  # < CONF_DELTA_TIME

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -41,6 +41,7 @@ Section index
 18. Manual Override & Transit
 19. Motion Control
 20. Position Verification
+20a. Travel Time Calibration
 21. Venetian Dual-Axis Sequencing
 22. Debug & Diagnostics
 23. Control Status (diagnostic enum)
@@ -1535,6 +1536,77 @@ MAX_POSITION_RETRIES = 3  # maximum re-send attempts before giving up
 # Default for CONF_ENABLE_POSITION_MATCHING (issue #591). False = matching off:
 # command once, no resend; a settle past tolerance becomes a manual override.
 DEFAULT_ENABLE_POSITION_MATCHING = False
+
+
+# =============================================================================
+# 20a. Travel Time Calibration
+# =============================================================================
+# How long a cover takes to traverse its full range, measured once and reused
+# to model where it IS while it is moving.
+#
+# NB the name. "Calibration" already means the position INTERPOLATION curve in
+# this codebase (CONF_INTERP / interp_lo / interp_hi, rendered as
+# "Calibration {lo}→{hi}"). Everything in this section is TRAVEL TIME
+# calibration and says so in its name — the two are unrelated and must stay
+# greppable apart.
+
+# Derived per-entity travel data. NOT a user-authored scalar, so it has no
+# OPTION_RANGES row (that map is keyed by top-level option key) and no
+# config-flow selector of its own. Shape:
+#
+#   {entity_id: {"full_travel_seconds": float,     # headline / manual / fallback
+#                "open_seconds": float | None,     # sweep toward axis value_max
+#                "close_seconds": float | None,    # sweep toward axis value_min
+#                "start_delay_seconds": float,     # command → motion observed
+#                "calibrated_at": "<iso>",
+#                "source": "measured" | "manual"}}
+#
+# One table for both sources so every consumer has a single path; ``source`` is
+# display-only and must never be branched on for behaviour.
+CONF_TRAVEL_TIME_CALIBRATION = "travel_time_calibration"
+
+# Per-move ceiling for one calibration leg. Generous: a slow patio awning can
+# take well over a minute, and the run aborts the ENTITY (not the batch) when
+# this expires, so an over-tight value silently drops covers from the results.
+DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS = 180  # seconds
+
+# How long the seed leg waits for a no-position cover to publish a transit
+# state before declaring it unobservable. Covers the actuator start-up lag that
+# VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS exists for, with headroom — a
+# cover that has not begun moving by now never will report that it did.
+TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS = 10  # seconds
+
+# Cadence at which a proxy cover republishes its estimated position while a
+# travel plan is live (cover.py). 1 s is what an HA cover card needs to animate
+# visibly; the timer runs ONLY while at least one plan exists, never at idle.
+TRAVEL_CALIBRATION_TICK_SECONDS = 1  # seconds
+
+# Bounds for a manually entered travel time. Consumed by BOTH the options-flow
+# selector and the calibrator's sanity clamp, so a value the UI accepts can
+# never be one the manager rejects. 0 is outside the band on purpose: the
+# options-flow field treats it as "unset", never as a zero-second travel.
+TRAVEL_TIME_MIN_SECONDS = 1.0
+TRAVEL_TIME_MAX_SECONDS = 300.0
+
+# Run lifecycle, as reported by the travel_calibration diagnostic sensor.
+TRAVEL_CALIBRATION_STATE_IDLE = "idle"
+TRAVEL_CALIBRATION_STATE_RUNNING = "running"
+TRAVEL_CALIBRATION_STATE_COMPLETE = "complete"
+TRAVEL_CALIBRATION_STATE_FAILED = "failed"
+TRAVEL_CALIBRATION_STATE_CANCELLED = "cancelled"
+
+# Per-entity outcome within a run.
+TRAVEL_CALIBRATION_STATUS_OK = "ok"
+TRAVEL_CALIBRATION_STATUS_TIMEOUT = "timeout"
+TRAVEL_CALIBRATION_STATUS_UNAVAILABLE = "unavailable"
+# The cover cannot be watched: HA reports assumed_state, or it exposes no
+# position axis and never publishes a transit state. Timing it would measure
+# service-call latency, not travel. Manual entry is the only path for these.
+TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE = "skipped_unobservable"
+
+# Where a table row came from. Display-only (see CONF_TRAVEL_TIME_CALIBRATION).
+TRAVEL_CALIBRATION_SOURCE_MEASURED = "measured"
+TRAVEL_CALIBRATION_SOURCE_MANUAL = "manual"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1608,6 +1608,18 @@ TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE = "skipped_unobservable"
 TRAVEL_CALIBRATION_SOURCE_MEASURED = "measured"
 TRAVEL_CALIBRATION_SOURCE_MANUAL = "manual"
 
+# Why an entity ended up with the status it did, as recorded on its result row
+# and rendered by the travel_calibration sensor. Named rather than free text so
+# the sites that write them, the sensor that shows them and the tests that
+# assert on them cannot drift.
+REASON_ASSUMED_STATE = "assumed_state"
+REASON_NO_MOTION_OBSERVED = "no_motion_observed"
+REASON_NO_ENTITIES = "no_entities"
+REASON_IMPLAUSIBLE_RESULT = "implausible_result"
+REASON_CLEARANCE_FAILED = "clearance_failed"
+# Dispatch label the go-home pass carries into the policy's clearance gate.
+REASON_RESTORE = "travel_calibration_restore"
+
 
 # =============================================================================
 # 21. Venetian Dual-Axis Sequencing

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -665,6 +665,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             get_travel_calibration=lambda eid: (
                 self.config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
             ).get(eid),
+            # A safety target stands a calibration run down rather than being
+            # blocked by it. ``restore=False``: the safety command is about to
+            # move the cover anyway, so sending it home first would be movement
+            # in the wrong direction at the worst moment.
+            on_safety_preempt=lambda: self.async_cancel_travel_calibration(
+                restore=False
+            ),
         )
 
         # Wire the manual-override engine's edge + origin seams once. Any

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -38,7 +38,7 @@ except ImportError:
     # Fallback for older Home Assistant versions
     EventStateChangedData = dict  # type: ignore[misc,assignment]
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
@@ -99,6 +99,8 @@ from .const import (
     CONF_SUNSET_OFFSET,
     CONF_SUNSET_POS,
     CONF_TRANSIT_TIMEOUT,
+    CONF_TRAVEL_TIME_CALIBRATION,
+    TRAVEL_CALIBRATION_TICK_SECONDS,
     CUSTOM_POSITION_SAFETY_PRIORITY,
     CUSTOM_POSITION_SLOTS,
     DEFAULT_CUSTOM_POSITION_ENABLED,
@@ -148,6 +150,7 @@ from .managers.sensor_health import SensorHealthManager
 from .managers.weather import WeatherManager
 from .managers.time_window import TimeWindowManager
 from .managers.toggles import ToggleManager
+from .managers.travel_calibration import TravelTimeCalibrator
 from .position_utils import flip_if, interpolate_position, inverse_state
 from .pipeline.handlers import (
     ManualOverrideHandler,
@@ -650,8 +653,18 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # coordinator's debug-categories gate (INFO when debug_mode +
             # category enabled, otherwise DEBUG).
             debug_log=self._debug_log,
-            # Clock the post-command window for time-based override detectors.
-            on_command_sent=self.manager.note_command_sent,
+            # Clock the post-command window for time-based override detectors,
+            # and start the travel-ramp republish tick if this dispatch created
+            # a plan.
+            on_command_sent=self._on_command_sent,
+            # Travel-time row for one entity, read live from options at each
+            # dispatch. A per-cycle snapshot would serve stale numbers for a
+            # whole cycle after a calibration run or a manual edit rewrites the
+            # table out-of-band, and the table changes far too rarely to be
+            # worth caching.
+            get_travel_calibration=lambda eid: (
+                self.config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
+            ).get(eid),
         )
 
         # Wire the manual-override engine's edge + origin seams once. Any
@@ -740,6 +753,22 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             schedule_refresh_after=self._schedule_refresh_after,
         )
 
+        # Travel-time calibration. Built here because it drives covers through
+        # the command service and reads the same policy the dispatch path uses;
+        # it stays idle until something asks it to run.
+        self._travel_calibrator = TravelTimeCalibrator(
+            self.hass,
+            self.logger,
+            cmd_svc=self._cmd_svc,
+            policy=self._policy,
+            # Resolved live, not captured: a run can start long after setup, and
+            # the cover list and rail roles may have changed in between.
+            get_entities=lambda: list(self.entities or []),
+            get_options=lambda: self.config_entry.options,
+            persist=self._async_persist_travel_calibration,
+            on_progress=self.async_update_listeners,
+        )
+
         # Window-transition tracker — owns sun-visibility and astronomical
         # sunset-window transition state (extracted from coordinator in Phase E).
         self._window_tracker = WindowTransitionTracker(
@@ -763,6 +792,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # ``async_track_time_interval`` cancel handle.
         self._position_forecast: Forecast | None = None
         self._forecast_unsub: Callable[[], None] | None = None
+
+        # Cancel handle for the travel-ramp republish tick. Non-None ONLY while
+        # at least one cover has a live travel plan — see ``_sync_travel_tick``.
+        self._travel_tick_unsub: Callable[[], None] | None = None
 
         # Issue #547: cached forecast daily-high (°) for the configured weather
         # entity, refreshed on a slow wall-clock cadence by
@@ -3662,6 +3695,110 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.state_change = True
         await self.async_refresh()
 
+    async def async_apply_travel_calibration_update(self) -> None:
+        """Take up a new travel-time table without reloading the entry.
+
+        Registered in ``_RUNTIME_APPLICABLE_OPTIONS``. Without it, every write —
+        and a calibration run writes once per pass — would reload the config
+        entry, tearing down the very run that produced the numbers.
+
+        No pipeline rebuild: the table changes nothing about how a position is
+        decided, only how an in-flight move is rendered. Refreshing
+        ``_cached_options`` is what keeps the listener's next reload/apply
+        comparison honest.
+        """
+        self._cached_options = dict(self.config_entry.options)
+        self.async_update_listeners()
+        await self.async_refresh()
+
+    async def _async_persist_travel_calibration(
+        self, table: dict[str, dict[str, Any]]
+    ) -> None:
+        """Write the finished travel-time table back to the config entry."""
+        from .services.options_service import apply_options_patch  # noqa: PLC0415
+
+        await apply_options_patch(
+            self.hass, self, {CONF_TRAVEL_TIME_CALIBRATION: table or None}
+        )
+
+    async def async_run_travel_calibration(self) -> None:
+        """Measure every configured cover's travel time (Calibration menu).
+
+        Runs the covers to their mechanical stops and back — several minutes of
+        movement — so it is deliberately reachable only from the options flow,
+        never from a dashboard entity that could be pressed by accident.
+        """
+        await self._travel_calibrator.async_run()
+
+    @callback
+    def async_cancel_travel_calibration(self, *, restore: bool = True) -> bool:
+        """Stop a calibration run. Returns whether there was one to stop.
+
+        ``restore=False`` is the panic-stop path: stand down without issuing the
+        go-home moves, because more movement is exactly what that caller is
+        trying to prevent.
+        """
+        return self._travel_calibrator.async_cancel(restore=restore)
+
+    @property
+    def travel_calibration(self) -> TravelTimeCalibrator:
+        """The travel-time calibrator, for the options flow and the sensor."""
+        return self._travel_calibrator
+
+    def travel_estimated_position(self, entity_id: str) -> int | None:
+        """Modelled position of ``entity_id`` mid-move, or None when it is idle.
+
+        Display-only (§3b): never merged into the position the command gates
+        read. Consumed by the proxy cover, which republishes it so ordinary HA
+        cover cards animate.
+        """
+        return self._cmd_svc.estimated_position(entity_id)
+
+    @callback
+    def _on_command_sent(self, entity_id: str) -> None:
+        """React to an outbound command: clock detectors, and start the tick.
+
+        The dispatch chokepoint is also where a travel plan is created, so this
+        is the earliest moment the republish tick can be needed.
+        """
+        self.manager.note_command_sent(entity_id)
+        self._sync_travel_tick()
+
+    @callback
+    def _sync_travel_tick(self) -> None:
+        """Run the 1 s republish timer exactly while some cover is mid-ramp.
+
+        A travel plan is a clock-driven model, so nothing else would prompt a
+        redraw between the command and the arrival — the proxy would show one
+        frozen frame for the whole move. The timer therefore exists only for the
+        duration of actual movement: it must never be left running at idle,
+        where it would be a state write per second per instance forever.
+        """
+        active = self._cmd_svc.has_travel_plans()
+        if active and self._travel_tick_unsub is None:
+            self._travel_tick_unsub = async_track_time_interval(
+                self.hass,
+                self._travel_tick,
+                dt.timedelta(seconds=TRAVEL_CALIBRATION_TICK_SECONDS),
+            )
+        elif not active:
+            self._stop_travel_tick()
+
+    @callback
+    def _stop_travel_tick(self) -> None:
+        """Cancel the republish timer if it is running."""
+        if self._travel_tick_unsub is not None:
+            self._travel_tick_unsub()
+            self._travel_tick_unsub = None
+
+    @callback
+    def _travel_tick(self, _now: dt.datetime) -> None:
+        """Redraw the ramp, then decide whether another tick is warranted."""
+        self.async_update_listeners()
+        # Self-limiting: the tick after the last plan clears is the one that
+        # cancels the timer, so no other code path has to remember to.
+        self._sync_travel_tick()
+
     def _build_pipeline(self) -> PipelineRegistry:
         """Build the override pipeline from the registry of handler factories.
 
@@ -4494,10 +4631,18 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             cover_entities, self._policy, assumed=self._cmd_svc.get_assumed_position
         )
         _caps = self._cover_provider.read_all_capabilities(cover_entities)
+        _travel_plans = self._cmd_svc.travel_plans()
+        _estimated = self._cmd_svc.estimated_positions()
         _covers = {
             eid: {
                 "current_position": _positions.get(eid),
                 "transit_state": self._cmd_svc.get_transit_direction(eid),
+                # Where the travel-time model says the cover is right now, and
+                # the ramp it came from. Display-only siblings of transit_state:
+                # both are present only mid-move, and neither is ever read back
+                # by a command gate.
+                "estimated_position": _estimated.get(eid),
+                "travel_plan": _travel_plans.get(eid),
                 "available": _positions.get(eid) is not None,
                 "ha_state": getattr(self.hass.states.get(eid), "state", None),
                 "capabilities": (
@@ -5418,6 +5563,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._sun_tracking_gate_unsub is not None:
             self._sun_tracking_gate_unsub()
             self._sun_tracking_gate_unsub = None
+
+        # Stand down a calibration run and its republish tick. The run holds
+        # ``calibrating`` on the command service, so an unload that left it
+        # going would keep that flag set on an orphaned object.
+        self.async_cancel_travel_calibration(restore=False)
+        self._stop_travel_tick()
 
         # Cancel any in-flight external-command interlock correction (#1138).
         # Each is a config-entry task, so HA would wait on it during unload;

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -665,13 +665,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             get_travel_calibration=lambda eid: (
                 self.config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
             ).get(eid),
-            # A safety target stands a calibration run down rather than being
-            # blocked by it. ``restore=False``: the safety command is about to
-            # move the cover anyway, so sending it home first would be movement
-            # in the wrong direction at the worst moment.
-            on_safety_preempt=lambda: self.async_cancel_travel_calibration(
-                restore=False
-            ),
         )
 
         # Wire the manual-override engine's edge + origin seams once. Any
@@ -4698,6 +4691,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             start_time=self._time_mgr.start_time_value,
             end_time=self._end_time,
             automatic_control=self.automatic_control,
+            calibrating=self._cmd_svc.calibrating,
             last_cover_action=self.last_cover_action,
             last_skipped_action=self.last_skipped_action,
             min_change=self.min_change,

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -209,7 +209,24 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         mapped back here — the read side of the same predicate
         ``_to_cover_frame`` uses, which is what keeps the round trip closed
         (#1027 / #1028).
+
+        **While the source is mid-move and its travel time is known**, this
+        reports the modelled position from the travel plan instead of the last
+        mirrored reading. That is the whole reason the proxy is worth animating:
+        the source covers that need it are precisely the ones whose own reading
+        is stale (published once a second at best) or absent (open/close-only
+        hardware), and every generic HA cover card renders from this number.
+
+        The estimate is a model. A source that stalls mid-travel will be
+        reported as continuing, and arriving. That is strictly better than the
+        frozen or missing value it replaces, and it self-corrects the moment the
+        move ends and the plan clears.
         """
+        estimated = self.coordinator.travel_estimated_position(self._source_entity_id)
+        if estimated is not None:
+            # Already logical: the plan's endpoints were captured in the source's
+            # own frame, so it needs the same un-inversion as a live reading.
+            return flip_if(estimated, inverted=self.coordinator.position_axis_inverted)
         return self._logical_axis_value(
             STATE_ATTR_POSITION, inverted=self.coordinator.position_axis_inverted
         )
@@ -247,6 +264,20 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         if pos is None:
             return None
         return pos == 0
+
+    def _acp_render_signature(self) -> object:
+        """Include the position, which the base signature cannot see.
+
+        The base builds its signature from ``state`` plus
+        ``extra_state_attributes``. For a cover, ``state`` is only
+        open/closed/opening/closing and the position is a native property, not
+        an extra attribute — so a pure position change produces an identical
+        signature and the write is suppressed. That is harmless for a mirrored
+        reading (the source event path writes it), but it would swallow every
+        frame of the travel ramp, whose redraws arrive as coordinator updates
+        from the republish tick and change nothing else.
+        """
+        return (*super()._acp_render_signature(), self.current_cover_position)
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to source state changes once mounted."""

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -224,8 +224,9 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         """
         estimated = self.coordinator.travel_estimated_position(self._source_entity_id)
         if estimated is not None:
-            # Already logical: the plan's endpoints were captured in the source's
-            # own frame, so it needs the same un-inversion as a live reading.
+            # The plan's endpoints were captured in the SOURCE's frame — the same
+            # cover-frame numbers the raw attribute carries — so the estimate
+            # owes the reader exactly the same un-inversion a live reading does.
             return flip_if(estimated, inverted=self.coordinator.position_axis_inverted)
         return self._logical_axis_value(
             STATE_ATTR_POSITION, inverted=self.coordinator.position_axis_inverted

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -1102,6 +1102,41 @@ class CoverTypePolicy(ABC):
         cover type whose entities are physically independent.
         """
         return None
+
+    def travel_calibration_clearance(
+        self,
+        subject: str,  # noqa: ARG002
+        entities: Sequence[str],  # noqa: ARG002
+        options: Mapping[str, Any] | None,  # noqa: ARG002
+    ) -> dict[str, int]:
+        """Where coupled entities must be parked before ``subject`` can sweep.
+
+        The third member of the coupled-entity family, alongside
+        :meth:`await_dispatch_clearance` ("may this move start yet?") and
+        :meth:`plan_external_command_interlock` ("what would unblock this
+        move?"). This one answers a question only travel-time calibration asks:
+        a normal command moves a cover part-way, but calibration must drive it
+        from one mechanical stop to the other and time the result — so anything
+        physically in the way has to be moved out first, once, before the run's
+        legs begin.
+
+        Returns ``{entity_id: wire position}``. **Wire**, not logical: the
+        calibrator hands these straight to
+        ``CoverCommandService._execute_command``, whose contract is "already
+        transformed". A policy that reasons in open-percent must apply
+        :func:`axis_inverted` itself — the calibrator has no frame knowledge and
+        must not acquire any.
+
+        ``options`` is passed rather than read from any per-cycle cache the
+        policy keeps. A calibration run can be started from the options flow
+        before a single update cycle has primed those caches, and a stale prime
+        would park the wrong entity — which, for stacked rails, means driving
+        one into the other.
+
+        Liskov-safe default: ``{}`` — nothing to move, which is every cover type
+        whose entities are physically independent.
+        """
+        return {}
 
     async def after_position_command(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -375,13 +375,23 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         control-model precedent (#1114).
         """
         self._set_control_model(options)
-        # The rail role is a per-instance option like any other, and this is the
-        # seam for those. ``_cache_dual_entity`` also writes it once a pipeline
-        # result exists, but that is per-CYCLE: anything asking the clearance
-        # gate before the first cycle — a travel-time calibration started from
-        # the options flow — would otherwise find no middle rail configured and
-        # be told every rail is free to move.
+        # The rail role and the inversion frame are per-instance options like any
+        # other, and this is the seam for those. ``_cache_dual_entity`` also
+        # writes both once a pipeline result exists, but that is per-CYCLE:
+        # anything asking the clearance gate before the first cycle — a
+        # travel-time calibration started from the options flow — would
+        # otherwise find no middle rail configured and be told every rail is
+        # free to move.
+        #
+        # The two MUST be primed together. The role alone turns the gate from
+        # inert to active while leaving the frame at its ``__init__`` default of
+        # upright, and a token-less caller resolves the frame through
+        # ``_dispatch_frame(None)`` — so on an inverse-state install the gate
+        # would answer confidently and backwards, waving the middle rail down
+        # through the bottom rail (the #993 bug class). Identical expression to
+        # the per-cycle write, so priming early can only make it more current.
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
+        self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_concurrent_travel = bool(
             options.get(
                 CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -17,7 +17,7 @@ math is replaced by a pure fabric-choice decision keyed on the season.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -2103,6 +2103,62 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             dispatch_token=dispatch_token,
             is_middle=is_middle,
         )
+
+    def travel_calibration_clearance(
+        self,
+        subject: str,
+        entities: Sequence[str],
+        options: Mapping[str, Any] | None,
+    ) -> dict[str, int]:
+        """Park the partner rail so ``subject`` can sweep its whole range (Model C).
+
+        Timing a rail means driving it stop-to-stop, and the two rails share one
+        track under the no-pass invariant (``middle% >= bottom%`` in open-percent
+        space). Each rail therefore has exactly one place its partner has to be:
+
+        * the **bottom** rail can only rise to fully-open if the middle rail is
+          already fully open — otherwise it would have to travel through it;
+        * the **middle** rail can only drop to fully-closed if the bottom rail
+          is already fully closed, for the same reason.
+
+        Both parking moves are legal from *any* starting geometry — raising the
+        middle and lowering the bottom each strictly widen the gap between them —
+        so this never has to reason about where the rails currently sit. It also
+        makes the two subjects order-independent: after the bottom rail's
+        closing leg it is already parked where the middle rail needs it.
+
+        Reads the model and the rail role straight out of ``options`` rather than
+        from ``_control_model`` / ``_dual_entity_middle_rail``. Those are primed
+        per update cycle, and a run can be started from the options flow before
+        any cycle has run — a stale prime here would park the wrong rail, which
+        for stacked rails means driving one into the other.
+
+        Returns WIRE positions: the open-percent endpoints above, put through
+        ``axis_inverted`` here, because the calibrator dispatches them verbatim
+        and holds no frame knowledge of its own (the #993 bug class).
+        """
+        opts = options or {}
+        if opts.get(CONF_DAY_NIGHT_CONTROL_MODEL) != DAY_NIGHT_MODEL_DUAL_ENTITY:
+            return {}
+        middle = opts.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
+        # An unconfigured or foreign middle rail is the same silent-degradation
+        # case the travel gate declines to act on: without knowing which rail is
+        # which there is no safe parking spot to name.
+        if not middle or middle not in entities:
+            return {}
+        bottom = next((eid for eid in entities if eid != middle), None)
+        if bottom is None:
+            return {}
+
+        axis = self.axes[0]
+        inverted = axis_inverted(axis, opts)
+        fully_open = flip_if(axis.value_max, inverted=inverted)
+        fully_closed = flip_if(axis.value_min, inverted=inverted)
+        if subject == bottom:
+            return {middle: fully_open}
+        if subject == middle:
+            return {bottom: fully_closed}
+        return {}
 
     def plan_external_command_interlock(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -375,6 +375,13 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         control-model precedent (#1114).
         """
         self._set_control_model(options)
+        # The rail role is a per-instance option like any other, and this is the
+        # seam for those. ``_cache_dual_entity`` also writes it once a pipeline
+        # result exists, but that is per-CYCLE: anything asking the clearance
+        # gate before the first cycle — a travel-time calibration started from
+        # the options flow — would otherwise find no middle rail configured and
+        # be told every rail is free to move.
+        self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
         self._dual_entity_concurrent_travel = bool(
             options.get(
                 CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -80,6 +80,8 @@ class DiagnosticContext:
 
     # Automation
     automatic_control: bool
+    # True while a travel-time calibration run holds the covers.
+    calibrating: bool = False
     last_cover_action: dict = field(default_factory=dict)
     last_skipped_action: dict = field(default_factory=dict)
     min_change: int = 1
@@ -420,6 +422,11 @@ class DiagnosticsBuilder:
     @staticmethod
     def _determine_control_status(ctx: DiagnosticContext) -> str:
         """Determine current control status from pipeline result."""
+        # First, and above automatic_control: a run blocks every command, so
+        # any other answer here would describe a decision that is not being
+        # acted on.
+        if ctx.calibrating:
+            return ControlStatus.CALIBRATING
         if not ctx.automatic_control:
             return ControlStatus.AUTOMATIC_CONTROL_OFF
 

--- a/custom_components/adaptive_cover_pro/icons.json
+++ b/custom_components/adaptive_cover_pro/icons.json
@@ -35,6 +35,15 @@
       }
     },
     "sensor": {
+      "travel_calibration": {
+        "default": "mdi:timer-cog-outline",
+        "state": {
+          "running": "mdi:timer-sand",
+          "complete": "mdi:timer-check-outline",
+          "failed": "mdi:timer-alert-outline",
+          "cancelled": "mdi:timer-off-outline"
+        }
+      },
       "control": {
         "default": "mdi:white-balance-sunny",
         "state": {

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -40,7 +40,13 @@ from .diagnostics import DiagnosticsRecorder
 from .position_context import PositionContextTracker
 from .routing import ServiceCallPlan, build_special_positions, route_service_call
 from .state_classifier import StateClassifier
-from .state_store import PerEntityState, PositionContext
+from .state_store import (
+    PerEntityState,
+    PositionContext,
+    TravelCalibration,
+    TravelPlan,
+    build_travel_plan,
+)
 from .stop import StopTracker
 
 __all__ = [
@@ -48,7 +54,10 @@ __all__ = [
     "PerEntityState",
     "PositionContext",
     "ServiceCallPlan",
+    "TravelCalibration",
+    "TravelPlan",
     "build_special_positions",
+    "build_travel_plan",
     "route_service_call",
 ]
 
@@ -109,6 +118,7 @@ class CoverCommandService:
         event_buffer=None,
         debug_log=None,
         on_command_sent=None,
+        get_travel_calibration=None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -151,6 +161,15 @@ class CoverCommandService:
                 manager asks it silently degrades to the default (issue #1115).
                 Omitted, a fresh instance is built from ``cover_type``, which is
                 still correct for the stateless axis/capability queries.
+            get_travel_calibration: Optional ``(entity_id) -> Mapping | None``
+                returning that entity's row from the ``travel_time_calibration``
+                option table, used to build a ``TravelPlan`` for each dispatched
+                move. A live callable rather than a cached copy: the table is
+                rewritten out-of-band by the calibrator and by the options flow's
+                manual-entry step, so a snapshot taken at construction (or once
+                per cycle) would serve stale numbers until the next reload.
+                Omitted, no travel plans are recorded and every estimated-position
+                surface stays empty — the pre-calibration behaviour.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -179,6 +198,17 @@ class CoverCommandService:
         self._wait_for_target_timeout_seconds = transit_timeout_seconds
         self._on_tick = on_tick
         self._on_command_sent = on_command_sent
+        self._get_travel_calibration = get_travel_calibration
+
+        # True while a travel-time calibration run owns the covers. Blocks every
+        # outbound command from ``apply_position`` and stands the reconciliation
+        # pass down, so automation cannot fight a run that is deliberately
+        # driving covers to their mechanical stops. Deliberately absolute — it
+        # outranks is_safety and force, because a safety command colliding with
+        # a rail mid-sweep is worse than a safety command deferred by the couple
+        # of minutes a run lasts. The escape hatch is the panic stop service,
+        # which cancels the run outright rather than racing it.
+        self._calibrating: bool = False
 
         # Per-entity positioning state — single source of truth.
         # All previously-parallel dicts/sets (target_call, _sent_at,
@@ -450,14 +480,17 @@ class CoverCommandService:
             self._clear_waiting(s)
 
     def _clear_waiting(self, s: PerEntityState) -> None:
-        """Clear the waiting flag and its synthetic transit direction together.
+        """Clear the waiting flag and every transit-scoped display value with it.
 
         Single funnel for every "no longer in transit" site so the
-        opening/closing indicator (``transit_direction``) never outlives the
-        ``waiting`` window it is gated on.
+        opening/closing indicator (``transit_direction``) and the position ramp
+        (``travel_plan``) never outlive the ``waiting`` window both are gated on.
+        A plan left behind here would keep a settled cover animating, and — via
+        ``has_travel_plans`` — keep the proxy cover's 1 s tick alive forever.
         """
         s.waiting = False
         s.transit_direction = None
+        s.travel_plan = None
 
     def waiting_entities(self) -> list[str]:
         """Return all entities currently in ``waiting=True``."""
@@ -593,6 +626,100 @@ class CoverCommandService:
         else:
             self.clear_transit_direction(entity_id)
 
+    # ------------------------------------------------------------------ #
+    # Travel plans — the position-vs-time model for an in-flight move.
+    # Same lifecycle as transit_direction above (written at the dispatch
+    # chokepoint, cleared by _clear_waiting, surfaced only while ``waiting``),
+    # but where that says only WHICH WAY a cover is going, this says where it
+    # should appear to be. Requires a travel-time calibration; absent one every
+    # surface here is empty and nothing changes.
+    # ------------------------------------------------------------------ #
+
+    def _record_travel_plan(
+        self,
+        entity_id: str,
+        *,
+        routed_target: int | None,
+        from_position: int | None,
+        started_at: dt.datetime,
+        caps: dict[str, bool] | None,
+    ) -> None:
+        """Model this dispatch as a ramp, or clear any stale one.
+
+        Always writes: a cover that loses its calibration, or moves to where it
+        already is, must not keep animating along the previous move's plan.
+        """
+        s = self.state(entity_id)
+        if self._get_travel_calibration is None:
+            s.travel_plan = None
+            return
+        axis = self._policy.select_default_axis(caps or {})
+        s.travel_plan = build_travel_plan(
+            self._get_travel_calibration(entity_id),
+            from_position=from_position,
+            to_position=routed_target,
+            started_at=started_at,
+            span=axis.value_max - axis.value_min,
+        )
+
+    def get_travel_plan(self, entity_id: str) -> TravelPlan | None:
+        """Return the in-flight ramp for ``entity_id``, or None.
+
+        Gated on ``waiting`` for the same reason ``transit_states`` is: a plan
+        recorded on a cover that has since settled describes a move that is over.
+        """
+        s = self._state.get(entity_id)
+        if s is None or not s.waiting:
+            return None
+        return s.travel_plan
+
+    def travel_plans(self) -> dict[str, dict[str, Any]]:
+        """Return ``{entity_id: payload}`` for every cover mid-ramp.
+
+        The companion card's contract — see ``TravelPlan.as_payload``.
+        """
+        return {
+            eid: s.travel_plan.as_payload()
+            for eid, s in self._state.items()
+            if s.waiting and s.travel_plan is not None
+        }
+
+    def has_travel_plans(self) -> bool:
+        """Whether any cover is mid-ramp right now.
+
+        Drives the proxy cover's republish timer (``cover.py``), which exists
+        only while this is True — hence a dedicated predicate rather than
+        ``bool(self.travel_plans())``, which would build and throw away a dict
+        of payloads once a second.
+        """
+        return any(
+            s.waiting and s.travel_plan is not None for s in self._state.values()
+        )
+
+    def estimated_position(
+        self, entity_id: str, now: dt.datetime | None = None
+    ) -> int | None:
+        """Modelled position of ``entity_id`` right now, or None if not moving.
+
+        DISPLAY ONLY. Never consulted by a command gate and never merged into
+        the position read the gates use (§3b): it is derived from a clock, not
+        from the cover, and putting it in front of the delta gates would let a
+        model decide whether to send a command.
+        """
+        plan = self.get_travel_plan(entity_id)
+        if plan is None:
+            return None
+        return plan.position_at(now or dt.datetime.now(dt.UTC))
+
+    def estimated_positions(self, now: dt.datetime | None = None) -> dict[str, int]:
+        """Return ``{entity_id: modelled position}`` for every cover mid-ramp."""
+        stamp = now or dt.datetime.now(dt.UTC)
+        return {
+            eid: s.travel_plan.position_at(stamp)
+            for eid, s in self._state.items()
+            if s.waiting and s.travel_plan is not None
+        }
+
     def begin_transit(self, entity_id: str, direction: str | None) -> None:
         """Open a transit-timeout window with a pre-computed direction.
 
@@ -685,6 +812,21 @@ class CoverCommandService:
         coordinator each update cycle from the Integration Enabled switch.
         """
         self._enabled = value
+
+    @property
+    def calibrating(self) -> bool:
+        """Whether a travel-time calibration run currently owns the covers."""
+        return self._calibrating
+
+    @calibrating.setter
+    def calibrating(self, value: bool) -> None:
+        """Hand the covers to (or back from) a calibration run.
+
+        Set by ``TravelTimeCalibrator`` around a run, and cleared in a ``finally``
+        so neither an exception nor a cancellation can leave automation switched
+        off with no visible cause.
+        """
+        self._calibrating = bool(value)
 
     @property
     def enable_position_matching(self) -> bool:
@@ -1427,6 +1569,24 @@ class CoverCommandService:
             return self._skip(
                 entity_id,
                 "integration_disabled",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=_current,
+            )
+
+        # Calibration gate — a travel-time run owns the covers while it is
+        # sweeping them to their mechanical stops, so nothing else may command
+        # them. Sits alongside the kill switch and shares its absoluteness:
+        # is_safety and force do NOT bypass it, because a safety command landing
+        # on a Model C rail mid-sweep drives a rail into a rail, and the run is
+        # bounded in minutes. A user who genuinely needs the covers back
+        # cancels the run (the panic stop service does exactly that), which is a
+        # decision rather than a collision.
+        if self._calibrating:
+            return self._skip(
+                entity_id,
+                "calibration_in_progress",
                 position,
                 trigger=_trigger,
                 inverse_state=_inverse,
@@ -2219,6 +2379,14 @@ class CoverCommandService:
         if not self._enabled:
             return
 
+        # A travel-time calibration run drives covers to their endpoints through
+        # ``_execute_command``, which books a target like any other dispatch.
+        # Left running, this pass would see those targets, judge the mid-sweep
+        # cover "off target", and resend — racing the run's own legs and
+        # corrupting the timings it is there to measure.
+        if self._calibrating:
+            return
+
         # Same policy-mandated dispatch order as every other fan-out seam
         # (issue #1115): a Model C day/night shade's bottom rail must be resent
         # before its middle rail, which cannot physically travel past it.
@@ -2725,6 +2893,18 @@ class CoverCommandService:
         # routed target. Uses the command-gate read (no assumed fallback) so the
         # comparison stays in the raw display frame.
         prior_position = self._read_position_with_capabilities(entity, caps)
+        # Origin for the travel ramp. Captured HERE, before
+        # ``_record_assumed_if_blind`` below overwrites the assumed store with
+        # THIS command's target — read afterwards it would report the
+        # destination as the starting point and every no-feedback cover would
+        # ramp from nowhere. The assumed fallback is what makes a manual travel
+        # time useful at all: on an open/close-only cover the live read is None,
+        # so without it the covers that most need a ramp would never get one.
+        travel_origin = (
+            prior_position
+            if prior_position is not None
+            else self.get_assumed_position(entity)
+        )
         s = self.state(entity)
         # The booking chokepoint: the target and the dispatch provenance that
         # explains it are recorded by the same call, so a resend can never be
@@ -2743,6 +2923,16 @@ class CoverCommandService:
         # holds. Runs before the dry-run early return so a dry-run cycle keeps
         # the display honest too.
         self._record_assumed_if_blind(entity, plan.routed_target, caps)
+        # Same chokepoint, same window, same clear (``_clear_waiting``) as the
+        # synthetic direction recorded just above — this adds the "how far along"
+        # the direction alone cannot express.
+        self._record_travel_plan(
+            entity,
+            routed_target=plan.routed_target,
+            from_position=travel_origin,
+            started_at=now,
+            caps=caps,
+        )
         s.waiting = True
         s.sent_at = now
         s.last_progress_at = None

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -119,7 +119,6 @@ class CoverCommandService:
         debug_log=None,
         on_command_sent=None,
         get_travel_calibration=None,
-        on_safety_preempt=None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -171,10 +170,6 @@ class CoverCommandService:
                 per cycle) would serve stale numbers until the next reload.
                 Omitted, no travel plans are recorded and every estimated-position
                 surface stays empty — the pre-calibration behaviour.
-            on_safety_preempt: Optional ``() -> None`` invoked when a safety
-                target is dispatched while a travel-time run holds the covers.
-                The coordinator wires it to cancel the run, so a storm never
-                waits for a calibration.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -204,11 +199,6 @@ class CoverCommandService:
         self._on_tick = on_tick
         self._on_command_sent = on_command_sent
         self._get_travel_calibration = get_travel_calibration
-        # Called when a safety target arrives while a calibration run holds the
-        # covers. Wired by the coordinator to cancel the run; ``None`` leaves the
-        # gate absolute, which is the right default for a service with no
-        # calibrator behind it.
-        self._on_safety_preempt = on_safety_preempt
 
         # True while a travel-time calibration run owns the covers. Blocks every
         # outbound command from ``apply_position`` and stands the reconciliation
@@ -1586,34 +1576,26 @@ class CoverCommandService:
             )
 
         # Calibration gate — a travel-time run owns the covers while it is
-        # sweeping them to their mechanical stops, so ordinary automation must
-        # not command them. ``force`` does not bypass it: a recurring resend has
-        # nothing to say that cannot wait a few minutes.
+        # sweeping them to their mechanical stops, so nothing else may command
+        # them. Sits alongside the kill switch and shares its absoluteness:
+        # is_safety and force do NOT bypass it, because a command landing on a
+        # coupled rail mid-sweep drives a rail into a rail, and a half-swept
+        # cover is in a position nothing else has reasoned about.
         #
-        # A SAFETY target does bypass it, by standing the run down first. The
-        # collision this gate exists to prevent — a command landing on a Model C
-        # rail mid-sweep — is better answered by stopping the run than by
-        # refusing the command: a safety dispatch still goes through the policy's
-        # own clearance gating, whereas a blocked one means a storm waits for a
-        # calibration. Cancelling with ``restore=False`` also stops the run
-        # issuing any further commands of its own, so the two never race.
+        # What makes that acceptable is that the run is never invisible or
+        # unstoppable: the control status reports ``calibrating`` for its whole
+        # duration, the options flow's Travel Time page says so and offers
+        # Cancel, and the run budget ends it regardless. A user who needs the
+        # covers back takes them back — a decision, rather than a collision.
         if self._calibrating:
-            if not context.is_safety:
-                return self._skip(
-                    entity_id,
-                    "calibration_in_progress",
-                    position,
-                    trigger=_trigger,
-                    inverse_state=_inverse,
-                    current_position=_current,
-                )
-            self._logger.warning(
-                "Safety target for %s pre-empting the travel-time calibration "
-                "run — standing the run down",
+            return self._skip(
                 entity_id,
+                "calibration_in_progress",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=_current,
             )
-            if self._on_safety_preempt is not None:
-                self._on_safety_preempt()
 
         # auto_control gate — bypassed only by is_safety or bypass_auto_control,
         # NOT by plain force=True (issue #293).
@@ -2405,9 +2387,7 @@ class CoverCommandService:
         # ``_execute_command``, which books a target like any other dispatch.
         # Left running, this pass would see those targets, judge the mid-sweep
         # cover "off target", and resend — racing the run's own legs and
-        # corrupting the timings it is there to measure. No safety carve-out
-        # here: a safety target reaches the covers through ``apply_position``,
-        # which pre-empts the run, and by the next tick this flag is clear.
+        # corrupting the timings it is there to measure.
         if self._calibrating:
             return
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -119,6 +119,7 @@ class CoverCommandService:
         debug_log=None,
         on_command_sent=None,
         get_travel_calibration=None,
+        on_safety_preempt=None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -170,6 +171,10 @@ class CoverCommandService:
                 per cycle) would serve stale numbers until the next reload.
                 Omitted, no travel plans are recorded and every estimated-position
                 surface stays empty — the pre-calibration behaviour.
+            on_safety_preempt: Optional ``() -> None`` invoked when a safety
+                target is dispatched while a travel-time run holds the covers.
+                The coordinator wires it to cancel the run, so a storm never
+                waits for a calibration.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -199,6 +204,11 @@ class CoverCommandService:
         self._on_tick = on_tick
         self._on_command_sent = on_command_sent
         self._get_travel_calibration = get_travel_calibration
+        # Called when a safety target arrives while a calibration run holds the
+        # covers. Wired by the coordinator to cancel the run; ``None`` leaves the
+        # gate absolute, which is the right default for a service with no
+        # calibrator behind it.
+        self._on_safety_preempt = on_safety_preempt
 
         # True while a travel-time calibration run owns the covers. Blocks every
         # outbound command from ``apply_position`` and stands the reconciliation
@@ -1576,22 +1586,34 @@ class CoverCommandService:
             )
 
         # Calibration gate — a travel-time run owns the covers while it is
-        # sweeping them to their mechanical stops, so nothing else may command
-        # them. Sits alongside the kill switch and shares its absoluteness:
-        # is_safety and force do NOT bypass it, because a safety command landing
-        # on a Model C rail mid-sweep drives a rail into a rail, and the run is
-        # bounded in minutes. A user who genuinely needs the covers back
-        # cancels the run (the panic stop service does exactly that), which is a
-        # decision rather than a collision.
+        # sweeping them to their mechanical stops, so ordinary automation must
+        # not command them. ``force`` does not bypass it: a recurring resend has
+        # nothing to say that cannot wait a few minutes.
+        #
+        # A SAFETY target does bypass it, by standing the run down first. The
+        # collision this gate exists to prevent — a command landing on a Model C
+        # rail mid-sweep — is better answered by stopping the run than by
+        # refusing the command: a safety dispatch still goes through the policy's
+        # own clearance gating, whereas a blocked one means a storm waits for a
+        # calibration. Cancelling with ``restore=False`` also stops the run
+        # issuing any further commands of its own, so the two never race.
         if self._calibrating:
-            return self._skip(
+            if not context.is_safety:
+                return self._skip(
+                    entity_id,
+                    "calibration_in_progress",
+                    position,
+                    trigger=_trigger,
+                    inverse_state=_inverse,
+                    current_position=_current,
+                )
+            self._logger.warning(
+                "Safety target for %s pre-empting the travel-time calibration "
+                "run — standing the run down",
                 entity_id,
-                "calibration_in_progress",
-                position,
-                trigger=_trigger,
-                inverse_state=_inverse,
-                current_position=_current,
             )
+            if self._on_safety_preempt is not None:
+                self._on_safety_preempt()
 
         # auto_control gate — bypassed only by is_safety or bypass_auto_control,
         # NOT by plain force=True (issue #293).
@@ -2383,7 +2405,9 @@ class CoverCommandService:
         # ``_execute_command``, which books a target like any other dispatch.
         # Left running, this pass would see those targets, judge the mid-sweep
         # cover "off target", and resend — racing the run's own legs and
-        # corrupting the timings it is there to measure.
+        # corrupting the timings it is there to measure. No safety carve-out
+        # here: a safety target reaches the covers through ``apply_position``,
+        # which pre-empts the run, and by the next tick this flag is clear.
         if self._calibrating:
             return
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -20,7 +20,190 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+from collections.abc import Mapping
 from typing import Any
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TravelCalibration:
+    """One entity's row in the ``travel_time_calibration`` option table.
+
+    The typed view of what is persisted as plain JSON in ``config_entry.options``
+    (shape documented at ``const.CONF_TRAVEL_TIME_CALIBRATION``). Everything that
+    reads or writes a row — the calibrator, the options flow's manual-entry step,
+    the diagnostic sensor, :func:`build_travel_plan` — goes through this class, so
+    the key names have exactly one definition instead of a string literal per
+    call site.
+
+    ``source`` records whether the numbers were measured or typed in by hand. It
+    is DISPLAY-ONLY: no behaviour may branch on it. A manual row is a first-class
+    calibration — for an ``assumed_state`` cover it is the only one obtainable —
+    and treating it as second-rate is how the feature stops working for the covers
+    that need it most.
+
+    ``open_seconds`` / ``close_seconds`` are ``None`` on a manual row, which
+    carries a single headline figure and no per-leg detail.
+    """
+
+    full_travel_seconds: float
+    open_seconds: float | None = None
+    close_seconds: float | None = None
+    start_delay_seconds: float = 0.0
+    calibrated_at: str | None = None
+    source: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for ``config_entry.options`` (plain JSON, no dataclasses)."""
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> TravelCalibration | None:
+        """Build from a stored row, or ``None`` if it is unusable.
+
+        Tolerant by design: this reads user-editable persisted config that an
+        older build, a hand-edited ``.storage`` file, or a partially-written row
+        could leave malformed. A row without a usable ``full_travel_seconds`` is
+        dropped rather than raising — a missing ramp is a cosmetic loss, and
+        taking down the command path over one is not a trade worth making.
+        """
+        try:
+            full = float(raw["full_travel_seconds"])
+        except (KeyError, TypeError, ValueError):
+            return None
+        if full <= 0:
+            return None
+
+        def _leg(key: str) -> float | None:
+            value = raw.get(key)
+            if value is None:
+                return None
+            try:
+                seconds = float(value)
+            except (TypeError, ValueError):
+                return None
+            return seconds if seconds > 0 else None
+
+        try:
+            delay = max(0.0, float(raw.get("start_delay_seconds") or 0.0))
+        except (TypeError, ValueError):
+            delay = 0.0
+
+        return cls(
+            full_travel_seconds=full,
+            open_seconds=_leg("open_seconds"),
+            close_seconds=_leg("close_seconds"),
+            start_delay_seconds=delay,
+            calibrated_at=raw.get("calibrated_at"),
+            source=raw.get("source"),
+        )
+
+    def seconds_for(self, *, rising: bool) -> float:
+        """Full-sweep seconds for a move in this direction.
+
+        ``rising`` is in WIRE space — the raw ``current_position`` number going
+        up — matching ``transit._TRANSIT_WIRE_SIGN``, because that is the frame
+        the legs were measured in. A caller holding an open-percent direction on
+        an inverse-state install must flip it before asking (the #993 bug class).
+
+        Falls back to the averaged figure whenever the relevant leg is absent,
+        which is every manual row.
+        """
+        leg = self.open_seconds if rising else self.close_seconds
+        return leg if leg is not None else self.full_travel_seconds
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TravelPlan:
+    """Where a cover should appear to be, at any instant of an in-flight move.
+
+    Recorded when a position command is dispatched and cleared when the entity
+    stops ``waiting``. Consumers render from it rather than being fed a ticking
+    value: two state writes per move instead of a sub-second loop, and a card can
+    interpolate at whatever framerate it draws at.
+
+    ``start_delay_seconds`` is not padding. Several actuator families (Somfy IO
+    via Tahoma is the documented one — see
+    ``VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS``) sit still for seconds
+    after accepting a command. Folding that dead time into the ramp starts every
+    animation early and lands it late; holding at the origin for it does not.
+    """
+
+    from_position: int
+    to_position: int
+    started_at: dt.datetime
+    start_delay_seconds: float
+    duration_seconds: float
+
+    def position_at(self, now: dt.datetime) -> int:
+        """Modelled position at ``now``, clamped to the move's own endpoints.
+
+        Never overshoots and never runs backwards: before the actuator is due to
+        move this is the origin, after the move is due to finish it is the
+        target. A cover that stalls mid-travel will therefore be reported as
+        arrived — the estimate is a model, and this is the direction in which it
+        is wrong.
+        """
+        elapsed = (now - self.started_at).total_seconds()
+        if elapsed <= self.start_delay_seconds:
+            return self.from_position
+        if self.duration_seconds <= 0:
+            return self.to_position
+        progress = min(
+            1.0, (elapsed - self.start_delay_seconds) / self.duration_seconds
+        )
+        return round(
+            self.from_position + (self.to_position - self.from_position) * progress
+        )
+
+    def as_payload(self) -> dict[str, Any]:
+        """JSON-safe projection for the sensor attribute / diagnostics.
+
+        The companion card's wire contract. ``started_at`` is ISO text because
+        the value is handed to HA's state machine, which will not carry a
+        ``datetime`` through a recorder round-trip.
+        """
+        return {
+            "from": self.from_position,
+            "to": self.to_position,
+            "started_at": self.started_at.isoformat(),
+            "start_delay_seconds": self.start_delay_seconds,
+            "duration_seconds": self.duration_seconds,
+        }
+
+
+def build_travel_plan(
+    raw: Mapping[str, Any] | None,
+    *,
+    from_position: int | None,
+    to_position: int | None,
+    started_at: dt.datetime,
+    span: int,
+) -> TravelPlan | None:
+    """Derive the ramp for one dispatched move, or ``None`` when it can't be.
+
+    Returns ``None`` — meaning "no animation for this move", never an exception —
+    for an uncalibrated cover, an unknown origin, a zero-length move, or a
+    degenerate axis span. Every caller is on the command-dispatch path, where a
+    missing cosmetic surface must not become a failed command.
+
+    ``span`` is the axis's own ``value_max - value_min``, not a literal 100: the
+    calibration measured a full sweep of THAT axis, so the fraction of it this
+    move covers has to be taken against the same range.
+    """
+    calibration = TravelCalibration.from_dict(raw) if raw else None
+    if calibration is None or from_position is None or to_position is None:
+        return None
+    delta = to_position - from_position
+    if delta == 0 or span <= 0:
+        return None
+    seconds = calibration.seconds_for(rising=delta > 0)
+    return TravelPlan(
+        from_position=from_position,
+        to_position=to_position,
+        started_at=started_at,
+        start_delay_seconds=calibration.start_delay_seconds,
+        duration_seconds=seconds * abs(delta) / span,
+    )
 
 
 @dataclasses.dataclass(slots=True)
@@ -76,6 +259,12 @@ class PerEntityState:
     # ``transit_states()`` surface is gated on ``waiting`` so it disappears
     # exactly when the transit window closes.
     transit_direction: str | None = None
+    # Position-vs-time model for the move currently in flight, or None. Written
+    # at the same dispatch chokepoint as ``transit_direction`` and cleared by the
+    # same ``_clear_waiting``, so the two cannot drift out of step: both describe
+    # the transit window and both must vanish when it closes. Present only for
+    # covers with a travel-time calibration (measured or manual).
+    travel_plan: TravelPlan | None = None
     # Anti-relay latch for full-mechanical-endpoint forcing (issue #897). Holds
     # the endpoint (0 or 100) that ``apply_position`` last force-routed via
     # close_cover/open_cover. Read BEFORE computing force_endpoint and written

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -57,6 +57,7 @@ from ..const import (
     TRAVEL_TIME_MAX_SECONDS,
     TRAVEL_TIME_MIN_SECONDS,
 )
+from ..cover_types.base import caps_get
 from ..helpers import is_assumed_state
 from .cover_command.transit import is_state_in_transit
 
@@ -303,10 +304,23 @@ class TravelTimeCalibrator:
                 self._state = TRAVEL_CALIBRATION_STATE_CANCELLED
             else:
                 self._state = TRAVEL_CALIBRATION_STATE_COMPLETE
-            # Persist even a cancelled or failed run: the entities that finished
-            # produced real measurements, and throwing them away would mean
-            # re-sweeping covers that were already done.
-            await self._persist(self._merged_table(entities, measured))
+            # A hard abort is an unload or a panic stop. Writing options during
+            # an unload dispatches the entry's update listeners — via a task HA
+            # does NOT scope to the entry — which would run a full refresh on the
+            # coordinator that just shut down. Discarding this run's measurements
+            # is the cheaper loss by a wide margin, and a panic stop discarding a
+            # half-finished sweep is what the button means anyway.
+            #
+            # An ordinary cancel or a failure DOES persist: those entities really
+            # were measured, and dropping them would mean re-sweeping covers that
+            # were already done.
+            #
+            # Expressed as a condition rather than an early return: a ``return``
+            # inside a ``finally`` discards whatever exception is in flight, and
+            # on the unload path that exception is the CancelledError this branch
+            # exists to handle.
+            if not self._hard_aborted:
+                await self._persist(self._merged_table(entities, measured))
             self._notify()
 
     # ------------------------------------------------------------------ #
@@ -510,7 +524,10 @@ class TravelTimeCalibrator:
             return _Arrival(arrived_at=self._now())
 
         axis = self._policy.select_default_axis(caps or {})
-        position_capable = self._policy.position_axis_supported(caps)
+        # Same axis question as _is_arrival — see there for why this is not
+        # ``position_axis_supported``. Getting it wrong here also mis-routes the
+        # wait into the observability probe.
+        position_capable = caps_get(caps, axis.capability_key, default=True)
         origin = self._cmd_svc.get_current_position(entity_id)
         loop = asyncio.get_running_loop()
         arrived: asyncio.Future[dt.datetime] = loop.create_future()
@@ -642,7 +659,14 @@ class TravelTimeCalibrator:
     def _is_arrival(self, state_obj, target: int, caps) -> bool:
         """Whether ``state_obj`` shows the cover parked on the commanded target."""
         axis = self._policy.select_default_axis(caps or {})
-        if self._policy.position_axis_supported(caps):
+        # ``axis.capability_key``, NOT ``position_axis_supported`` — the latter
+        # always asks about ``axes[0]``, while ``select_default_axis`` returns
+        # the TILT axis for a position-primary policy bound to tilt-only
+        # hardware. Pairing the two asks whether the cover supports one axis and
+        # then reads another: the tilt reading is discarded, arrival never
+        # resolves, and the cover burns three full timeouts. This is the same
+        # pairing ``CoverTypePolicy.read_axis_value`` makes.
+        if caps_get(caps, axis.capability_key, default=True):
             value = state_obj.attributes.get(axis.state_attr)
             if value is None:
                 return False
@@ -682,7 +706,14 @@ class TravelTimeCalibrator:
         return dt.datetime.now(dt.UTC)
 
     def _timeout(self, subject: str) -> None:
-        """Record a leg that never landed, and return None for the row."""
+        """Record a leg that never landed, and return None for the row.
+
+        Silent when the run was cancelled: the leg did not fail, it was
+        interrupted, and reporting a timeout would blame the cover for the
+        user's own Cancel.
+        """
+        if self._aborted:
+            return None
         self._logger.warning(
             "Travel-time calibration timed out for %s — skipping it", subject
         )

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -1,0 +1,592 @@
+"""Measure how long each cover takes to traverse its full range.
+
+Drives every configured cover to one mechanical stop, times it to the other and
+back, and averages the two legs into a ``full_travel_seconds`` figure stored per
+entity in ``CONF_TRAVEL_TIME_CALIBRATION``. Once that number exists, every
+subsequent dispatch can carry a ``TravelPlan`` — a position-vs-time ramp a
+dashboard card can animate — for covers that report position too rarely to
+animate from, or not at all.
+
+**Cover-type-agnostic.** Endpoints come from the policy's own axis descriptor,
+dispatch order from ``order_for_dispatch``, and the "move this other entity out
+of the way first" question from ``travel_calibration_clearance``. Nothing here
+knows what a rail is. Per CODING_GUIDELINES.md § "Managers Hold State, Policies
+Hold Behavior": this manager owns the run's state and side effects, the policy
+owns every decision that depends on what kind of cover it is.
+
+**Reuses, never re-derives.** Commands go out through
+``CoverCommandService._execute_command`` (the existing bypass-the-gates seam),
+"has it arrived?" is ``CoverCommandService._at_target`` (the same tolerance
+reconciliation uses), "is it moving?" is ``transit.is_state_in_transit``, and
+"can HA even see this cover?" is ``helpers.is_assumed_state``. A second copy of
+any of those would drift.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import datetime as dt
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any
+
+from homeassistant.const import STATE_CLOSED, STATE_OPEN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+
+from ..const import (
+    CONF_TRAVEL_TIME_CALIBRATION,
+    DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS,
+    TRAVEL_CALIBRATION_SOURCE_MEASURED,
+    TRAVEL_CALIBRATION_STATE_CANCELLED,
+    TRAVEL_CALIBRATION_STATE_COMPLETE,
+    TRAVEL_CALIBRATION_STATE_FAILED,
+    TRAVEL_CALIBRATION_STATE_IDLE,
+    TRAVEL_CALIBRATION_STATE_RUNNING,
+    TRAVEL_CALIBRATION_STATUS_OK,
+    TRAVEL_CALIBRATION_STATUS_TIMEOUT,
+    TRAVEL_CALIBRATION_STATUS_UNAVAILABLE,
+    TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
+    TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
+    TRAVEL_TIME_MAX_SECONDS,
+    TRAVEL_TIME_MIN_SECONDS,
+)
+from ..helpers import is_assumed_state
+from .cover_command.transit import is_state_in_transit
+
+# Why an entity was skipped, as recorded on its result row. Free text would
+# drift between the three sites that write it and the sensor that renders it.
+REASON_ASSUMED_STATE = "assumed_state"
+REASON_NO_MOTION_OBSERVED = "no_motion_observed"
+REASON_NO_ENTITIES = "no_entities"
+_REASON_CLEARANCE = "clearance_failed"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Arrival:
+    """Outcome of waiting for one commanded move to land.
+
+    ``first_motion_at`` is when the cover was first *observed* moving — a
+    transit state, or a change in the axis value. It is the boundary between
+    actuator dead time and actual travel, which the two must be split at: a
+    figure that silently includes 4 s of Somfy IO start-up lag makes every
+    ramp derived from it start early and finish late.
+    """
+
+    arrived_at: dt.datetime | None = None
+    first_motion_at: dt.datetime | None = None
+    unobservable: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """Whether the cover actually reached the commanded endpoint."""
+        return self.arrived_at is not None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _Leg:
+    """One timed traverse, split into dead time and travel."""
+
+    travel_seconds: float
+    start_delay_seconds: float
+
+    @classmethod
+    def from_arrival(cls, arrival: _Arrival, sent_at: dt.datetime) -> _Leg:
+        """Split a landed move into its dead-time and travel halves.
+
+        With no observed motion the whole elapsed time is booked as travel and
+        the delay as zero. That is the conservative split: over-reporting travel
+        makes a ramp run slightly slow, whereas over-reporting the delay would
+        make the cover appear stationary for a stretch it was actually moving.
+
+        The same fallback catches a motion stamp at or after the arrival stamp,
+        which an out-of-order publish can produce. Trusting it would yield a
+        zero or negative traverse, and a negative one propagates into a ramp
+        that runs backwards.
+        """
+        started = arrival.first_motion_at or sent_at
+        if arrival.arrived_at is not None and started >= arrival.arrived_at:
+            started = sent_at
+        return cls(
+            travel_seconds=(arrival.arrived_at - started).total_seconds(),
+            start_delay_seconds=max(0.0, (started - sent_at).total_seconds()),
+        )
+
+
+class TravelTimeCalibrator:
+    """Runs, and reports on, a travel-time calibration pass."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger,
+        *,
+        cmd_svc,
+        policy,
+        get_entities: Callable[[], Sequence[str]],
+        get_options: Callable[[], Mapping[str, Any]],
+        persist: Callable[[dict[str, dict[str, Any]]], Any],
+        on_progress: Callable[[], None] | None = None,
+        move_timeout_seconds: int = DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS,
+        probe_seconds: int = TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
+    ) -> None:
+        """Wire the calibrator to its collaborators.
+
+        ``get_entities`` / ``get_options`` are callables rather than values so a
+        run started long after construction still sees the current cover list
+        and config. ``persist`` is the coroutine that writes the finished table
+        back to ``config_entry.options``.
+        """
+        self._hass = hass
+        self._logger = logger
+        self._cmd_svc = cmd_svc
+        self._policy = policy
+        self._get_entities = get_entities
+        self._get_options = get_options
+        self._persist = persist
+        self._on_progress = on_progress
+        self._move_timeout = float(move_timeout_seconds)
+        self._probe_seconds = float(probe_seconds)
+
+        self._state: str = TRAVEL_CALIBRATION_STATE_IDLE
+        self._results: dict[str, dict[str, Any]] = {}
+        self._active: str | None = None
+        self._last_error: str | None = None
+        # Created per run. Set by ``async_cancel`` and raced against every
+        # arrival wait, so a cancel takes effect at the next observation rather
+        # than sitting behind a 180 s timeout.
+        self._abort: asyncio.Event | None = None
+        self._restore_on_cancel: bool = True
+
+    # ------------------------------------------------------------------ #
+    # Public surface
+    # ------------------------------------------------------------------ #
+
+    @property
+    def state(self) -> str:
+        """Lifecycle state of the most recent (or current) run."""
+        return self._state
+
+    @property
+    def is_running(self) -> bool:
+        """Whether a run currently owns the covers."""
+        return self._state == TRAVEL_CALIBRATION_STATE_RUNNING
+
+    @property
+    def active_entity(self) -> str | None:
+        """The cover currently being swept, or None."""
+        return self._active
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Snapshot for the diagnostic sensor and the downloadable diagnostics."""
+        return {
+            "state": self._state,
+            "active_entity": self._active,
+            "last_error": self._last_error,
+            "results": {eid: dict(row) for eid, row in self._results.items()},
+        }
+
+    @callback
+    def async_cancel(self, *, restore: bool = True) -> bool:
+        """Stop an in-flight run. Returns whether there was one to stop.
+
+        ``restore=True`` (the options-flow Cancel button) still puts the covers
+        back where the run found them. ``restore=False`` is for the panic stop
+        service, where more movement is precisely what the user is asking to
+        avoid — the run stands down and the covers stay put.
+        """
+        if not self.is_running or self._abort is None:
+            return False
+        self._restore_on_cancel = restore
+        self._abort.set()
+        return True
+
+    async def async_run(self) -> None:
+        """Calibrate every configured cover, then restore their positions.
+
+        Sequential by design. Concurrent sweeps would be faster, but a cover
+        type with physically coupled entities cannot have two of them travelling
+        at once, and the per-entity clearance parking (§ policy hook) only
+        guarantees a clear track for ONE subject at a time.
+        """
+        if self.is_running:
+            self._logger.debug("Travel-time calibration already running — ignoring")
+            return
+
+        entities = list(self._get_entities() or [])
+        if not entities:
+            self._state = TRAVEL_CALIBRATION_STATE_FAILED
+            self._last_error = REASON_NO_ENTITIES
+            self._notify()
+            return
+
+        self._abort = asyncio.Event()
+        self._restore_on_cancel = True
+        self._results = {}
+        self._last_error = None
+        self._state = TRAVEL_CALIBRATION_STATE_RUNNING
+        # Hand the covers over: automation and reconciliation both stand down
+        # until the finally below gives them back.
+        self._cmd_svc.calibrating = True
+        self._notify()
+
+        # Captured before anything moves, so the restore pass can put every
+        # cover back exactly where the user left it.
+        origins = {eid: self._cmd_svc.get_current_position(eid) for eid in entities}
+        table = self._pruned_table(entities)
+
+        try:
+            for subject in self._policy.order_for_dispatch(entities):
+                if self._aborted:
+                    break
+                self._active = subject
+                self._notify()
+                row = await self._calibrate_entity(subject, entities)
+                if row is not None:
+                    table[subject] = row
+        finally:
+            self._active = None
+            try:
+                if not self._aborted or self._restore_on_cancel:
+                    await self._restore(origins)
+            finally:
+                # Always, on every path: a run that leaves this set has switched
+                # automation off indefinitely with no visible cause.
+                self._cmd_svc.calibrating = False
+
+            self._state = (
+                TRAVEL_CALIBRATION_STATE_CANCELLED
+                if self._aborted
+                else TRAVEL_CALIBRATION_STATE_COMPLETE
+            )
+            # Persist even a cancelled run: the entities that finished produced
+            # real measurements, and throwing them away would mean re-sweeping
+            # covers that were already done.
+            await self._persist(table)
+            self._notify()
+
+    # ------------------------------------------------------------------ #
+    # Per-entity run
+    # ------------------------------------------------------------------ #
+
+    async def _calibrate_entity(
+        self, subject: str, entities: Sequence[str]
+    ) -> dict[str, Any] | None:
+        """Sweep one cover and return its table row, or None if it was skipped."""
+        if self._cmd_svc.is_entity_unavailable(subject):
+            self._record(subject, TRAVEL_CALIBRATION_STATUS_UNAVAILABLE)
+            return None
+
+        # An assumed-state cover reports open/closed the instant the command is
+        # accepted, so "arrival" is the round trip of a service call, not a
+        # traverse. Timing it would produce a confidently wrong number, which is
+        # worse than no number: manual entry is the honest path for these.
+        if is_assumed_state(self._hass.states.get(subject)):
+            self._record(
+                subject,
+                TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
+                reason=REASON_ASSUMED_STATE,
+            )
+            return None
+
+        caps = self._cmd_svc.get_cover_capabilities(subject)
+        axis = self._policy.select_default_axis(caps)
+
+        if not await self._apply_clearance(subject, entities):
+            self._record(
+                subject, TRAVEL_CALIBRATION_STATUS_TIMEOUT, reason=_REASON_CLEARANCE
+            )
+            return None
+
+        # Seed — untimed. Only job is to put the cover on a known endpoint so
+        # the legs that follow are genuinely full-range sweeps.
+        seed = await self._drive_and_wait(subject, axis.value_min, caps=caps)
+        if seed.unobservable:
+            self._record(
+                subject,
+                TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
+                reason=REASON_NO_MOTION_OBSERVED,
+            )
+            return None
+        if not seed.ok:
+            return self._timeout(subject)
+
+        legs: list[_Leg] = []
+        for target in (axis.value_max, axis.value_min):
+            sent_at = self._now()
+            arrival = await self._drive_and_wait(subject, target, caps=caps)
+            if not arrival.ok:
+                return self._timeout(subject)
+            legs.append(_Leg.from_arrival(arrival, sent_at))
+
+        opening, closing = legs
+        return self._build_row(subject, opening=opening, closing=closing)
+
+    def _build_row(
+        self, subject: str, *, opening: _Leg, closing: _Leg
+    ) -> dict[str, Any] | None:
+        """Turn two timed legs into a persisted row, or reject an absurd result.
+
+        A sweep faster than ``TRAVEL_TIME_MIN_SECONDS`` almost always means the
+        cover reported arrival without moving (a device that echoes the target
+        back before acting), and one slower than ``TRAVEL_TIME_MAX_SECONDS``
+        means something stalled. Both would produce ramps wrong enough to look
+        broken, so neither is stored — the same band the manual-entry field is
+        bounded by, read from the same constants.
+        """
+        full = (opening.travel_seconds + closing.travel_seconds) / 2
+        if not TRAVEL_TIME_MIN_SECONDS <= full <= TRAVEL_TIME_MAX_SECONDS:
+            self._logger.warning(
+                "Travel-time calibration for %s produced an implausible %.1fs "
+                "full traverse — discarding",
+                subject,
+                full,
+            )
+            self._record(
+                subject,
+                TRAVEL_CALIBRATION_STATUS_TIMEOUT,
+                reason="implausible_result",
+                full_travel_seconds=round(full, 2),
+            )
+            return None
+
+        row = {
+            "full_travel_seconds": round(full, 2),
+            "open_seconds": round(opening.travel_seconds, 2),
+            "close_seconds": round(closing.travel_seconds, 2),
+            "start_delay_seconds": round(
+                (opening.start_delay_seconds + closing.start_delay_seconds) / 2, 2
+            ),
+            "calibrated_at": self._now().isoformat(),
+            "source": TRAVEL_CALIBRATION_SOURCE_MEASURED,
+        }
+        self._record(subject, TRAVEL_CALIBRATION_STATUS_OK, **row)
+        return row
+
+    async def _apply_clearance(self, subject: str, entities: Sequence[str]) -> bool:
+        """Park whatever the policy says is standing in ``subject``'s way."""
+        plan = self._policy.travel_calibration_clearance(
+            subject, entities, self._get_options()
+        )
+        for partner, park_at in plan.items():
+            if partner == subject:
+                continue
+            caps = self._cmd_svc.get_cover_capabilities(partner)
+            arrival = await self._drive_and_wait(partner, park_at, caps=caps)
+            if not arrival.ok:
+                self._logger.warning(
+                    "Travel-time calibration: could not park %s at %s%% to clear "
+                    "the way for %s",
+                    partner,
+                    park_at,
+                    subject,
+                )
+                return False
+        return True
+
+    async def _restore(self, origins: Mapping[str, int | None]) -> None:
+        """Put every cover back where the run found it.
+
+        Waits for each to land before moving the next, in policy dispatch order:
+        a cover type with coupled entities cannot have both travelling at once,
+        and this pass has no clearance plan protecting it. Outcomes are ignored
+        — a cover that will not go home is a cosmetic annoyance, not a reason to
+        fail a run whose measurements already succeeded.
+        """
+        targets = {eid: pos for eid, pos in origins.items() if pos is not None}
+        for entity_id in self._policy.order_for_dispatch(targets):
+            caps = self._cmd_svc.get_cover_capabilities(entity_id)
+            await self._drive_and_wait(entity_id, targets[entity_id], caps=caps)
+
+    # ------------------------------------------------------------------ #
+    # Driving and observing one move
+    # ------------------------------------------------------------------ #
+
+    async def _drive_and_wait(
+        self, entity_id: str, target: int, *, caps: Mapping[str, bool] | None
+    ) -> _Arrival:
+        """Command ``entity_id`` to ``target`` and wait for it to land there.
+
+        Subscribes BEFORE dispatching: a fast cover can publish its whole
+        transit between the service call returning and a later subscription
+        taking effect, and a missed arrival is indistinguishable from a stall.
+        """
+        if self._already_at(entity_id, target, caps):
+            # Nothing to observe and nothing to time. Skipping the command also
+            # spares the motor a relay click it would gain nothing from (#290).
+            return _Arrival(arrived_at=self._now())
+
+        axis = self._policy.select_default_axis(caps or {})
+        position_capable = self._policy.position_axis_supported(caps)
+        origin = self._cmd_svc.get_current_position(entity_id)
+        loop = asyncio.get_running_loop()
+        arrived: asyncio.Future[dt.datetime] = loop.create_future()
+        # Boxed so the callback can write it without a nonlocal declaration
+        # across the closure boundary.
+        motion: list[dt.datetime | None] = [None]
+
+        @callback
+        def _on_change(event) -> None:
+            new_state = event.data.get("new_state")
+            if new_state is None:
+                return
+            # The EVENT's timestamp, not ``now()`` at handler entry: a busy loop
+            # can defer this callback by tens of milliseconds, and that error
+            # would land straight in the measurement.
+            stamp = event.time_fired
+            if is_state_in_transit(new_state.state):
+                if motion[0] is None:
+                    motion[0] = stamp
+                # Still travelling — it cannot have arrived, whatever the
+                # position attribute says while the motor is running.
+                return
+            landed = self._is_arrival(new_state, target, caps)
+            value = new_state.attributes.get(axis.state_attr)
+            if (
+                motion[0] is None
+                and not landed
+                and value is not None
+                and value != origin
+            ):
+                # A cover that publishes positions but never an opening/closing
+                # state still shows its start this way — but ONLY from an
+                # intermediate publish. A cover that reports nothing until it is
+                # already home would otherwise mark motion and arrival at the
+                # same instant, and the traverse would measure zero.
+                motion[0] = stamp
+            if landed and not arrived.done():
+                arrived.set_result(stamp)
+
+        unsub = async_track_state_change_event(self._hass, [entity_id], _on_change)
+        try:
+            # Deliberately the reconciliation seam: it already routes through
+            # the policy's axis, applies open/close substitution, books the
+            # target and stamps the ACP context so the external-command
+            # detector does not read our own sweep as a user move.
+            await self._cmd_svc._execute_command(entity_id, target)  # noqa: SLF001
+            return await self._await_outcome(
+                arrived, motion, probe=not position_capable
+            )
+        finally:
+            unsub()
+
+    async def _await_outcome(
+        self,
+        arrived: asyncio.Future[dt.datetime],
+        motion: list[dt.datetime | None],
+        *,
+        probe: bool,
+    ) -> _Arrival:
+        """Wait for arrival, giving position-less covers an observability probe.
+
+        A cover with no position axis is watched purely through its
+        ``opening``/``closing`` states. Some devices never publish those and
+        report the destination state immediately — indistinguishable, from the
+        outside, from a cover that teleported. The probe catches exactly that:
+        no motion seen in the first few seconds means there is nothing here to
+        time, and the entity is reported unobservable rather than credited with
+        an instantaneous traverse.
+        """
+        if probe:
+            stamp = await self._wait_for(arrived, self._probe_seconds)
+            if self._aborted:
+                return _Arrival(None, motion[0])
+            if motion[0] is None:
+                # Nothing was seen to move. Note this is checked BEFORE the
+                # arrival stamp, because the snapping cover this catches does
+                # claim to arrive — instantly, without ever having moved. Taking
+                # that claim at face value would book a zero-second traverse.
+                return _Arrival(unobservable=True)
+            if stamp is not None:
+                return _Arrival(stamp, motion[0])
+            remaining = max(0.0, self._move_timeout - self._probe_seconds)
+        else:
+            remaining = self._move_timeout
+
+        stamp = await self._wait_for(arrived, remaining)
+        return _Arrival(stamp, motion[0])
+
+    async def _wait_for(
+        self, arrived: asyncio.Future[dt.datetime], timeout: float
+    ) -> dt.datetime | None:
+        """Arrival stamp, or None if the wait timed out or the run was cancelled.
+
+        Races the abort event alongside the timeout so Cancel lands at the next
+        scheduling point instead of after the full per-move budget.
+        """
+        assert self._abort is not None  # noqa: S101 — set for the whole run
+        abort_task = asyncio.ensure_future(self._abort.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {arrived, abort_task},
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            abort_task.cancel()
+        return arrived.result() if arrived in done else None
+
+    def _is_arrival(self, state_obj, target: int, caps) -> bool:
+        """Whether ``state_obj`` shows the cover parked on the commanded target."""
+        axis = self._policy.select_default_axis(caps or {})
+        if self._policy.position_axis_supported(caps):
+            value = state_obj.attributes.get(axis.state_attr)
+            if value is None:
+                return False
+            # The same tolerance predicate check_target_reached and
+            # reconciliation use — a second "close enough" rule would let a
+            # cover be simultaneously arrived and not arrived.
+            return self._cmd_svc._at_target(int(value), target)  # noqa: SLF001
+        # Open/close-only: the endpoint states are the only evidence there is.
+        # Calibration never targets anything but the two endpoints, so this is
+        # total rather than a partial mapping.
+        if target <= axis.value_min:
+            return state_obj.state == STATE_CLOSED
+        if target >= axis.value_max:
+            return state_obj.state == STATE_OPEN
+        return False
+
+    def _already_at(self, entity_id: str, target: int, caps) -> bool:
+        """Whether the cover is parked on ``target`` right now."""
+        state_obj = self._hass.states.get(entity_id)
+        if state_obj is None or is_state_in_transit(state_obj.state):
+            return False
+        return self._is_arrival(state_obj, target, caps)
+
+    # ------------------------------------------------------------------ #
+    # Bookkeeping
+    # ------------------------------------------------------------------ #
+
+    @property
+    def _aborted(self) -> bool:
+        return self._abort is not None and self._abort.is_set()
+
+    def _now(self) -> dt.datetime:
+        return dt.datetime.now(dt.UTC)
+
+    def _timeout(self, subject: str) -> None:
+        """Record a leg that never landed, and return None for the row."""
+        self._logger.warning(
+            "Travel-time calibration timed out for %s — skipping it", subject
+        )
+        self._record(subject, TRAVEL_CALIBRATION_STATUS_TIMEOUT)
+        return None
+
+    def _record(self, entity_id: str, status: str, **extra: Any) -> None:
+        self._results[entity_id] = {"status": status, **extra}
+        self._notify()
+
+    def _pruned_table(self, entities: Iterable[str]) -> dict[str, dict[str, Any]]:
+        """Return the stored table, minus covers this instance no longer controls.
+
+        Swapping a cover out in the options flow would otherwise leave its row
+        behind forever, quietly inflating the "N of M calibrated" count and
+        keeping a dead entity in the diagnostics.
+        """
+        stored = self._get_options().get(CONF_TRAVEL_TIME_CALIBRATION) or {}
+        keep = set(entities)
+        return {eid: dict(row) for eid, row in stored.items() if eid in keep}
+
+    def _notify(self) -> None:
+        if self._on_progress is not None:
+            self._on_progress()

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -25,6 +25,7 @@ any of those would drift.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import datetime as dt
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -54,6 +55,7 @@ from ..const import (
     REASON_NO_MOTION_OBSERVED,
     REASON_RESTORE,
     REASON_RUN_BUDGET_EXCEEDED,
+    TRAVEL_CALIBRATION_RESTORE_BUDGET_SECONDS,
     TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS,
     TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
     TRAVEL_TIME_MAX_SECONDS,
@@ -133,6 +135,7 @@ class TravelTimeCalibrator:
         move_timeout_seconds: int = DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS,
         probe_seconds: int = TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
         run_budget_seconds: int = TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS,
+        restore_budget_seconds: int = TRAVEL_CALIBRATION_RESTORE_BUDGET_SECONDS,
     ) -> None:
         """Wire the calibrator to its collaborators.
 
@@ -152,6 +155,7 @@ class TravelTimeCalibrator:
         self._move_timeout = float(move_timeout_seconds)
         self._probe_seconds = float(probe_seconds)
         self._run_budget = float(run_budget_seconds)
+        self._restore_budget = float(restore_budget_seconds)
         # Wall-clock deadline for the current run, or None when idle.
         self._deadline: dt.datetime | None = None
 
@@ -261,6 +265,7 @@ class TravelTimeCalibrator:
         measured: dict[str, dict[str, Any]] = {}
         origins: dict[str, int | None] = {}
         failed = False
+        budget_exceeded = False
 
         # EVERYTHING the finally has to undo lives inside this try — the
         # handover, the first notify and the origin capture included. Those
@@ -289,7 +294,7 @@ class TravelTimeCalibrator:
                         self._run_budget,
                         subject,
                     )
-                    self._last_error = REASON_RUN_BUDGET_EXCEEDED
+                    budget_exceeded = True
                     self._abort.set()
                     break
                 self._active = subject
@@ -303,6 +308,9 @@ class TravelTimeCalibrator:
             failed = True
             raise
         finally:
+            # Expiry inside the final subject leaves the loop without ever
+            # re-testing the boundary, so ask once more here.
+            budget_exceeded = budget_exceeded or self._budget_spent()
             self._active = None
             try:
                 if not self._aborted or self._restore_on_cancel:
@@ -328,8 +336,15 @@ class TravelTimeCalibrator:
 
             if failed:
                 self._state = TRAVEL_CALIBRATION_STATE_FAILED
-            elif self._aborted:
+            elif self._aborted or budget_exceeded:
+                # ``budget_exceeded`` is checked separately from ``_aborted``
+                # because expiry during the LAST (or only) subject never reaches
+                # the next loop boundary, so nothing sets the abort — and the run
+                # would settle on "complete" with an empty results table and no
+                # error, which on a single-cover install is every run that runs
+                # out of time.
                 self._state = TRAVEL_CALIBRATION_STATE_CANCELLED
+                self._last_error = REASON_RUN_BUDGET_EXCEEDED
             else:
                 self._state = TRAVEL_CALIBRATION_STATE_COMPLETE
             # A hard abort is an unload or a panic stop. Writing options during
@@ -350,7 +365,11 @@ class TravelTimeCalibrator:
             if not self._hard_aborted:
                 await self._persist(self._merged_table(entities, measured))
             self._deadline = None
-            self._notify()
+            with contextlib.suppress(Exception):
+                # Never let a listener's failure replace the exception already
+                # in flight — on the unload path that is the CancelledError the
+                # branch above is built around.
+                self._notify()
 
     # ------------------------------------------------------------------ #
     # Per-entity run
@@ -507,7 +526,15 @@ class TravelTimeCalibrator:
         the covers hostage. A cover that will not go home is a cosmetic
         annoyance, not a reason to fail a run whose measurements succeeded.
         """
+        # A fresh window. Every wait in this module is clamped to the remaining
+        # budget, and by the time the restore runs the measurement phase may
+        # have spent all of it — leaving each wait to return instantly, the
+        # leader never observed to land, and every cover the clearance gate
+        # defers abandoned at a mechanical stop on the second lap. Granting the
+        # allowance here keeps the pass bounded without letting it be starved.
         pending = {eid: pos for eid, pos in origins.items() if pos is not None}
+        if pending:
+            self._deadline = self._now() + dt.timedelta(seconds=self._restore_budget)
         while pending and not self._hard_aborted:
             moved = False
             for entity_id in list(pending):
@@ -557,6 +584,11 @@ class TravelTimeCalibrator:
         deliberately one-at-a-time pass into a simultaneous fan-out, on the one
         path where coupled entities have no clearance plan protecting them.
         """
+        if not ignore_abort and self._interrupted:
+            # Asked to stop between one leg landing and the next dispatching.
+            # Without this the next command still goes out, sending a cover to a
+            # mechanical stop after a panic stop asked for no further movement.
+            return _Arrival()
         if self._already_at(entity_id, target, caps):
             # Nothing to observe and nothing to time. Skipping the command also
             # spares the motor a relay click it would gain nothing from (#290).

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -59,6 +59,7 @@ from .cover_command.transit import is_state_in_transit
 REASON_ASSUMED_STATE = "assumed_state"
 REASON_NO_MOTION_OBSERVED = "no_motion_observed"
 REASON_NO_ENTITIES = "no_entities"
+REASON_IMPLAUSIBLE_RESULT = "implausible_result"
 _REASON_CLEARANCE = "clearance_failed"
 
 
@@ -230,10 +231,16 @@ class TravelTimeCalibrator:
         self._cmd_svc.calibrating = True
         self._notify()
 
+        # Only what THIS run measured. Deliberately not a copy of the stored
+        # table: the run is long, and anything else that writes to the table
+        # while it is going (a hand-entered time saved from the options flow)
+        # would be erased when a start-of-run snapshot was written back at the
+        # end. The merge against live options happens at persist time instead.
+        measured: dict[str, dict[str, Any]] = {}
         # Captured before anything moves, so the restore pass can put every
         # cover back exactly where the user left it.
         origins = {eid: self._cmd_svc.get_current_position(eid) for eid in entities}
-        table = self._pruned_table(entities)
+        failed = False
 
         try:
             for subject in self._policy.order_for_dispatch(entities):
@@ -243,7 +250,12 @@ class TravelTimeCalibrator:
                 self._notify()
                 row = await self._calibrate_entity(subject, entities)
                 if row is not None:
-                    table[subject] = row
+                    measured[subject] = row
+        except Exception:
+            # Reported as failed rather than swallowed — the exception still
+            # propagates, but the sensor must not claim the run completed.
+            failed = True
+            raise
         finally:
             self._active = None
             try:
@@ -254,15 +266,16 @@ class TravelTimeCalibrator:
                 # automation off indefinitely with no visible cause.
                 self._cmd_svc.calibrating = False
 
-            self._state = (
-                TRAVEL_CALIBRATION_STATE_CANCELLED
-                if self._aborted
-                else TRAVEL_CALIBRATION_STATE_COMPLETE
-            )
-            # Persist even a cancelled run: the entities that finished produced
-            # real measurements, and throwing them away would mean re-sweeping
-            # covers that were already done.
-            await self._persist(table)
+            if failed:
+                self._state = TRAVEL_CALIBRATION_STATE_FAILED
+            elif self._aborted:
+                self._state = TRAVEL_CALIBRATION_STATE_CANCELLED
+            else:
+                self._state = TRAVEL_CALIBRATION_STATE_COMPLETE
+            # Persist even a cancelled or failed run: the entities that finished
+            # produced real measurements, and throwing them away would mean
+            # re-sweeping covers that were already done.
+            await self._persist(self._merged_table(entities, measured))
             self._notify()
 
     # ------------------------------------------------------------------ #
@@ -345,7 +358,7 @@ class TravelTimeCalibrator:
             self._record(
                 subject,
                 TRAVEL_CALIBRATION_STATUS_TIMEOUT,
-                reason="implausible_result",
+                reason=REASON_IMPLAUSIBLE_RESULT,
                 full_travel_seconds=round(full, 2),
             )
             return None
@@ -385,31 +398,67 @@ class TravelTimeCalibrator:
         return True
 
     async def _restore(self, origins: Mapping[str, int | None]) -> None:
-        """Put every cover back where the run found it.
+        """Put every cover back where the run found it, furthest traveller first.
 
-        Waits for each to land before moving the next, in policy dispatch order:
-        a cover type with coupled entities cannot have both travelling at once,
-        and this pass has no clearance plan protecting it. Outcomes are ignored
-        — a cover that will not go home is a cosmetic annoyance, not a reason to
-        fail a run whose measurements already succeeded.
+        Ordering matters here for the same reason it matters during a sweep:
+        coupled entities cannot pass through each other. But this pass cannot use
+        ``order_for_dispatch`` — that view is keyed on the single number a seam
+        is fanning out, and a restore sends every cover to a DIFFERENT number, so
+        there is none to name. Asked without one it falls back to a fixed order,
+        which is wrong half the time.
+
+        The covers all sit on the same endpoint when a completed run ends, and
+        they all travel the same way out of it, so the safe order follows from
+        distance alone: whoever has furthest to go must lead, because it is the
+        one everyone else would otherwise have to travel through. That holds in
+        both frames without the calibrator knowing which it is in — on an upright
+        Model C install the leader works out to the middle rail (a raise), on an
+        inverse one to the bottom rail (a lower), which is exactly what each
+        direction requires.
+
+        Sorting by distance also degrades sanely after a cancel, where covers can
+        be scattered mid-travel rather than parked together.
+
+        Outcomes are ignored: a cover that will not go home is a cosmetic
+        annoyance, not a reason to fail a run whose measurements succeeded.
         """
         targets = {eid: pos for eid, pos in origins.items() if pos is not None}
-        for entity_id in self._policy.order_for_dispatch(targets):
+        ordered = sorted(
+            targets,
+            key=lambda eid: abs(
+                targets[eid] - (self._cmd_svc.get_current_position(eid) or 0)
+            ),
+            reverse=True,
+        )
+        for entity_id in ordered:
             caps = self._cmd_svc.get_cover_capabilities(entity_id)
-            await self._drive_and_wait(entity_id, targets[entity_id], caps=caps)
+            await self._drive_and_wait(
+                entity_id, targets[entity_id], caps=caps, ignore_abort=True
+            )
 
     # ------------------------------------------------------------------ #
     # Driving and observing one move
     # ------------------------------------------------------------------ #
 
     async def _drive_and_wait(
-        self, entity_id: str, target: int, *, caps: Mapping[str, bool] | None
+        self,
+        entity_id: str,
+        target: int,
+        *,
+        caps: Mapping[str, bool] | None,
+        ignore_abort: bool = False,
     ) -> _Arrival:
         """Command ``entity_id`` to ``target`` and wait for it to land there.
 
         Subscribes BEFORE dispatching: a fast cover can publish its whole
         transit between the service call returning and a later subscription
         taking effect, and a missed arrival is indistinguishable from a stall.
+
+        ``ignore_abort`` is for the restore pass, which runs AFTER a cancel has
+        already been signalled. Without it every wait there would see the abort
+        event already set and return on its first scheduling — turning a
+        deliberately one-at-a-time pass into a simultaneous fan-out, on the one
+        path where coupled entities have no clearance plan protecting them.
         """
         if self._already_at(entity_id, target, caps):
             # Nothing to observe and nothing to time. Skipping the command also
@@ -465,7 +514,10 @@ class TravelTimeCalibrator:
             # detector does not read our own sweep as a user move.
             await self._cmd_svc._execute_command(entity_id, target)  # noqa: SLF001
             return await self._await_outcome(
-                arrived, motion, probe=not position_capable
+                arrived,
+                motion,
+                probe=not position_capable,
+                ignore_abort=ignore_abort,
             )
         finally:
             unsub()
@@ -476,6 +528,7 @@ class TravelTimeCalibrator:
         motion: list[dt.datetime | None],
         *,
         probe: bool,
+        ignore_abort: bool = False,
     ) -> _Arrival:
         """Wait for arrival, giving position-less covers an observability probe.
 
@@ -488,8 +541,10 @@ class TravelTimeCalibrator:
         an instantaneous traverse.
         """
         if probe:
-            stamp = await self._wait_for(arrived, self._probe_seconds)
-            if self._aborted:
+            stamp = await self._wait_for(
+                arrived, self._probe_seconds, ignore_abort=ignore_abort
+            )
+            if self._aborted and not ignore_abort:
                 return _Arrival(None, motion[0])
             if motion[0] is None:
                 # Nothing was seen to move. Note this is checked BEFORE the
@@ -503,27 +558,37 @@ class TravelTimeCalibrator:
         else:
             remaining = self._move_timeout
 
-        stamp = await self._wait_for(arrived, remaining)
+        stamp = await self._wait_for(arrived, remaining, ignore_abort=ignore_abort)
         return _Arrival(stamp, motion[0])
 
     async def _wait_for(
-        self, arrived: asyncio.Future[dt.datetime], timeout: float
+        self,
+        arrived: asyncio.Future[dt.datetime],
+        timeout: float,
+        *,
+        ignore_abort: bool = False,
     ) -> dt.datetime | None:
         """Arrival stamp, or None if the wait timed out or the run was cancelled.
 
         Races the abort event alongside the timeout so Cancel lands at the next
         scheduling point instead of after the full per-move budget.
+
+        ``ignore_abort`` drops that race for the restore pass, which by
+        definition runs with the abort already set and still has to wait for
+        each cover in turn.
         """
-        assert self._abort is not None  # noqa: S101 — set for the whole run
-        abort_task = asyncio.ensure_future(self._abort.wait())
+        waiters: set[asyncio.Future] = {arrived}
+        abort_task: asyncio.Task | None = None
+        if not ignore_abort and self._abort is not None:
+            abort_task = asyncio.ensure_future(self._abort.wait())
+            waiters.add(abort_task)
         try:
             done, _pending = await asyncio.wait(
-                {arrived, abort_task},
-                timeout=timeout,
-                return_when=asyncio.FIRST_COMPLETED,
+                waiters, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
             )
         finally:
-            abort_task.cancel()
+            if abort_task is not None:
+                abort_task.cancel()
         return arrived.result() if arrived in done else None
 
     def _is_arrival(self, state_obj, target: int, caps) -> bool:
@@ -576,16 +641,27 @@ class TravelTimeCalibrator:
         self._results[entity_id] = {"status": status, **extra}
         self._notify()
 
-    def _pruned_table(self, entities: Iterable[str]) -> dict[str, dict[str, Any]]:
-        """Return the stored table, minus covers this instance no longer controls.
+    def _merged_table(
+        self, entities: Iterable[str], measured: Mapping[str, dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        """Rebase this run's measurements onto the table as it stands NOW.
 
-        Swapping a cover out in the options flow would otherwise leave its row
-        behind forever, quietly inflating the "N of M calibrated" count and
-        keeping a dead entity in the diagnostics.
+        Read at persist time, not run start. A sweep takes minutes, and the
+        options flow can write a hand-entered time for an unmeasurable cover in
+        the meantime — that write is the only way such a cover ever gets a time,
+        so overwriting it with a stale snapshot would undo the one thing the
+        user could do for it. This is the mirror of the flow's own save-time
+        merge; between them, neither side can clobber the other.
+
+        Also drops rows for covers this instance no longer controls: swapping a
+        cover out would otherwise leave its row behind forever, inflating the
+        "N of M calibrated" count and keeping a dead entity in diagnostics.
         """
         stored = self._get_options().get(CONF_TRAVEL_TIME_CALIBRATION) or {}
         keep = set(entities)
-        return {eid: dict(row) for eid, row in stored.items() if eid in keep}
+        table = {eid: dict(row) for eid, row in stored.items() if eid in keep}
+        table.update({eid: dict(row) for eid, row in measured.items() if eid in keep})
+        return table
 
     def _notify(self) -> None:
         if self._on_progress is not None:

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -252,10 +252,6 @@ class TravelTimeCalibrator:
         self._results = {}
         self._last_error = None
         self._state = TRAVEL_CALIBRATION_STATE_RUNNING
-        # Hand the covers over: automation and reconciliation both stand down
-        # until the finally below gives them back.
-        self._cmd_svc.calibrating = True
-        self._notify()
 
         # Only what THIS run measured. Deliberately not a copy of the stored
         # table: the run is long, and anything else that writes to the table
@@ -263,12 +259,24 @@ class TravelTimeCalibrator:
         # would be erased when a start-of-run snapshot was written back at the
         # end. The merge against live options happens at persist time instead.
         measured: dict[str, dict[str, Any]] = {}
-        # Captured before anything moves, so the restore pass can put every
-        # cover back exactly where the user left it.
-        origins = {eid: self._cmd_svc.get_current_position(eid) for eid in entities}
+        origins: dict[str, int | None] = {}
         failed = False
 
+        # EVERYTHING the finally has to undo lives inside this try — the
+        # handover, the first notify and the origin capture included. Those
+        # three used to sit above it, which meant an exception from any of them
+        # (``_notify`` runs entity callbacks; ``get_current_position`` reads HA)
+        # left ``calibrating`` set and the state on ``running`` forever: every
+        # command skipped as calibration_in_progress, and every later run
+        # refused by the is_running guard, for the life of the config entry.
         try:
+            # Hand the covers over: automation and reconciliation both stand
+            # down until the finally below gives them back.
+            self._cmd_svc.calibrating = True
+            self._notify()
+            # Captured before anything moves, so the restore pass can put every
+            # cover back exactly where the user left it.
+            origins = {eid: self._cmd_svc.get_current_position(eid) for eid in entities}
             for subject in self._policy.order_for_dispatch(entities):
                 if self._aborted:
                     break
@@ -372,7 +380,7 @@ class TravelTimeCalibrator:
         axis = self._policy.select_default_axis(caps)
 
         if not await self._apply_clearance(subject, entities):
-            if not self._aborted:
+            if not self._interrupted:
                 # A cancel is not evidence about the cover. Recording one as a
                 # clearance failure tells the user their shade is jammed on the
                 # strength of them having pressed Cancel — the same rule the
@@ -464,7 +472,7 @@ class TravelTimeCalibrator:
             caps = self._cmd_svc.get_cover_capabilities(partner)
             arrival = await self._drive_and_wait(partner, park_at, caps=caps)
             if not arrival.ok:
-                if not self._aborted:
+                if not self._interrupted:
                     self._logger.warning(
                         "Travel-time calibration: could not park %s at %s%% to "
                         "clear the way for %s",
@@ -636,7 +644,7 @@ class TravelTimeCalibrator:
             stamp = await self._wait_for(
                 arrived, self._probe_seconds, ignore_abort=ignore_abort
             )
-            if self._aborted and not ignore_abort:
+            if self._interrupted and not ignore_abort:
                 return _Arrival(None, motion[0])
             if motion[0] is None:
                 # Nothing was seen to move. Note this is checked BEFORE the
@@ -737,6 +745,18 @@ class TravelTimeCalibrator:
     def _hard_aborted(self) -> bool:
         return self._hard_abort is not None and self._hard_abort.is_set()
 
+    @property
+    def _interrupted(self) -> bool:
+        """Whether the run was stopped from OUTSIDE rather than by the cover.
+
+        A cancel and an exhausted run budget are both interruptions: neither is
+        evidence about whichever cover happened to be under way, so neither may
+        be written up as a verdict about it. One predicate for both, because the
+        three verdict sites were guarded against cancels only and a spent budget
+        went on to record a healthy shade as jammed.
+        """
+        return self._aborted or self._budget_spent()
+
     def _budget_spent(self) -> bool:
         """Whether this run has held the covers for as long as it may."""
         return self._deadline is not None and self._now() >= self._deadline
@@ -753,11 +773,11 @@ class TravelTimeCalibrator:
     def _timeout(self, subject: str) -> None:
         """Record a leg that never landed, and return None for the row.
 
-        Silent when the run was cancelled: the leg did not fail, it was
-        interrupted, and reporting a timeout would blame the cover for the
-        user's own Cancel.
+        Silent when the run was interrupted — cancelled, or out of budget. The
+        leg did not fail, it was cut short, and reporting a timeout would blame
+        the cover for the user's Cancel or for the clock.
         """
-        if self._aborted:
+        if self._interrupted:
             return None
         self._logger.warning(
             "Travel-time calibration timed out for %s — skipping it", subject

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -47,20 +47,18 @@ from ..const import (
     TRAVEL_CALIBRATION_STATUS_TIMEOUT,
     TRAVEL_CALIBRATION_STATUS_UNAVAILABLE,
     TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
+    REASON_ASSUMED_STATE,
+    REASON_CLEARANCE_FAILED,
+    REASON_IMPLAUSIBLE_RESULT,
+    REASON_NO_ENTITIES,
+    REASON_NO_MOTION_OBSERVED,
+    REASON_RESTORE,
     TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
     TRAVEL_TIME_MAX_SECONDS,
     TRAVEL_TIME_MIN_SECONDS,
 )
 from ..helpers import is_assumed_state
 from .cover_command.transit import is_state_in_transit
-
-# Why an entity was skipped, as recorded on its result row. Free text would
-# drift between the three sites that write it and the sensor that renders it.
-REASON_ASSUMED_STATE = "assumed_state"
-REASON_NO_MOTION_OBSERVED = "no_motion_observed"
-REASON_NO_ENTITIES = "no_entities"
-REASON_IMPLAUSIBLE_RESULT = "implausible_result"
-_REASON_CLEARANCE = "clearance_failed"
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -157,6 +155,13 @@ class TravelTimeCalibrator:
         # arrival wait, so a cancel takes effect at the next observation rather
         # than sitting behind a 180 s timeout.
         self._abort: asyncio.Event | None = None
+        # A second, stronger signal. The restore pass deliberately ignores
+        # ``_abort`` — it runs after a cancel has already been raised and still
+        # has to wait for each cover in turn — so without this it would be
+        # uncancellable, and an unload would sit through a full per-move timeout
+        # per cover. Set by an unload/panic cancel (``restore=False``), never by
+        # the options-flow Cancel, which is asking for the restore to happen.
+        self._hard_abort: asyncio.Event | None = None
         self._restore_on_cancel: bool = True
 
     # ------------------------------------------------------------------ #
@@ -200,6 +205,10 @@ class TravelTimeCalibrator:
             return False
         self._restore_on_cancel = restore
         self._abort.set()
+        if not restore and self._hard_abort is not None:
+            # "Stop moving" means stop moving, including a restore already under
+            # way — the panic-stop and unload callers want no further commands.
+            self._hard_abort.set()
         return True
 
     async def async_run(self) -> None:
@@ -221,7 +230,15 @@ class TravelTimeCalibrator:
             self._notify()
             return
 
+        # Refresh the policy's option-derived state before anything asks it a
+        # question. A run can be started from the options flow at any time, and
+        # the clearance gate the restore leans on reads role state the
+        # coordinator normally primes per cycle — cold, it would report every
+        # coupled entity free to move.
+        self._policy.sync_runtime_options(dict(self._get_options()))
+
         self._abort = asyncio.Event()
+        self._hard_abort = asyncio.Event()
         self._restore_on_cancel = True
         self._results = {}
         self._last_error = None
@@ -261,6 +278,20 @@ class TravelTimeCalibrator:
             try:
                 if not self._aborted or self._restore_on_cancel:
                     await self._restore(origins)
+            except Exception:  # noqa: BLE001 — see below
+                # Swallowed deliberately, and this is the one place in the module
+                # where that is right. Everything after this point is what makes
+                # the run recoverable: clearing ``calibrating``, leaving a
+                # terminal state, and persisting the measurements. Letting a
+                # failed go-home move escape would skip all three and strand the
+                # calibrator reporting ``running`` forever — after which every
+                # later run early-returns at the is_running guard and the feature
+                # is dead for the life of the config entry.
+                self._logger.exception(
+                    "Travel-time calibration could not return the covers to "
+                    "their original positions"
+                )
+                failed = True
             finally:
                 # Always, on every path: a run that leaves this set has switched
                 # automation off indefinitely with no visible cause.
@@ -307,7 +338,9 @@ class TravelTimeCalibrator:
 
         if not await self._apply_clearance(subject, entities):
             self._record(
-                subject, TRAVEL_CALIBRATION_STATUS_TIMEOUT, reason=_REASON_CLEARANCE
+                subject,
+                TRAVEL_CALIBRATION_STATUS_TIMEOUT,
+                reason=REASON_CLEARANCE_FAILED,
             )
             return None
 
@@ -398,43 +431,54 @@ class TravelTimeCalibrator:
         return True
 
     async def _restore(self, origins: Mapping[str, int | None]) -> None:
-        """Put every cover back where the run found it, furthest traveller first.
+        """Put every cover back where the run found it, one at a time.
 
-        Ordering matters here for the same reason it matters during a sweep:
-        coupled entities cannot pass through each other. But this pass cannot use
-        ``order_for_dispatch`` — that view is keyed on the single number a seam
-        is fanning out, and a restore sends every cover to a DIFFERENT number, so
-        there is none to name. Asked without one it falls back to a fixed order,
-        which is wrong half the time.
+        Ordering matters for the same reason it matters during a sweep: coupled
+        entities cannot pass through each other. But this pass cannot derive an
+        order for itself. ``order_for_dispatch`` is keyed on the single number a
+        seam is fanning out and a restore sends every cover somewhere different;
+        sorting by distance instead looks plausible and is wrong — it ties when
+        two rails share an origin, and after a cancel the covers are scattered
+        mid-travel with no shared starting point to reason from.
 
-        The covers all sit on the same endpoint when a completed run ends, and
-        they all travel the same way out of it, so the safe order follows from
-        distance alone: whoever has furthest to go must lead, because it is the
-        one everyone else would otherwise have to travel through. That holds in
-        both frames without the calibrator knowing which it is in — on an upright
-        Model C install the leader works out to the middle rail (a raise), on an
-        inverse one to the bottom rail (a lower), which is exactly what each
-        direction requires.
+        So the order is not computed here at all. Each candidate is offered to
+        ``await_dispatch_clearance`` — the policy's own "may this entity move
+        there right now?" gate, the same one ``apply_position`` and
+        reconciliation consult — and only the ones it clears are dispatched.
+        Whatever was blocked is re-offered on the next lap, by which point the
+        cover in its way has landed. That is correct in every geometry and both
+        frames without this manager knowing what a rail is.
 
-        Sorting by distance also degrades sanely after a cancel, where covers can
-        be scattered mid-travel rather than parked together.
-
-        Outcomes are ignored: a cover that will not go home is a cosmetic
+        The loop stops as soon as a lap moves nothing: the remainder is either
+        genuinely stuck or its blocker never arrived, and spinning would hold
+        the covers hostage. A cover that will not go home is a cosmetic
         annoyance, not a reason to fail a run whose measurements succeeded.
         """
-        targets = {eid: pos for eid, pos in origins.items() if pos is not None}
-        ordered = sorted(
-            targets,
-            key=lambda eid: abs(
-                targets[eid] - (self._cmd_svc.get_current_position(eid) or 0)
-            ),
-            reverse=True,
-        )
-        for entity_id in ordered:
-            caps = self._cmd_svc.get_cover_capabilities(entity_id)
-            await self._drive_and_wait(
-                entity_id, targets[entity_id], caps=caps, ignore_abort=True
-            )
+        pending = {eid: pos for eid, pos in origins.items() if pos is not None}
+        while pending and not self._hard_aborted:
+            moved = False
+            for entity_id in list(pending):
+                if not await self._policy.await_dispatch_clearance(
+                    entity_id,
+                    position=pending[entity_id],
+                    reason=REASON_RESTORE,
+                    wait=False,
+                ):
+                    continue
+                caps = self._cmd_svc.get_cover_capabilities(entity_id)
+                await self._drive_and_wait(
+                    entity_id, pending.pop(entity_id), caps=caps, ignore_abort=True
+                )
+                moved = True
+                if self._hard_aborted:
+                    return
+            if not moved:
+                self._logger.debug(
+                    "Travel-time calibration: %d cover(s) could not be returned "
+                    "to their original position — nothing left is clear to move",
+                    len(pending),
+                )
+                return
 
     # ------------------------------------------------------------------ #
     # Driving and observing one move
@@ -578,9 +622,13 @@ class TravelTimeCalibrator:
         each cover in turn.
         """
         waiters: set[asyncio.Future] = {arrived}
+        # ``ignore_abort`` drops only the ordinary cancel. The hard abort is
+        # raced either way, so an unload or a panic stop is never left waiting
+        # out a per-move timeout.
+        signal = self._hard_abort if ignore_abort else self._abort
         abort_task: asyncio.Task | None = None
-        if not ignore_abort and self._abort is not None:
-            abort_task = asyncio.ensure_future(self._abort.wait())
+        if signal is not None:
+            abort_task = asyncio.ensure_future(signal.wait())
             waiters.add(abort_task)
         try:
             done, _pending = await asyncio.wait(
@@ -625,6 +673,10 @@ class TravelTimeCalibrator:
     @property
     def _aborted(self) -> bool:
         return self._abort is not None and self._abort.is_set()
+
+    @property
+    def _hard_aborted(self) -> bool:
+        return self._hard_abort is not None and self._hard_abort.is_set()
 
     def _now(self) -> dt.datetime:
         return dt.datetime.now(dt.UTC)

--- a/custom_components/adaptive_cover_pro/managers/travel_calibration.py
+++ b/custom_components/adaptive_cover_pro/managers/travel_calibration.py
@@ -53,12 +53,15 @@ from ..const import (
     REASON_NO_ENTITIES,
     REASON_NO_MOTION_OBSERVED,
     REASON_RESTORE,
+    REASON_RUN_BUDGET_EXCEEDED,
+    TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS,
     TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
     TRAVEL_TIME_MAX_SECONDS,
     TRAVEL_TIME_MIN_SECONDS,
 )
 from ..cover_types.base import caps_get
 from ..helpers import is_assumed_state
+from .cover_command.state_store import TravelCalibration
 from .cover_command.transit import is_state_in_transit
 
 
@@ -129,6 +132,7 @@ class TravelTimeCalibrator:
         on_progress: Callable[[], None] | None = None,
         move_timeout_seconds: int = DEFAULT_TRAVEL_CALIBRATION_TIMEOUT_SECONDS,
         probe_seconds: int = TRAVEL_CALIBRATION_TRANSIT_PROBE_SECONDS,
+        run_budget_seconds: int = TRAVEL_CALIBRATION_RUN_BUDGET_SECONDS,
     ) -> None:
         """Wire the calibrator to its collaborators.
 
@@ -147,6 +151,9 @@ class TravelTimeCalibrator:
         self._on_progress = on_progress
         self._move_timeout = float(move_timeout_seconds)
         self._probe_seconds = float(probe_seconds)
+        self._run_budget = float(run_budget_seconds)
+        # Wall-clock deadline for the current run, or None when idle.
+        self._deadline: dt.datetime | None = None
 
         self._state: str = TRAVEL_CALIBRATION_STATE_IDLE
         self._results: dict[str, dict[str, Any]] = {}
@@ -240,6 +247,7 @@ class TravelTimeCalibrator:
 
         self._abort = asyncio.Event()
         self._hard_abort = asyncio.Event()
+        self._deadline = self._now() + dt.timedelta(seconds=self._run_budget)
         self._restore_on_cancel = True
         self._results = {}
         self._last_error = None
@@ -263,6 +271,18 @@ class TravelTimeCalibrator:
         try:
             for subject in self._policy.order_for_dispatch(entities):
                 if self._aborted:
+                    break
+                if self._budget_spent():
+                    # Stand down rather than keep the covers: every further
+                    # second is a second a safety command cannot reach them.
+                    self._logger.warning(
+                        "Travel-time calibration exceeded its %.0fs budget — "
+                        "standing down with %s and any later covers unmeasured",
+                        self._run_budget,
+                        subject,
+                    )
+                    self._last_error = REASON_RUN_BUDGET_EXCEEDED
+                    self._abort.set()
                     break
                 self._active = subject
                 self._notify()
@@ -321,6 +341,7 @@ class TravelTimeCalibrator:
             # exists to handle.
             if not self._hard_aborted:
                 await self._persist(self._merged_table(entities, measured))
+            self._deadline = None
             self._notify()
 
     # ------------------------------------------------------------------ #
@@ -351,11 +372,16 @@ class TravelTimeCalibrator:
         axis = self._policy.select_default_axis(caps)
 
         if not await self._apply_clearance(subject, entities):
-            self._record(
-                subject,
-                TRAVEL_CALIBRATION_STATUS_TIMEOUT,
-                reason=REASON_CLEARANCE_FAILED,
-            )
+            if not self._aborted:
+                # A cancel is not evidence about the cover. Recording one as a
+                # clearance failure tells the user their shade is jammed on the
+                # strength of them having pressed Cancel — the same rule the
+                # probe and timed-leg paths follow.
+                self._record(
+                    subject,
+                    TRAVEL_CALIBRATION_STATUS_TIMEOUT,
+                    reason=REASON_CLEARANCE_FAILED,
+                )
             return None
 
         # Seed — untimed. Only job is to put the cover on a known endpoint so
@@ -410,16 +436,20 @@ class TravelTimeCalibrator:
             )
             return None
 
-        row = {
-            "full_travel_seconds": round(full, 2),
-            "open_seconds": round(opening.travel_seconds, 2),
-            "close_seconds": round(closing.travel_seconds, 2),
-            "start_delay_seconds": round(
+        # Through the dataclass, not literals: it is the single definition of
+        # these key names, and the manual-entry write already goes through it.
+        # Two hand-written copies is how a new field ships in one row shape and
+        # silently not the other.
+        row = TravelCalibration(
+            full_travel_seconds=round(full, 2),
+            open_seconds=round(opening.travel_seconds, 2),
+            close_seconds=round(closing.travel_seconds, 2),
+            start_delay_seconds=round(
                 (opening.start_delay_seconds + closing.start_delay_seconds) / 2, 2
             ),
-            "calibrated_at": self._now().isoformat(),
-            "source": TRAVEL_CALIBRATION_SOURCE_MEASURED,
-        }
+            calibrated_at=self._now().isoformat(),
+            source=TRAVEL_CALIBRATION_SOURCE_MEASURED,
+        ).to_dict()
         self._record(subject, TRAVEL_CALIBRATION_STATUS_OK, **row)
         return row
 
@@ -434,13 +464,14 @@ class TravelTimeCalibrator:
             caps = self._cmd_svc.get_cover_capabilities(partner)
             arrival = await self._drive_and_wait(partner, park_at, caps=caps)
             if not arrival.ok:
-                self._logger.warning(
-                    "Travel-time calibration: could not park %s at %s%% to clear "
-                    "the way for %s",
-                    partner,
-                    park_at,
-                    subject,
-                )
+                if not self._aborted:
+                    self._logger.warning(
+                        "Travel-time calibration: could not park %s at %s%% to "
+                        "clear the way for %s",
+                        partner,
+                        park_at,
+                        subject,
+                    )
                 return False
         return True
 
@@ -638,6 +669,10 @@ class TravelTimeCalibrator:
         definition runs with the abort already set and still has to wait for
         each cover in turn.
         """
+        # Clamped so one stuck move cannot outlive the whole-run budget: the
+        # per-move timeout bounds a move, the budget bounds the run, and the
+        # gate this run holds is absolute for the duration of both.
+        timeout = min(timeout, self._remaining_budget())
         waiters: set[asyncio.Future] = {arrived}
         # ``ignore_abort`` drops only the ordinary cancel. The hard abort is
         # raced either way, so an unload or a panic stop is never left waiting
@@ -701,6 +736,16 @@ class TravelTimeCalibrator:
     @property
     def _hard_aborted(self) -> bool:
         return self._hard_abort is not None and self._hard_abort.is_set()
+
+    def _budget_spent(self) -> bool:
+        """Whether this run has held the covers for as long as it may."""
+        return self._deadline is not None and self._now() >= self._deadline
+
+    def _remaining_budget(self) -> float:
+        """Seconds left in the run budget, floored at zero."""
+        if self._deadline is None:
+            return self._move_timeout
+        return max(0.0, (self._deadline - self._now()).total_seconds())
 
     def _now(self) -> dt.datetime:
         return dt.datetime.now(dt.UTC)

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -22,6 +22,12 @@ from homeassistant.util import dt as dt_util
 from .const import (
     BLIND_SPOT_SLOTS,
     CONF_CLIMATE_MODE,
+    CONF_TRAVEL_TIME_CALIBRATION,
+    TRAVEL_CALIBRATION_STATE_CANCELLED,
+    TRAVEL_CALIBRATION_STATE_COMPLETE,
+    TRAVEL_CALIBRATION_STATE_FAILED,
+    TRAVEL_CALIBRATION_STATE_IDLE,
+    TRAVEL_CALIBRATION_STATE_RUNNING,
     CONF_CLOUD_COVERAGE_ENTITY,
     CONF_CLOUD_SUPPRESSION,
     CONF_ENABLE_GLARE_ZONES,
@@ -437,6 +443,22 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
     if transit:
         attrs["transit_states"] = transit
 
+    # Travel-time ramps for whatever is moving right now, plus the table they
+    # were derived from. The plan is the primary contract — a card interpolates
+    # it locally at display framerate — and ``estimated_positions`` is the same
+    # thing sampled now, for consumers that cannot. All three follow the
+    # ``transit_states`` convention of being emitted only when non-empty, so an
+    # uncalibrated install's attribute set is unchanged.
+    travel_plans = s.coordinator._cmd_svc.travel_plans()  # noqa: SLF001
+    if travel_plans:
+        attrs["travel_plans"] = travel_plans
+        attrs["estimated_positions"] = (
+            s.coordinator._cmd_svc.estimated_positions()
+        )  # noqa: SLF001
+    calibration = s.coordinator.config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION)
+    if calibration:
+        attrs["travel_time_calibration"] = calibration
+
     snapshot = s.coordinator._snapshot  # noqa: SLF001
     if snapshot and snapshot.cover_positions:
         actual_positions = dict(snapshot.cover_positions)
@@ -769,6 +791,27 @@ def _position_verification_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] |
     if recon_times:
         attrs["last_reconcile_time"] = max(recon_times)
     return attrs
+
+
+def _travel_calibration_value(s: _ACPDiagnosticSensor) -> str:
+    return s.coordinator.travel_calibration.state
+
+
+def _travel_calibration_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
+    """Per-entity outcomes, plus the stored table the run wrote.
+
+    Carries the skipped rows as well as the measured ones: "this cover reports
+    an assumed state and therefore needs a travel time typed in" is the single
+    most useful thing this sensor can tell someone, and it is invisible if only
+    successes are reported.
+    """
+    diag = s.coordinator.travel_calibration.diagnostics()
+    return {
+        "active_entity": diag["active_entity"],
+        "last_error": diag["last_error"],
+        "results": diag["results"],
+        "calibration": s.config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {},
+    }
 
 
 def _motion_status_value(s: _ACPDiagnosticSensor) -> str:
@@ -1233,6 +1276,12 @@ _STANDARD_SPECS: tuple[_SensorSpec, ...] = (
                 "linear_actual_positions",
                 "actual_distances",
                 "position_explanation",
+                # Travel-ramp surfaces change on every move — and, while the
+                # republish tick is running, once a second. Recording them would
+                # be pure churn: they describe a moment, not a history.
+                "travel_plans",
+                "estimated_positions",
+                "travel_time_calibration",
             }
         ),
     ),
@@ -1375,6 +1424,25 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         should_poll=False,
         value_fn=_motion_status_value,
         attrs_fn=_motion_status_attrs,
+    ),
+    _SensorSpec(
+        suffix="travel_calibration",
+        display_name="Travel Time Calibration",
+        icon="mdi:timer-cog-outline",
+        translation_key="travel_calibration",
+        device_class=SensorDeviceClass.ENUM,
+        options=(
+            TRAVEL_CALIBRATION_STATE_IDLE,
+            TRAVEL_CALIBRATION_STATE_RUNNING,
+            TRAVEL_CALIBRATION_STATE_COMPLETE,
+            TRAVEL_CALIBRATION_STATE_FAILED,
+            TRAVEL_CALIBRATION_STATE_CANCELLED,
+        ),
+        value_fn=_travel_calibration_value,
+        attrs_fn=_travel_calibration_attrs,
+        # Per-entity dicts that only change when a run does — recording them
+        # would store the same blob indefinitely between calibrations.
+        unrecorded_attributes=frozenset({"results", "calibration"}),
     ),
     _SensorSpec(
         suffix="climate_status",

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -344,6 +344,21 @@ def _set_enabled(
     coord.logger.debug("%s service: %s", service, outcome)
 
 
+def _stand_down_calibration(coord: AdaptiveDataUpdateCoordinator) -> None:
+    """Cancel any travel-time run BEFORE the covers are stopped.
+
+    Ordering is the whole point, which is why this is not folded into
+    ``_disable`` (which runs after the caller's stop pass). A calibration run
+    drives covers through ``_execute_command``, which bypasses the enabled gate
+    — so a run left going would keep issuing commands during and after the stop,
+    quietly undoing it.
+
+    ``restore=False``: both callers are asking for the covers to stop moving, and
+    sending them home is more movement.
+    """
+    coord.async_cancel_travel_calibration(restore=False)
+
+
 def _disable(
     coord: AdaptiveDataUpdateCoordinator,
     service: str,
@@ -415,6 +430,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async def handle_integration_disable(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
         for coord, entity_filter in targets.items():
+            _stand_down_calibration(coord)
             # Stop in-flight moves first (before gate closes)
             await coord._cmd_svc.stop_in_flight(entities=entity_filter)  # noqa: SLF001
             _disable(coord, "integration_disable", "disabled")
@@ -422,6 +438,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async def handle_emergency_stop(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
         for coord, entity_filter in targets.items():
+            _stand_down_calibration(coord)
             # Blanket stop: all configured covers (not just wait_for_target)
             entity_ids = (
                 list(entity_filter) if entity_filter is not None else coord.entities

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -88,7 +88,8 @@
     "proxy_no_min": "⚠️ Proxy-Beschattung ist aktiviert, aber kein benutzerdefinierter Positionsslot hat Als Minimum verwenden aktiviert — die verwaltete Beschattung wird nicht begrenzt.",
     "custom_and_no_sensors": "⚠️ Benutzerdefiniert #{slot}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
     "group_empty": "⚠️ Diese Gruppe hat keine Mitglieder – sie wird nichts steuern.",
-    "forecast_source_no_weather_entity": "⚠️ Außentemperaturquelle basiert auf Vorhersage, aber es ist keine Wetter-Entität konfiguriert — die Vorhersage wird stillschweigend auf den Live-Messwert zurückfallen. Konfigurieren Sie eine Wetter-Entität unter Wetter, Licht & Wolken."
+    "forecast_source_no_weather_entity": "⚠️ Außentemperaturquelle basiert auf Vorhersage, aber es ist keine Wetter-Entität konfiguriert — die Vorhersage wird stillschweigend auf den Live-Messwert zurückfallen. Konfigurieren Sie eine Wetter-Entität unter Wetter, Licht & Wolken.",
+    "travel_time_unmeasurable": "⚠️ {entities} melden einen angenommenen Zustand, daher kann ihre Laufzeit nicht gemessen werden und keine wurde eingegeben — Dashboards zeigen keine Bewegung. Geben Sie eine Zeit unter Kalibrierung → Laufzeit ein."
   },
   "motion": {
     "action_hold": "Behänge halten aktuelle Position (zurück zum Standard, wenn Sonne den Sonnen-Akzeptanzwinkel verlässt)",
@@ -213,7 +214,9 @@
     "sun_tracking_min": "Sonnenverfolgung Min: {pos}%",
     "separator": " · ",
     "position_matching_off": "📍 Positionsabgleich aus (Befehl wird einmal gesendet; Abweichung wird als manuelle Übersteuerung behandelt)",
-    "position_matching_on": "📍 Positionsabgleich an (Befehle werden wiederholt bis zum Erreichen der Zielposition)"
+    "position_matching_on": "📍 Positionsabgleich an (Befehle werden wiederholt bis zum Erreichen der Zielposition)",
+    "travel_time": "Laufzeit: {done}/{total} Beschattungen",
+    "travel_time_manual": "Laufzeit: {done}/{total} Beschattungen ({manual} manuell eingegeben)"
   },
   "my": {
     "entities_enabled": "🎛️ My-Preset-Entitäten: aktiviert",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -88,7 +88,8 @@
     "proxy_no_min": "⚠️ Proxy cover is enabled but no custom-position slot has Use as minimum on — the managed cover will not clamp.",
     "custom_and_no_sensors": "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are configured — the template alone activates the slot.",
     "group_empty": "⚠️ This group has no members — it will not command anything.",
-    "forecast_source_no_weather_entity": "⚠️ Outdoor-temperature source is forecast-based but no weather entity is configured — the forecast will silently fall back to the live reading. Configure a weather entity in Weather, Light & Cloud."
+    "forecast_source_no_weather_entity": "⚠️ Outdoor-temperature source is forecast-based but no weather entity is configured — the forecast will silently fall back to the live reading. Configure a weather entity in Weather, Light & Cloud.",
+    "travel_time_unmeasurable": "⚠️ {entities} report an assumed state, so their travel time cannot be measured and none has been entered — dashboards will not show them moving. Enter a time under Calibration → Travel Time."
   },
   "motion": {
     "template_source": "occupancy template",
@@ -213,7 +214,9 @@
     "calibration": "Calibration {lo}→{hi}",
     "calibration_on": "Position calibration on",
     "sun_tracking_min": "Sun-tracking min: {pos}%",
-    "separator": " · "
+    "separator": " · ",
+    "travel_time": "Travel time: {done}/{total} covers",
+    "travel_time_manual": "Travel time: {done}/{total} covers ({manual} entered by hand)"
   },
   "my": {
     "entities_enabled": "🎛️ My-preset entities: enabled",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -88,7 +88,8 @@
     "proxy_no_min": "⚠️ Store mandataire est activé mais aucun emplacement de position personnalisée n'a Utiliser comme minimum activé — le store géré ne limitera pas.",
     "custom_and_no_sensors": "⚠️ Personnalisé #{slot} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
     "group_empty": "⚠️ Ce groupe n'a pas de membres — il ne commandera rien.",
-    "forecast_source_no_weather_entity": "⚠️ La source de température extérieure est basée sur les prévisions mais aucune entité météo n'est configurée — les prévisions vont silencieusement revenir au relevé en direct. Configurez une entité météo dans Météo, lumière & nuages."
+    "forecast_source_no_weather_entity": "⚠️ La source de température extérieure est basée sur les prévisions mais aucune entité météo n'est configurée — les prévisions vont silencieusement revenir au relevé en direct. Configurez une entité météo dans Météo, lumière & nuages.",
+    "travel_time_unmeasurable": "⚠️ {entities} signalent un état supposé, donc leur temps de course ne peut pas être mesuré et aucun n'a été entré — les tableaux de bord ne les montreront pas en mouvement. Entrez une durée sous Étalonnage → Temps de course."
   },
   "motion": {
     "action_hold": "les stores maintiennent la position actuelle (retournent à la position par défaut quand le soleil quitte l'angle d'ouverture solaire)",
@@ -213,7 +214,9 @@
     "sun_tracking_min": "Min suivi solaire : {pos}%",
     "separator": " · ",
     "position_matching_off": "📍 Correspondance de position désactivée (commande unique; une stabilisation au-delà de la tolérance devient une dérogation manuelle)",
-    "position_matching_on": "📍 Correspondance de position activée (renvoie jusqu'à ce que la store atteigne la position cible)"
+    "position_matching_on": "📍 Correspondance de position activée (renvoie jusqu'à ce que la store atteigne la position cible)",
+    "travel_time": "Temps de course : {done}/{total} stores",
+    "travel_time_manual": "Temps de course : {done}/{total} stores ({manual} entrées manuellement)"
   },
   "my": {
     "entities_enabled": "🎛️ Entités préréglage My : activées",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1115,7 +1115,7 @@
         "title": "Laufzeit"
       },
       "travel_time_manual": {
-        "description": "Sekunden für eine vollständige Fahrt von vollständig geschlossen bis vollständig offen. Setzen Sie eine Beschattung auf **0**, um ihre Zeit zu löschen.\n\nEine ungefähre Zahl ist wertvoll: Sie beeinflusst nur, wie die Bewegung angezeigt wird, niemals, wohin die Beschattung geschickt wird. Das Timing eines vollständigen Schließens mit einer Stoppuhr ist ausreichend.\n\n{cover_list}",
+        "description": "Sekunden für eine vollständige Fahrt von vollständig geschlossen bis vollständig offen. Setzen Sie eine Beschattung auf **0**, um ihre Zeit zu löschen; alles andere muss mindestens {min_seconds} Sekunden betragen.\n\nEine ungefähre Zahl ist wertvoll: Sie beeinflusst nur, wie die Bewegung angezeigt wird, niemals, wohin die Beschattung geschickt wird. Das Timing eines vollständigen Schließens mit einer Stoppuhr ist ausreichend.\n\n{cover_list}",
         "title": "Laufzeit — manuelle Eingabe"
       }
     },
@@ -1126,6 +1126,9 @@
       "user_cancelled": "Synchronisierung abgebrochen.",
       "sync_complete": "Einstellungen erfolgreich synchronisiert.",
       "no_eligible_cover_types": "Kein anderer Beschattungstyp kann die an diese Instanz gebundenen Beschattungen steuern, daher gibt es nichts zum Wechseln."
+    },
+    "error": {
+      "travel_time_too_short": "Eine Laufzeit muss mindestens {min_seconds} Sekunden betragen, oder 0 zum Löschen. Ein kürzerer Wert ist fast immer ein Tippfehler – und eine Beschattung, die wirklich in unter einer Sekunde fährt, hat nichts Wertvolles zu animieren."
     }
   },
   "entity": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -298,7 +298,6 @@
           "behavior": "🎛️ Verhalten & Timing",
           "blind_spot": "🌳 Blindfleck",
           "glare_zones": "🔆 Blendungszonen",
-          "interp": "📊 Positionskalibrierung",
           "automation": "⏱️ Bewegung & Zeitplan",
           "weather": "Wetterbedingungen",
           "manual_override": "✋ Manuelle Übersteuerung",
@@ -320,7 +319,8 @@
           "group_membership": "👥 Gruppenmitglieder",
           "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung",
           "group_entities": "🧩 Verfügbar gemachte Entitäten",
-          "change_cover_type": "🔁 Beschattungstyp ändern"
+          "change_cover_type": "🔁 Beschattungstyp ändern",
+          "calibration": "📐 Kalibrierung"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1093,6 +1093,30 @@
         },
         "description": "Wechsel von **{from_type}** zu **{to_type}**.\n\nEinstellungen, die nur der alte Typ verwendet, bleiben gespeichert und werden nicht gelöscht, sodass ein Zurückwechsel sie intakt vorfindet. Nach dem Wechsel derzeit inaktiv:\n\n{stranded_options}\n\nFunktionseigenschaften für den neuen Typ:\n\n{capability_notes}\n\nPositionspolarität:\n\n{position_polarity}\n\nJede Entität behält ihre Entitäts-ID. Typspezifische Entitäten, die der neue Typ nicht bereitstellt, bleiben in der Entitätsregistrierung als nicht verfügbar und werden wiederhergestellt, wenn Sie zurückwechseln. Füllen Sie nach der Bestätigung die Geometrie des neuen Typs aus und beenden Sie mit Speichern und schließen, um die Änderung anzuwenden.",
         "title": "Beschattungstyp ändern – Bestätigung"
+      },
+      "calibration": {
+        "description": "Messen Sie, wie diese Beschattung tatsächlich funktioniert, und speichern Sie die Messergebnisse.\n\n**Positionskalibrierung** ordnet die von Adaptive Cover Pro berechnete Position der Zahl zu, die Ihre Beschattung erreichen muss. **Laufzeit** speichert, wie lange ein vollständiges Öffnen oder Schließen dauert, sodass Dashboards die Bewegung der Beschattung anzeigen können, statt sie zu springen.",
+        "menu_options": {
+          "init": "⬅️ Zurück",
+          "interp": "📊 Positionskalibrierung",
+          "travel_time": "⏱️ Laufzeit"
+        },
+        "title": "Kalibrierung"
+      },
+      "travel_time": {
+        "description": "Wie lange jede Beschattung braucht, um von vollständig geschlossen zu vollständig offen zu fahren. Wenn diese bekannt ist, kann Adaptive Cover Pro berichten, wo sich eine Beschattung *während der Bewegung* befindet, sodass Dashboard-Karten die Bewegung animieren, statt zum Ende zu springen.\n\nDie Messung fährt jede Beschattung zu beiden Endschaltern und misst die Zeit — mehrere Minuten, während derer die automatische Steuerung pausiert und sich die Beschattungen selbst bewegen. Sie werden danach an ihre ursprüngliche Position zurückgebracht.\n\nBeschattungen, deren Status Home Assistant nur *annehmen* kann (One-Way-Funk, typischerweise Somfy RTS), melden die Ankunft sofort nach Befehl, daher gibt es nichts zu messen. Geben Sie für diese manuell eine Zeit ein.\n\n{travel_time_status}",
+        "menu_options": {
+          "calibration": "⬅️ Zurück",
+          "travel_time_cancel": "⏹️ Messung abbrechen",
+          "travel_time_manual": "✏️ Zeiten manuell eingeben",
+          "travel_time_reset": "🗑️ Alle Zeiten löschen",
+          "travel_time_run": "▶️ Jetzt messen"
+        },
+        "title": "Laufzeit"
+      },
+      "travel_time_manual": {
+        "description": "Sekunden für eine vollständige Fahrt von vollständig geschlossen bis vollständig offen. Setzen Sie eine Beschattung auf **0**, um ihre Zeit zu löschen.\n\nEine ungefähre Zahl ist wertvoll: Sie beeinflusst nur, wie die Bewegung angezeigt wird, niemals, wohin die Beschattung geschickt wird. Das Timing eines vollständigen Schließens mit einer Stoppuhr ist ausreichend.\n\n{cover_list}",
+        "title": "Laufzeit — manuelle Eingabe"
       }
     },
     "abort": {
@@ -1181,6 +1205,16 @@
           "winter_mode": "Winter",
           "intermediate": "Zwischenmodus",
           "mixed": "Gemischt"
+        }
+      },
+      "travel_calibration": {
+        "name": "Kalibrierung der Laufzeit",
+        "state": {
+          "cancelled": "Abgebrochen",
+          "complete": "Abgeschlossen",
+          "failed": "Fehlgeschlagen",
+          "idle": "Bereit",
+          "running": "Messung läuft"
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -300,7 +300,7 @@
           "behavior": "🎛️ Behaviour & Timing",
           "blind_spot": "🌳 Blind Spot",
           "glare_zones": "🔆 Glare Zones",
-          "interp": "📊 Position Calibration",
+          "calibration": "📐 Calibration",
           "automation": "⏱️ Movement & Schedule",
           "weather": "Weather Conditions",
           "manual_override": "✋ Manual Override",
@@ -728,6 +728,30 @@
       "blind_spot": {
         "title": "Blind Spots",
         "description": "Up to 3 independent areas where obstacles block the sun (trees, buildings, roof overhangs). Each configured slot is listed below — pick one to edit it, or add a new one.\n\n[Learn more]({learn_more})"
+      },
+      "calibration": {
+        "title": "Calibration",
+        "description": "Measure how this cover actually behaves, and store what was measured.\n\n**Position Calibration** maps the position Adaptive Cover Pro calculates onto the number your cover needs to reach it. **Travel Time** records how long a full open or close takes, so dashboards can show the cover moving instead of jumping.",
+        "menu_options": {
+          "travel_time": "⏱️ Travel Time",
+          "interp": "📊 Position Calibration",
+          "init": "⬅️ Back"
+        }
+      },
+      "travel_time": {
+        "title": "Travel Time",
+        "description": "How long each cover takes to travel from fully closed to fully open. Once known, Adaptive Cover Pro can report where a cover is *while it is moving*, so dashboard cards animate the movement instead of jumping to the end.\n\nMeasuring runs every cover to both end stops and times it — several minutes, during which automatic control pauses and the covers move on their own. They are returned to where they started afterwards.\n\nCovers whose state Home Assistant can only *assume* (one-way radio, typically Somfy RTS) report arrival the instant they are commanded, so there is nothing to time. Enter a time by hand for those.\n\n{travel_time_status}",
+        "menu_options": {
+          "travel_time_run": "▶️ Measure now",
+          "travel_time_cancel": "⏹️ Cancel the run",
+          "travel_time_manual": "✏️ Enter times manually",
+          "travel_time_reset": "🗑️ Clear all times",
+          "calibration": "⬅️ Back"
+        }
+      },
+      "travel_time_manual": {
+        "title": "Travel Time — manual entry",
+        "description": "Seconds for a full travel from fully closed to fully open. Set a cover to **0** to clear its time.\n\nA rough figure is worth having: it only affects how movement is drawn, never where the cover is sent. Timing one full close with a stopwatch is plenty.\n\n{cover_list}"
       },
       "interp": {
         "data": {
@@ -1181,6 +1205,16 @@
           "winter_mode": "Winter",
           "intermediate": "Intermediate",
           "mixed": "Mixed"
+        }
+      },
+      "travel_calibration": {
+        "name": "Travel Time Calibration",
+        "state": {
+          "idle": "Idle",
+          "running": "Measuring",
+          "complete": "Complete",
+          "failed": "Failed",
+          "cancelled": "Cancelled"
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -751,7 +751,7 @@
       },
       "travel_time_manual": {
         "title": "Travel Time — manual entry",
-        "description": "Seconds for a full travel from fully closed to fully open. Set a cover to **0** to clear its time.\n\nA rough figure is worth having: it only affects how movement is drawn, never where the cover is sent. Timing one full close with a stopwatch is plenty.\n\n{cover_list}"
+        "description": "Seconds for a full travel from fully closed to fully open. Set a cover to **0** to clear its time; anything else must be at least {min_seconds} seconds.\n\nA rough figure is worth having: it only affects how movement is drawn, never where the cover is sent. Timing one full close with a stopwatch is plenty.\n\n{cover_list}"
       },
       "interp": {
         "data": {
@@ -1118,6 +1118,9 @@
           "glare_zone_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for."
         }
       }
+    },
+    "error": {
+      "travel_time_too_short": "A travel time must be at least {min_seconds} seconds, or 0 to clear it. A shorter value is almost always a typo — and a cover that really does traverse in under a second has nothing worth animating."
     },
     "abort": {
       "no_eligible_cover_types": "No other cover type can drive the covers bound to this instance, so there is nothing to switch to.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -298,7 +298,6 @@
           "behavior": "🎛️ Comportement & minuterie",
           "blind_spot": "🌳 Zone cachée",
           "glare_zones": "🔆 Zones d'éblouissement",
-          "interp": "📊 Étalonnage de position",
           "automation": "⏱️ Mouvement & horaires",
           "weather": "Conditions météorologiques",
           "manual_override": "✋ Dérogation manuelle",
@@ -320,7 +319,8 @@
           "group_membership": "👥 Membres du groupe",
           "group_arbitration": "⚖️ Arbitrage & Synchronisation",
           "group_entities": "🧩 Entités exposées",
-          "change_cover_type": "🔁 Modifier le type de store"
+          "change_cover_type": "🔁 Modifier le type de store",
+          "calibration": "📐 Étalonnage"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1093,6 +1093,30 @@
         },
         "description": "Basculement de **{from_type}** vers **{to_type}**.\n\nLes paramètres que seul l'ancien type utilise restent stockés et ne sont pas supprimés, ainsi revenir en arrière les retrouve intacts. Actuellement inactifs après le basculement :\n\n{stranded_options}\n\nNotes de capacité pour le nouveau type :\n\n{capability_notes}\n\nPolarité des positions :\n\n{position_polarity}\n\nChaque entité conserve son ID d'entité. Les entités spécifiques au type que le nouveau type ne fournit pas restent dans le registre des entités comme indisponibles et reviennent si vous revenez à l'ancien type. Après confirmation, remplissez la géométrie du nouveau type et terminez avec Enregistrer et fermer pour appliquer la modification.",
         "title": "Modifier le type de store — Confirmer"
+      },
+      "calibration": {
+        "description": "Mesurez le comportement réel de ce store et enregistrez les mesures.\n\n**L'étalonnage de position** mappe la position calculée par Adaptive Cover Pro sur le nombre que votre store doit atteindre. **Le temps de course** enregistre la durée d'une ouverture ou fermeture complète, afin que les cartes de tableau de bord puissent animer le mouvement au lieu de sauter.",
+        "menu_options": {
+          "init": "⬅️ Retour",
+          "interp": "📊 Étalonnage de position",
+          "travel_time": "⏱️ Temps de course"
+        },
+        "title": "Étalonnage"
+      },
+      "travel_time": {
+        "description": "La durée que met chaque store pour voyager de complètement fermé à complètement ouvert. Une fois mesurée, Adaptive Cover Pro peut indiquer où se trouve un store *alors qu'il se déplace*, afin que les cartes de tableau de bord animent le mouvement au lieu de sauter à la fin.\n\nLa mesure fait voyager chaque store jusqu'aux deux fins de course et les chronomètre — quelques minutes, pendant lesquelles le contrôle automatique s'arrête et les stores se déplacent d'eux-mêmes. Ils sont remis à leur position de départ ensuite.\n\nLes stores dont Home Assistant ne peut que *supposer* l'état (radio unidirectionnelle, typiquement Somfy RTS) signalent l'arrivée instantanément quand ils sont commandés, il n'y a donc rien à mesurer. Entrez une durée manuellement pour ceux-ci.\n\n{travel_time_status}",
+        "menu_options": {
+          "calibration": "⬅️ Retour",
+          "travel_time_cancel": "⏹️ Annuler la mesure",
+          "travel_time_manual": "✏️ Entrer les durées manuellement",
+          "travel_time_reset": "🗑️ Effacer toutes les durées",
+          "travel_time_run": "▶️ Mesurer maintenant"
+        },
+        "title": "Temps de course"
+      },
+      "travel_time_manual": {
+        "description": "Secondes pour un voyage complet de complètement fermé à complètement ouvert. Mettez un store à **0** pour effacer sa durée.\n\nUne valeur approximative est suffisante : elle n'affecte que la manière dont le mouvement est dessiné, jamais où le store est commandé. Chronométrer une fermeture complète avec un chronomètre est largement suffisant.\n\n{cover_list}",
+        "title": "Temps de course — entrée manuelle"
       }
     },
     "abort": {
@@ -1181,6 +1205,16 @@
           "winter_mode": "Hiver",
           "intermediate": "Intermédiaire",
           "mixed": "Mixte"
+        }
+      },
+      "travel_calibration": {
+        "name": "Étalonnage du temps de course",
+        "state": {
+          "cancelled": "Annulé",
+          "complete": "Terminé",
+          "failed": "Échoué",
+          "idle": "Inactif",
+          "running": "Mesure en cours"
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1115,7 +1115,7 @@
         "title": "Temps de course"
       },
       "travel_time_manual": {
-        "description": "Secondes pour un voyage complet de complètement fermé à complètement ouvert. Mettez un store à **0** pour effacer sa durée.\n\nUne valeur approximative est suffisante : elle n'affecte que la manière dont le mouvement est dessiné, jamais où le store est commandé. Chronométrer une fermeture complète avec un chronomètre est largement suffisant.\n\n{cover_list}",
+        "description": "Secondes pour un voyage complet de complètement fermé à complètement ouvert. Mettez un store à **0** pour effacer sa durée ; tout autre valeur doit être d'au moins {min_seconds} secondes.\n\nUne valeur approximative est suffisante : elle n'affecte que la manière dont le mouvement est dessiné, jamais où le store est commandé. Chronométrer une fermeture complète avec un chronomètre est largement suffisant.\n\n{cover_list}",
         "title": "Temps de course — entrée manuelle"
       }
     },
@@ -1126,6 +1126,9 @@
       "user_cancelled": "Synchronisation annulée.",
       "sync_complete": "Paramètres synchronisés avec succès.",
       "no_eligible_cover_types": "Aucun autre type de store ne peut gérer les protections liées à cette instance, il n'y a donc rien vers quoi basculer."
+    },
+    "error": {
+      "travel_time_too_short": "Un temps de course doit être d'au moins {min_seconds} secondes, ou 0 pour l'effacer. Une valeur plus courte est presque toujours une faute de frappe — et un store qui traverse vraiment en moins d'une seconde n'a rien à animer."
     }
   },
   "entity": {

--- a/tests/cover/test_proxy_cover_estimated_position.py
+++ b/tests/cover/test_proxy_cover_estimated_position.py
@@ -1,0 +1,203 @@
+"""The proxy cover animates from the travel-time model while a move is in flight.
+
+Travel plans on their own only reach the companion card. The proxy is what makes
+*any* HA cover card show movement, because it is an ordinary cover entity — so
+while its source has a live plan it publishes the modelled position instead of
+the source's last (stale, or absent) reading.
+
+That needs a republish tick, since nothing else would prompt a redraw between
+the command and the arrival. The tick's lifetime is the load-bearing part: it
+must exist exactly while something is moving, and never at idle.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_INVERSE_STATE,
+    CONF_SENSOR_TYPE,
+    CONF_TRAVEL_TIME_CALIBRATION,
+    DOMAIN,
+    TRAVEL_CALIBRATION_SOURCE_MEASURED,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command.state_store import (
+    TravelPlan,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+pytestmark = pytest.mark.integration
+
+_SOURCE = "cover.living_room"
+_T0 = dt.datetime(2026, 8, 2, 12, 0, 0, tzinfo=dt.UTC)
+
+_CALIBRATION = {
+    _SOURCE: {
+        "full_travel_seconds": 40.0,
+        "open_seconds": 40.0,
+        "close_seconds": 40.0,
+        "start_delay_seconds": 0.0,
+        "calibrated_at": _T0.isoformat(),
+        "source": TRAVEL_CALIBRATION_SOURCE_MEASURED,
+    }
+}
+
+
+async def _setup(hass, *, entry_id: str, extra_options: dict | None = None):
+    """Set up one proxied cover and return ``(coordinator, proxy_entity_id)``."""
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = [_SOURCE]
+    opts[CONF_ENABLE_PROXY_COVER] = True
+    opts[CONF_TRAVEL_TIME_CALIBRATION] = _CALIBRATION
+    if extra_options:
+        opts.update(extra_options)
+
+    hass.states.async_set(
+        _SOURCE, "open", {"current_position": 0, "supported_features": 143}
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Ramp Cover", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title="Ramp Cover",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+    return entry.runtime_data, proxy_eid
+
+
+def _start_ramp(
+    coordinator, *, from_position: int, to_position: int, elapsed: float = 20.0
+) -> None:
+    """Put a live travel plan on the source, ``elapsed`` seconds in."""
+    svc = coordinator._cmd_svc
+    state = svc.state(_SOURCE)
+    state.waiting = True
+    state.travel_plan = TravelPlan(
+        from_position=from_position,
+        to_position=to_position,
+        started_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=elapsed),
+        start_delay_seconds=0.0,
+        duration_seconds=40.0,
+    )
+
+
+async def test_proxy_reports_the_modelled_position_mid_move(hass) -> None:
+    """Half way through a 40 s sweep to 100, the proxy shows roughly half open.
+
+    The source is still publishing 0 — that is the whole problem the ramp
+    solves.
+    """
+    coordinator, proxy_eid = await _setup(hass, entry_id="ramp_mid")
+    _start_ramp(coordinator, from_position=0, to_position=100)
+
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(proxy_eid).attributes["current_position"] == pytest.approx(
+        50, abs=2
+    )
+
+
+async def test_proxy_falls_back_to_the_source_reading_when_idle(hass) -> None:
+    coordinator, proxy_eid = await _setup(hass, entry_id="ramp_idle")
+
+    hass.states.async_set(
+        _SOURCE, "open", {"current_position": 37, "supported_features": 143}
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(proxy_eid).attributes["current_position"] == 37
+
+
+async def test_estimate_is_un_inverted_like_any_other_reading(hass) -> None:
+    """The plan's endpoints are in the source's frame, so the estimate is too.
+
+    Deliberately sampled a quarter of the way through rather than half: at the
+    midpoint the flip is the identity, and a test that cannot fail if the
+    un-inversion is dropped is not testing it.
+    """
+    coordinator, proxy_eid = await _setup(
+        hass, entry_id="ramp_inverse", extra_options={CONF_INVERSE_STATE: True}
+    )
+    _start_ramp(coordinator, from_position=0, to_position=100, elapsed=10.0)
+
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    # Wire 25 → logical 75 on an inverse install.
+    assert hass.states.get(proxy_eid).attributes["current_position"] == pytest.approx(
+        75, abs=2
+    )
+
+
+async def test_estimate_is_published_raw_on_an_upright_install(hass) -> None:
+    """The same quarter-way sample, un-flipped — the control for the test above."""
+    coordinator, proxy_eid = await _setup(hass, entry_id="ramp_upright")
+    _start_ramp(coordinator, from_position=0, to_position=100, elapsed=10.0)
+
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(proxy_eid).attributes["current_position"] == pytest.approx(
+        25, abs=2
+    )
+
+
+async def test_tick_runs_only_while_a_plan_is_live(hass) -> None:
+    """No timer at idle, a timer during a move, and no timer after it lands.
+
+    A tick left running is a state write per second per instance, forever.
+    """
+    coordinator, _ = await _setup(hass, entry_id="ramp_tick")
+    assert coordinator._travel_tick_unsub is None
+
+    _start_ramp(coordinator, from_position=0, to_position=100)
+    coordinator._sync_travel_tick()
+    assert coordinator._travel_tick_unsub is not None
+
+    coordinator._cmd_svc._clear_waiting(coordinator._cmd_svc.state(_SOURCE))
+    coordinator._sync_travel_tick()
+    assert coordinator._travel_tick_unsub is None
+
+
+async def test_tick_stops_itself_once_the_last_plan_clears(hass) -> None:
+    """The tick is self-limiting — nothing else has to remember to cancel it."""
+    coordinator, _ = await _setup(hass, entry_id="ramp_tick_self")
+    _start_ramp(coordinator, from_position=0, to_position=100)
+    coordinator._sync_travel_tick()
+
+    coordinator._cmd_svc._clear_waiting(coordinator._cmd_svc.state(_SOURCE))
+    coordinator._travel_tick(dt.datetime.now(dt.UTC))
+
+    assert coordinator._travel_tick_unsub is None
+
+
+async def test_tick_is_cancelled_on_unload(hass) -> None:
+    coordinator, _ = await _setup(hass, entry_id="ramp_tick_unload")
+    _start_ramp(coordinator, from_position=0, to_position=100)
+    coordinator._sync_travel_tick()
+    assert coordinator._travel_tick_unsub is not None
+
+    await coordinator.async_shutdown()
+
+    assert coordinator._travel_tick_unsub is None

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -268,8 +268,9 @@ def _bare_coordinator(**overrides: Any) -> Any:
     six ``if self._X_unsub is not None: ...`` cancel blocks
     (``_forecast_unsub``, ``_forecast_max_unsub``, ``_gate_fallback_unsub``,
     ``_refresh_after_unsub``, ``_custom_position_hold_unsub``,
-    ``_sun_tracking_gate_unsub``), and the
-    ``_external_interlock_tasks`` map (#1138). Every test
+    ``_sun_tracking_gate_unsub``), the
+    ``_external_interlock_tasks`` map (#1138), and the travel-time calibrator
+    plus its republish tick handle. Every test
     that exercises ``async_shutdown`` against a from-scratch stub needs all of
     these stubbed or it raises ``AttributeError`` — this was hand-mirrored
     across ``tests/test_issue_632_daytime_gate.py`` and
@@ -298,6 +299,9 @@ def _bare_coordinator(**overrides: Any) -> Any:
     coord._custom_position_hold_unsub = None
     coord._sun_tracking_gate_unsub = None
     coord._external_interlock_tasks = {}
+    # Shutdown stands a calibration run down and cancels its republish tick.
+    coord._travel_calibrator = MagicMock()
+    coord._travel_tick_unsub = None
     for name, value in overrides.items():
         setattr(coord, f"_{name}", value)
     return coord

--- a/tests/test_config_flow_travel_time.py
+++ b/tests/test_config_flow_travel_time.py
@@ -20,6 +20,7 @@ import re
 
 import pytest
 from homeassistant.data_entry_flow import InvalidData
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -441,3 +442,94 @@ async def test_cancel_stops_the_run_and_returns_to_the_menu(
 
 async def _noop() -> None:
     return None
+
+
+async def test_a_sub_minimum_time_is_rejected_not_clamped(
+    hass: HomeAssistant,
+) -> None:
+    """The floor the constant advertises is actually enforced.
+
+    Clamping would store a number the user never typed; accepting would let the
+    manual path produce a ramp the measured path discards as implausible.
+    """
+    entry = await _setup_entry(hass, entry_id="tt_too_short")
+    _, flow_id = await _open_calibration(hass, entry)
+    result = await _submit_manual(hass, flow_id, {_COVER: 0.3})
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "travel_time_too_short"}
+    assert CONF_TRAVEL_TIME_CALIBRATION not in entry.options
+
+
+async def test_the_status_block_reflects_a_run_that_finished_mid_dialog(
+    hass: HomeAssistant,
+) -> None:
+    """The page that starts a run must show what the run produced.
+
+    Rendering the flow's opening snapshot would report every freshly-measured
+    cover as "not calibrated" on the very page that just measured it.
+    """
+    entry = await _setup_entry(hass, entry_id="tt_live_status")
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = result["flow_id"]
+
+    _write_behind_the_flow(hass, entry, {_COVER: dict(_MEASURED)})
+
+    flow = hass.config_entries.options._progress[flow_id]
+    assert "24.0" in flow._travel_time_status()
+    assert "not calibrated" not in flow._travel_time_status()
+
+
+async def test_a_run_writes_its_results_to_the_config_entry(
+    hass: HomeAssistant,
+) -> None:
+    """The whole persist path: calibrator → apply_options_patch → entry options.
+
+    Also pins that the write does NOT reload the entry — the key is registered
+    as runtime-applicable precisely because a reload would tear down the run
+    that produced the numbers.
+    """
+    from custom_components.adaptive_cover_pro import options_write_reloads
+
+    entry = await _setup_entry(hass, entry_id="tt_persist")
+    coordinator = entry.runtime_data
+    table = {_COVER: dict(_MEASURED)}
+
+    # A live coordinator has run at least one cycle, so it holds a baseline to
+    # diff against. Without one the listener reloads unconditionally, which is
+    # the right conservative default but not the state under test here.
+    coordinator._cached_options = dict(entry.options)
+    new_options = {**entry.options, CONF_TRAVEL_TIME_CALIBRATION: table}
+    assert options_write_reloads(entry, new_options) is False
+
+    await coordinator._async_persist_travel_calibration(table)
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_TRAVEL_TIME_CALIBRATION] == table
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_a_manual_entry_saved_mid_run_is_not_erased_when_the_run_ends(
+    hass: HomeAssistant,
+) -> None:
+    """The mirror of the flow-side merge.
+
+    A run holds the covers for minutes. If it wrote a start-of-run snapshot at
+    the end, a time hand-entered in the meantime — the ONLY way an unmeasurable
+    cover ever gets one — would be silently undone.
+    """
+    entry = await _setup_entry(
+        hass, entry_id="tt_persist_merge", entities=[_COVER, _OTHER]
+    )
+    calibrator = entry.runtime_data.travel_calibration
+    manual = {**_MEASURED, "source": TRAVEL_CALIBRATION_SOURCE_MANUAL}
+
+    # The run began with an empty table…
+    measured = {_COVER: dict(_MEASURED)}
+    # …and the user saved a manual time for the other cover while it ran.
+    _write_behind_the_flow(hass, entry, {_OTHER: manual})
+
+    merged = calibrator._merged_table([_COVER, _OTHER], measured)
+
+    assert merged[_COVER] == _MEASURED
+    assert merged[_OTHER] == manual

--- a/tests/test_config_flow_travel_time.py
+++ b/tests/test_config_flow_travel_time.py
@@ -16,6 +16,7 @@ everything the run measured.
 
 from __future__ import annotations
 
+import asyncio
 import re
 
 import pytest
@@ -25,6 +26,9 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.config_flow import _build_config_summary
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    PositionContext,
+)
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENTITIES,
     CONF_INTERP,
@@ -533,3 +537,40 @@ async def test_a_manual_entry_saved_mid_run_is_not_erased_when_the_run_ends(
 
     assert merged[_COVER] == _MEASURED
     assert merged[_OTHER] == manual
+
+
+async def test_a_weather_safety_target_stands_a_live_run_down(
+    hass: HomeAssistant,
+) -> None:
+    """End-to-end: the coordinator wires the pre-emption, not just the manager.
+
+    A storm reaching the covers matters more than a calibration finishing, and
+    the wiring is the part that could silently be missing — the manager's own
+    test stubs the callback.
+    """
+    entry = await _setup_entry(hass, entry_id="tt_safety_preempt")
+    coordinator = entry.runtime_data
+    calibrator = coordinator.travel_calibration
+    calibrator._state = "running"
+    calibrator._abort = asyncio.Event()
+    calibrator._hard_abort = asyncio.Event()
+    coordinator._cmd_svc.calibrating = True
+
+    await coordinator._cmd_svc.apply_position(
+        _COVER,
+        0,
+        "weather",
+        PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=1,
+            time_threshold=0,
+            special_positions=[],
+            is_safety=True,
+        ),
+    )
+
+    assert calibrator._abort.is_set()
+    # restore=False — the safety command is about to move the cover anyway.
+    assert calibrator._hard_abort.is_set()

--- a/tests/test_config_flow_travel_time.py
+++ b/tests/test_config_flow_travel_time.py
@@ -16,7 +16,6 @@ everything the run measured.
 
 from __future__ import annotations
 
-import asyncio
 import re
 
 import pytest
@@ -26,9 +25,6 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.config_flow import _build_config_summary
-from custom_components.adaptive_cover_pro.managers.cover_command import (
-    PositionContext,
-)
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENTITIES,
     CONF_INTERP,
@@ -539,38 +535,21 @@ async def test_a_manual_entry_saved_mid_run_is_not_erased_when_the_run_ends(
     assert merged[_OTHER] == manual
 
 
-async def test_a_weather_safety_target_stands_a_live_run_down(
+async def test_the_control_status_says_calibrating_while_a_run_holds_the_covers(
     hass: HomeAssistant,
 ) -> None:
-    """End-to-end: the coordinator wires the pre-emption, not just the manager.
+    """The gate blocks everything, so it has to say so.
 
-    A storm reaching the covers matters more than a calibration finishing, and
-    the wiring is the part that could silently be missing — the manager's own
-    test stubs the callback.
+    That visibility is the whole basis on which blocking is acceptable — without
+    it "nothing is moving and I cannot see why" is indistinguishable from a bug.
+    Reported above automatic_control, because while a run holds the covers no
+    other status describes a decision that is actually being acted on.
     """
-    entry = await _setup_entry(hass, entry_id="tt_safety_preempt")
+    entry = await _setup_entry(hass, entry_id="tt_status")
     coordinator = entry.runtime_data
-    calibrator = coordinator.travel_calibration
-    calibrator._state = "running"
-    calibrator._abort = asyncio.Event()
-    calibrator._hard_abort = asyncio.Event()
+
     coordinator._cmd_svc.calibrating = True
+    assert coordinator.build_diagnostic_data()["control_status"] == "calibrating"
 
-    await coordinator._cmd_svc.apply_position(
-        _COVER,
-        0,
-        "weather",
-        PositionContext(
-            auto_control=True,
-            manual_override=False,
-            sun_just_appeared=False,
-            min_change=1,
-            time_threshold=0,
-            special_positions=[],
-            is_safety=True,
-        ),
-    )
-
-    assert calibrator._abort.is_set()
-    # restore=False — the safety command is about to move the cover anyway.
-    assert calibrator._hard_abort.is_set()
+    coordinator._cmd_svc.calibrating = False
+    assert coordinator.build_diagnostic_data()["control_status"] != "calibrating"

--- a/tests/test_config_flow_travel_time.py
+++ b/tests/test_config_flow_travel_time.py
@@ -1,0 +1,443 @@
+"""The Calibration menu — travel time measured, typed in, or cleared.
+
+Two things here are more than UI plumbing.
+
+The **Calibration parent** exists because "calibration" already meant the
+position interpolation curve. Grouping that page with travel time under one
+parent is what lets each keep a name that says which it is.
+
+The **save-time merge** closes a real data-loss window. A measurement run is
+started from this menu and keeps going after the user navigates on; it writes
+its results straight to the config entry. The flow, meanwhile, is holding a
+snapshot of ``options`` taken when it opened, and saving writes that snapshot
+back wholesale — so without the merge, finishing the dialog silently erases
+everything the run measured.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from homeassistant.data_entry_flow import InvalidData
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.config_flow import _build_config_summary
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_INTERP,
+    CONF_SENSOR_TYPE,
+    CONF_TRAVEL_TIME_CALIBRATION,
+    DOMAIN,
+    TRAVEL_CALIBRATION_SOURCE_MANUAL,
+    TRAVEL_CALIBRATION_SOURCE_MEASURED,
+    TRAVEL_TIME_MAX_SECONDS,
+    CoverType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+pytestmark = pytest.mark.integration
+
+_COVER = "cover.living_room"
+_OTHER = "cover.kitchen"
+
+_MEASURED = {
+    "full_travel_seconds": 24.0,
+    "open_seconds": 26.0,
+    "close_seconds": 22.0,
+    "start_delay_seconds": 1.5,
+    "calibrated_at": "2026-08-02T12:00:00+00:00",
+    "source": TRAVEL_CALIBRATION_SOURCE_MEASURED,
+}
+
+
+async def _setup_entry(
+    hass: HomeAssistant,
+    *,
+    entry_id: str,
+    entities: list[str] | None = None,
+    extra_options: dict | None = None,
+    assumed: bool = False,
+) -> MockConfigEntry:
+    covers = entities or [_COVER]
+    for eid in covers:
+        attrs: dict = {"current_position": 40, "supported_features": 15}
+        if assumed:
+            attrs["assumed_state"] = True
+        hass.states.async_set(eid, "open", attrs)
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = covers
+    if extra_options:
+        opts.update(extra_options)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Travel", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title="Travel",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def _step(hass: HomeAssistant, flow_id: str, step: str):
+    return await hass.config_entries.options.async_configure(
+        flow_id, {"next_step_id": step}
+    )
+
+
+async def _open_calibration(hass: HomeAssistant, entry: MockConfigEntry):
+    """Init the options flow and step into the Calibration menu."""
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    flow_id = result["flow_id"]
+    return await _step(hass, flow_id, "calibration"), flow_id
+
+
+async def _open_travel_time(hass: HomeAssistant, flow_id: str):
+    """Step into Travel Time from wherever we are (via Calibration)."""
+    await _step(hass, flow_id, "calibration")
+    return await _step(hass, flow_id, "travel_time")
+
+
+async def _finish(hass: HomeAssistant, flow_id: str) -> None:
+    """Walk back out of the submenus and save.
+
+    Each menu only offers its own children plus a Back row, so Done is not
+    reachable from inside Travel Time — the walk is the same one a user makes.
+    """
+    await _step(hass, flow_id, "calibration")
+    await _step(hass, flow_id, "init")
+    await _step(hass, flow_id, "done")
+    await hass.async_block_till_done()
+
+
+# ------------------------------------------------------------------ #
+# Menu composition
+# ------------------------------------------------------------------ #
+
+
+async def test_calibration_replaces_interp_on_the_top_level_menu(
+    hass: HomeAssistant,
+) -> None:
+    entry = await _setup_entry(hass, entry_id="tt_menu")
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert "calibration" in result["menu_options"]
+    assert "interp" not in result["menu_options"]
+
+
+async def test_calibration_menu_always_offers_travel_time(hass: HomeAssistant) -> None:
+    entry = await _setup_entry(hass, entry_id="tt_menu_child")
+    result, _ = await _open_calibration(hass, entry)
+
+    assert result["type"] == "menu"
+    assert "travel_time" in result["menu_options"]
+
+
+async def test_position_calibration_stays_conditional_on_its_own_option(
+    hass: HomeAssistant,
+) -> None:
+    """Moving ``interp`` under a parent must not make it unconditionally visible."""
+    off = await _setup_entry(hass, entry_id="tt_interp_off")
+    result, _ = await _open_calibration(hass, off)
+    assert "interp" not in result["menu_options"]
+
+    on = await _setup_entry(
+        hass, entry_id="tt_interp_on", extra_options={CONF_INTERP: True}
+    )
+    result, _ = await _open_calibration(hass, on)
+    assert "interp" in result["menu_options"]
+
+
+async def test_cancel_is_offered_only_while_a_run_is_in_flight(
+    hass: HomeAssistant,
+) -> None:
+    """Start and cancel are mutually exclusive — never both, never neither."""
+    entry = await _setup_entry(hass, entry_id="tt_cancel_entry")
+    _, flow_id = await _open_calibration(hass, entry)
+    idle = await _step(hass, flow_id, "travel_time")
+    assert "travel_time_run" in idle["menu_options"]
+    assert "travel_time_cancel" not in idle["menu_options"]
+
+    entry.runtime_data.travel_calibration._state = "running"
+    running = await _open_travel_time(hass, flow_id)
+    assert "travel_time_cancel" in running["menu_options"]
+    assert "travel_time_run" not in running["menu_options"]
+
+
+# ------------------------------------------------------------------ #
+# Manual entry
+# ------------------------------------------------------------------ #
+
+
+async def _submit_manual(hass: HomeAssistant, flow_id: str, values: dict):
+    """From the Calibration menu: into Travel Time, into the form, submit."""
+    await _step(hass, flow_id, "travel_time")
+    await _step(hass, flow_id, "travel_time_manual")
+    return await hass.config_entries.options.async_configure(flow_id, values)
+
+
+async def test_manual_entry_stores_a_manual_row(hass: HomeAssistant) -> None:
+    entry = await _setup_entry(hass, entry_id="tt_manual")
+    _, flow_id = await _open_calibration(hass, entry)
+    await _submit_manual(hass, flow_id, {_COVER: 23.5})
+    await _finish(hass, flow_id)
+
+    row = entry.options[CONF_TRAVEL_TIME_CALIBRATION][_COVER]
+    assert row["full_travel_seconds"] == 23.5
+    assert row["source"] == TRAVEL_CALIBRATION_SOURCE_MANUAL
+    # A hand-entered figure has no per-leg detail to offer.
+    assert row["open_seconds"] is None
+    assert row["close_seconds"] is None
+
+
+async def test_zero_clears_an_existing_entry(hass: HomeAssistant) -> None:
+    """0 is the clear gesture — the reason the field is a BOX, not a slider."""
+    entry = await _setup_entry(
+        hass,
+        entry_id="tt_manual_clear",
+        extra_options={CONF_TRAVEL_TIME_CALIBRATION: {_COVER: dict(_MEASURED)}},
+    )
+    _, flow_id = await _open_calibration(hass, entry)
+    await _submit_manual(hass, flow_id, {_COVER: 0})
+    await _finish(hass, flow_id)
+
+    assert CONF_TRAVEL_TIME_CALIBRATION not in entry.options
+
+
+async def test_out_of_range_value_is_rejected(hass: HomeAssistant) -> None:
+    entry = await _setup_entry(hass, entry_id="tt_manual_range")
+    _, flow_id = await _open_calibration(hass, entry)
+
+    with pytest.raises(InvalidData, match=re.escape(f"data['{_COVER}']")):
+        await _submit_manual(hass, flow_id, {_COVER: TRAVEL_TIME_MAX_SECONDS + 50})
+
+
+async def test_reset_clears_the_whole_table(hass: HomeAssistant) -> None:
+    entry = await _setup_entry(
+        hass,
+        entry_id="tt_reset",
+        extra_options={CONF_TRAVEL_TIME_CALIBRATION: {_COVER: dict(_MEASURED)}},
+    )
+    _, flow_id = await _open_calibration(hass, entry)
+    await _step(hass, flow_id, "travel_time")
+    await _step(hass, flow_id, "travel_time_reset")
+    await _finish(hass, flow_id)
+
+    assert CONF_TRAVEL_TIME_CALIBRATION not in entry.options
+
+
+# ------------------------------------------------------------------ #
+# The save-time merge
+# ------------------------------------------------------------------ #
+
+
+def _write_behind_the_flow(hass: HomeAssistant, entry, table: dict) -> None:
+    """Simulate a calibration run finishing while the options dialog is open."""
+    hass.config_entries.async_update_entry(
+        entry, options={**entry.options, CONF_TRAVEL_TIME_CALIBRATION: table}
+    )
+
+
+async def test_a_measurement_taken_during_the_dialog_survives_saving(
+    hass: HomeAssistant,
+) -> None:
+    """The data-loss window this merge exists to close.
+
+    Without it, the flow's opening snapshot — which has no travel-time table at
+    all — is written back over the finished run's results.
+    """
+    entry = await _setup_entry(hass, entry_id="tt_race")
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    _write_behind_the_flow(hass, entry, {_COVER: dict(_MEASURED)})
+
+    await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+    assert entry.options[CONF_TRAVEL_TIME_CALIBRATION][_COVER] == _MEASURED
+
+
+async def test_a_manual_edit_and_a_concurrent_measurement_both_survive(
+    hass: HomeAssistant,
+) -> None:
+    """Per-entity, not all-or-nothing.
+
+    The user types a time for one cover while a run measures another. Resolving
+    this either way round would throw away real work.
+    """
+    entry = await _setup_entry(
+        hass, entry_id="tt_race_split", entities=[_COVER, _OTHER]
+    )
+    _, flow_id = await _open_calibration(hass, entry)
+    await _submit_manual(hass, flow_id, {_COVER: 18.0, _OTHER: 0})
+
+    _write_behind_the_flow(hass, entry, {_OTHER: dict(_MEASURED)})
+
+    await _finish(hass, flow_id)
+
+    table = entry.options[CONF_TRAVEL_TIME_CALIBRATION]
+    assert table[_COVER]["full_travel_seconds"] == 18.0
+    assert table[_COVER]["source"] == TRAVEL_CALIBRATION_SOURCE_MANUAL
+    assert table[_OTHER] == _MEASURED
+
+
+async def test_saving_prunes_rows_for_covers_no_longer_controlled(
+    hass: HomeAssistant,
+) -> None:
+    """Swapping a cover out must not leave its time behind forever."""
+    entry = await _setup_entry(
+        hass,
+        entry_id="tt_prune",
+        extra_options={
+            CONF_TRAVEL_TIME_CALIBRATION: {
+                _COVER: dict(_MEASURED),
+                "cover.removed": dict(_MEASURED),
+            }
+        },
+    )
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+    table = entry.options[CONF_TRAVEL_TIME_CALIBRATION]
+    assert set(table) == {_COVER}
+
+
+# ------------------------------------------------------------------ #
+# Configuration summary
+# ------------------------------------------------------------------ #
+
+
+def test_summary_counts_calibrated_covers() -> None:
+    config = {
+        CONF_ENTITIES: [_COVER, _OTHER],
+        CONF_TRAVEL_TIME_CALIBRATION: {_COVER: dict(_MEASURED)},
+    }
+    assert "Travel time: 1/2 covers" in _build_config_summary(config, CoverType.BLIND)
+
+
+def test_summary_calls_out_hand_entered_times() -> None:
+    manual = {**_MEASURED, "source": TRAVEL_CALIBRATION_SOURCE_MANUAL}
+    config = {
+        CONF_ENTITIES: [_COVER, _OTHER],
+        CONF_TRAVEL_TIME_CALIBRATION: {_COVER: dict(_MEASURED), _OTHER: manual},
+    }
+    summary = _build_config_summary(config, CoverType.BLIND)
+    assert "Travel time: 2/2 covers (1 entered by hand)" in summary
+
+
+def test_summary_omits_the_line_when_nothing_is_calibrated() -> None:
+    config = {CONF_ENTITIES: [_COVER]}
+    assert "Travel time" not in _build_config_summary(config, CoverType.BLIND)
+
+
+async def test_summary_warns_about_an_unmeasurable_cover_with_no_time(
+    hass: HomeAssistant,
+) -> None:
+    """The footgun: this cover can never be measured and has nothing entered.
+
+    Silently, it will simply never animate — exactly what the summary is for.
+    """
+    hass.states.async_set(
+        _COVER, "open", {"supported_features": 11, "assumed_state": True}
+    )
+    summary = _build_config_summary(
+        {CONF_ENTITIES: [_COVER]}, CoverType.BLIND, hass=hass
+    )
+
+    assert "report an assumed state" in summary
+    assert _COVER in summary
+
+
+async def test_no_warning_once_a_time_has_been_entered(hass: HomeAssistant) -> None:
+    hass.states.async_set(
+        _COVER, "open", {"supported_features": 11, "assumed_state": True}
+    )
+    manual = {**_MEASURED, "source": TRAVEL_CALIBRATION_SOURCE_MANUAL}
+    summary = _build_config_summary(
+        {
+            CONF_ENTITIES: [_COVER],
+            CONF_TRAVEL_TIME_CALIBRATION: {_COVER: manual},
+        },
+        CoverType.BLIND,
+        hass=hass,
+    )
+
+    assert "report an assumed state" not in summary
+
+
+async def test_visiting_the_manual_page_does_not_claim_untouched_covers(
+    hass: HomeAssistant,
+) -> None:
+    """Submitting the form must only claim the fields the user actually changed.
+
+    The form carries one field per cover and posts all of them back. Treating
+    every field as an edit would mean opening this page to set one cover
+    silently takes authority over the others, and the save-time merge would
+    then overwrite a concurrent measurement of a cover nobody touched — turning
+    a per-entity merge into an all-or-nothing one.
+    """
+    entry = await _setup_entry(hass, entry_id="tt_untouched", entities=[_COVER, _OTHER])
+    _, flow_id = await _open_calibration(hass, entry)
+    # Only _COVER is given a value; _OTHER keeps its pre-filled 0.
+    await _submit_manual(hass, flow_id, {_COVER: 30.0, _OTHER: 0})
+
+    flow = hass.config_entries.options._progress[flow_id]
+    assert flow._travel_time_edited == {_COVER}
+
+
+async def test_measure_now_starts_a_run_and_returns_to_the_menu(
+    hass: HomeAssistant,
+) -> None:
+    """Fire-and-forget: the dialog must not block for the length of a run.
+
+    Returning to the menu rather than aborting also preserves edits made
+    earlier in the same session.
+    """
+    entry = await _setup_entry(hass, entry_id="tt_run")
+    _, flow_id = await _open_calibration(hass, entry)
+    await _step(hass, flow_id, "travel_time")
+
+    calibrator = entry.runtime_data.travel_calibration
+    started: list[bool] = []
+    calibrator.async_run = lambda: started.append(True) or _noop()
+
+    result = await _step(hass, flow_id, "travel_time_run")
+    await hass.async_block_till_done()
+
+    assert started == [True]
+    assert result["step_id"] == "travel_time"
+
+
+async def test_cancel_stops_the_run_and_returns_to_the_menu(
+    hass: HomeAssistant,
+) -> None:
+    entry = await _setup_entry(hass, entry_id="tt_cancel_action")
+    calibrator = entry.runtime_data.travel_calibration
+    calibrator._state = "running"
+    cancelled: list[bool] = []
+    calibrator.async_cancel = lambda *, restore: cancelled.append(restore)
+
+    _, flow_id = await _open_calibration(hass, entry)
+    await _step(hass, flow_id, "travel_time")
+    result = await _step(hass, flow_id, "travel_time_cancel")
+
+    # restore=True: the menu's Cancel puts the covers back, unlike the panic
+    # stop, which stands the run down without further movement.
+    assert cancelled == [True]
+    assert result["step_id"] == "travel_time"
+
+
+async def _noop() -> None:
+    return None

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -2838,6 +2838,22 @@ _UNNAMED_TARGET_SEAMS = {
         "defers for a tick and is re-asked by the next pass — it never enters "
         "a settle budget and the recorded target is still there to resend."
     ),
+    ("managers/travel_calibration.py", "async_run"): (
+        "Orders the SUBJECTS of a calibration pass, not one fanned-out target: "
+        "each cover is then swept to both of its own endpoints in turn, so "
+        "there is no single number to name. Safe regardless of the order it "
+        "gets — every subject is preceded by the policy's clearance parking, "
+        "which leaves the track clear from any starting geometry, and the "
+        "sweeps are strictly sequential so two coupled entities are never in "
+        "motion together."
+    ),
+    ("managers/travel_calibration.py", "_restore"): (
+        "Sends every cover back to ITS OWN pre-run position, so the map has as "
+        "many targets as entities and none of them is the number being ordered "
+        "against. Each restore waits for its cover to land before the next is "
+        "dispatched, which is the guarantee the ordering hint would otherwise "
+        "be buying."
+    ),
 }
 
 

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -2847,13 +2847,6 @@ _UNNAMED_TARGET_SEAMS = {
         "sweeps are strictly sequential so two coupled entities are never in "
         "motion together."
     ),
-    ("managers/travel_calibration.py", "_restore"): (
-        "Sends every cover back to ITS OWN pre-run position, so the map has as "
-        "many targets as entities and none of them is the number being ordered "
-        "against. Each restore waits for its cover to land before the next is "
-        "dispatched, which is the guarantee the ordering hint would otherwise "
-        "be buying."
-    ),
 }
 
 

--- a/tests/test_entity_write_gating.py
+++ b/tests/test_entity_write_gating.py
@@ -51,6 +51,13 @@ def _make_coordinator(*, data=None):
     coord.last_update_success = True
     coord.logger = MagicMock()
     coord.hass = _make_hass()
+    # Pinned rather than left as auto-Mocks: the proxy reads both while
+    # rendering a position, and a bare MagicMock answers a truthy object to the
+    # "is anything moving?" question, which would route every read down the
+    # travel-ramp branch and return the same mock every time — freezing the
+    # render signature these tests are written to observe changing.
+    coord.travel_estimated_position = MagicMock(return_value=None)
+    coord.position_axis_inverted = False
     return coord
 
 

--- a/tests/test_global_services.py
+++ b/tests/test_global_services.py
@@ -616,3 +616,37 @@ async def test_unload_services_keeps_services_when_only_real_entry_remains():
     await async_unload_services(hass)  # must not raise AttributeError
 
     hass.services.async_remove.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Travel-time calibration stand-down (both disable paths)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service", ["integration_disable", "emergency_stop"])
+async def test_disable_paths_stand_a_calibration_run_down_first(service):
+    """A run must be cancelled BEFORE the covers are stopped, not after.
+
+    A calibration run drives covers through ``_execute_command``, which bypasses
+    the enabled gate — so a run left going would keep issuing commands during and
+    after the stop, quietly undoing it. ``restore=False`` because both callers are
+    asking for movement to stop, and sending the covers home is more movement.
+    """
+    order: list[str] = []
+    coord = _make_coordinator(["cover.a"])
+    coord.async_cancel_travel_calibration = MagicMock(
+        side_effect=lambda *, restore: order.append(f"cancel:{restore}")
+    )
+    coord._cmd_svc.stop_in_flight = AsyncMock(
+        side_effect=lambda **_kw: order.append("stop") or []
+    )
+    coord._cmd_svc.stop_all = AsyncMock(
+        side_effect=lambda *_a: order.append("stop") or []
+    )
+    hass = _make_hass({"entry_a": coord})
+
+    await async_setup_services(hass)
+    await _get_handler(hass, service)(_make_call())
+
+    assert order == ["cancel:False", "stop"]

--- a/tests/test_skip_reason_guard.py
+++ b/tests/test_skip_reason_guard.py
@@ -42,6 +42,7 @@ _EXPECTED_SKIP_CODES: frozenset[str] = frozenset(
         "service_call_failed",
         "cover_unavailable",
         "policy_deferred",
+        "calibration_in_progress",
     }
 )
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -77,6 +77,7 @@ _EXPECTED_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
         "motion_status",
         "position_forecast",
         "solar_calculation",
+        "travel_calibration",
     }
 )
 
@@ -235,6 +236,10 @@ _WITHHELD_FROM_NAMESPACE: dict[str, frozenset[str]] = {
             "solar_calculation",
             "decision_trace",
             "position_forecast",
+            # Setup-time measurement state. Nothing an automation would branch
+            # on: it reports whether a calibration pass is running, which is a
+            # thing a human does from the options flow once per install.
+            "travel_calibration",
             # No translation_key — unresolvable by the namespace resolver.
             "Cover_Position",
             "Cover_Tilt",

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -1305,3 +1305,65 @@ async def test_a_run_stands_down_when_its_whole_run_budget_is_spent(
     assert rig.commands("cover.b") == []
     assert rig.calibrator.diagnostics()["last_error"] == REASON_RUN_BUDGET_EXCEEDED
     assert rig.cmd_svc.calibrating is False
+
+
+@pytest.mark.asyncio
+async def test_no_single_wait_may_outlast_the_run_budget(
+    hass: HomeAssistant,
+) -> None:
+    """The clamp, not the loop check, is what bounds a single-cover install.
+
+    The per-subject boundary check runs once and never again when there is only
+    one cover, so with the clamp gone a stuck shade would hold the covers — and
+    hold off a safety command — for four full per-move timeouts.
+    """
+    rig = _rig(hass, stalled=True, move_timeout=30)
+    rig.calibrator._run_budget = 0.4
+
+    started = time.monotonic()
+    await rig.calibrator.async_run()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"run outlasted its budget ({elapsed:.1f}s)"
+    assert rig.cmd_svc.calibrating is False
+
+
+@pytest.mark.asyncio
+async def test_running_out_of_budget_is_not_a_verdict_about_the_cover(
+    hass: HomeAssistant,
+) -> None:
+    """A healthy shade must not be recorded as jammed because the clock ran out.
+
+    Budget expiry is an interruption like a cancel — it says something about the
+    run, not about the cover that happened to be under way.
+    """
+    rig = _rig(hass, stalled=True, move_timeout=30)
+    rig.calibrator._run_budget = 0.4
+
+    await rig.calibrator.async_run()
+
+    results = rig.calibrator.diagnostics()["results"]
+    assert results.get("cover.a", {}).get("status") != TRAVEL_CALIBRATION_STATUS_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_a_crash_during_setup_still_hands_the_covers_back(
+    hass: HomeAssistant,
+) -> None:
+    """The handover and the origin capture must be inside the guarded region.
+
+    Left outside it, an exception from either stranded ``calibrating`` set and
+    the state on ``running`` — every command skipped, and every later run
+    refused by the is_running guard, for the life of the config entry.
+    """
+    rig = _rig(hass)
+    rig.calibrator._on_progress = MagicMock(
+        side_effect=RuntimeError("listener blew up")
+    )
+
+    with pytest.raises(RuntimeError):
+        await rig.calibrator.async_run()
+
+    assert rig.cmd_svc.calibrating is False
+    assert rig.calibrator.is_running is False
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_FAILED

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -1367,3 +1367,84 @@ async def test_a_crash_during_setup_still_hands_the_covers_back(
     assert rig.cmd_svc.calibrating is False
     assert rig.calibrator.is_running is False
     assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_FAILED
+
+
+@pytest.mark.asyncio
+async def test_the_go_home_pass_gets_its_own_budget_not_the_leftovers(
+    hass: HomeAssistant,
+) -> None:
+    """The restore must start with a real window however the sweep ended.
+
+    Every wait in the module is clamped to the remaining budget, and the restore
+    runs last — so on any run that used its time the go-home waits would be
+    clamped to nothing. The leader is then never observed to land, the clearance
+    gate refuses the follower on the next lap, and a coupled rail is left at a
+    mechanical stop with its pre-run position lost.
+
+    Asserted on the budget the pass starts with rather than on the resulting
+    commands: whether a starved wait actually loses a cover depends on scheduling
+    the rig cannot pin down, but the starvation itself is exact.
+    """
+    covers = {
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=60),
+    }
+    rig = _Rig(
+        hass, covers, cover_type="cover_day_night_shade", options=_model_c_options()
+    )
+    rig.calibrator._restore_budget = 42.0
+    seen: list[float] = []
+    original = rig.calibrator._restore
+
+    async def _observe(origins):
+        # Arrive with the measurement budget fully spent, as a long run does.
+        rig.calibrator._deadline = rig.calibrator._now() - dt.timedelta(seconds=1)
+        await original(origins)
+        seen.append(rig.calibrator._remaining_budget())
+
+    rig.calibrator._restore = _observe
+    await rig.calibrator.async_run()
+
+    assert seen, "the restore pass did not run"
+    assert seen[0] > 1.0, "the go-home pass was starved by the measurement budget"
+
+
+@pytest.mark.asyncio
+async def test_running_out_of_budget_on_the_only_cover_still_reports_it(
+    hass: HomeAssistant,
+) -> None:
+    """Expiry inside the last subject never reaches the next loop boundary.
+
+    Left to the boundary check alone, a single-cover install reported a
+    successful calibration with an empty results table and no error — every time
+    it ran out of time.
+    """
+    rig = _rig(hass, stalled=True, move_timeout=30)
+    rig.calibrator._run_budget = 0.4
+
+    await rig.calibrator.async_run()
+
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_CANCELLED
+    assert rig.calibrator.diagnostics()["last_error"] == REASON_RUN_BUDGET_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_no_command_goes_out_after_a_stop_was_asked_for(
+    hass: HomeAssistant,
+) -> None:
+    """A leg landing and a cancel arriving together must not dispatch the next.
+
+    Otherwise a cover is sent to a mechanical stop immediately after the panic
+    stop asked for no further movement.
+    """
+    rig = _rig(hass, move_timeout=5)
+    rig.calibrator._abort = asyncio.Event()
+    rig.calibrator._hard_abort = asyncio.Event()
+    rig.calibrator._abort.set()
+
+    arrival = await rig.calibrator._drive_and_wait(
+        "cover.a", 100, caps=rig.cmd_svc.get_cover_capabilities("cover.a")
+    )
+
+    assert arrival.ok is False
+    assert rig.commands("cover.a") == []

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -929,28 +929,25 @@ async def test_ordinary_automation_waits_for_a_calibration_run(
 
 
 @pytest.mark.asyncio
-async def test_a_safety_target_pre_empts_the_run_instead_of_being_blocked(
+async def test_even_a_safety_target_waits_for_a_calibration_run(
     hass: HomeAssistant,
 ) -> None:
-    """A storm must never wait for a calibration.
+    """The gate is absolute, safety included.
 
-    The collision this gate exists to prevent — a command landing on a coupled
-    rail mid-sweep — is better answered by standing the run down than by
-    refusing the command: the safety dispatch still goes through the policy's
-    own clearance gating, and cancelling stops the run issuing anything further,
-    so the two never race.
+    A command landing on a coupled rail mid-sweep drives a rail into a rail, and
+    a half-swept cover is somewhere nothing else has reasoned about. What makes
+    blocking acceptable is that the run is neither invisible nor unstoppable:
+    the control status reads ``calibrating`` throughout, the options flow says so
+    and offers Cancel, and the run budget ends it regardless.
     """
     rig = _rig(hass)
-    cancelled: list[bool] = []
-    rig.cmd_svc._on_safety_preempt = lambda: cancelled.append(True)
     rig.cmd_svc.calibrating = True
 
     result = await rig.cmd_svc.apply_position(
         "cover.a", 70, "test", _context(is_safety=True)
     )
 
-    assert cancelled == [True]
-    assert result != ("skipped", "calibration_in_progress")
+    assert result == ("skipped", "calibration_in_progress")
 
 
 @pytest.mark.asyncio

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -910,19 +910,13 @@ def _context(**kw):
     [
         pytest.param({}, id="ordinary"),
         pytest.param({"force": True}, id="force"),
-        pytest.param({"is_safety": True}, id="safety"),
         pytest.param({"bypass_auto_control": True}, id="bypass-auto-control"),
     ],
 )
-async def test_no_command_gets_past_a_calibration_run(
+async def test_ordinary_automation_waits_for_a_calibration_run(
     hass: HomeAssistant, context_kwargs
 ) -> None:
-    """The gate is absolute — deliberately outranking force and safety.
-
-    A safety command landing on a rail mid-sweep drives a rail into a rail, and
-    a run is bounded in minutes. The escape hatch is cancelling the run, which
-    is a decision rather than a collision.
-    """
+    """``force`` does not bypass it: a recurring resend can wait a few minutes."""
     rig = _rig(hass)
     rig.cmd_svc.calibrating = True
 
@@ -932,6 +926,31 @@ async def test_no_command_gets_past_a_calibration_run(
 
     assert result == ("skipped", "calibration_in_progress")
     assert rig.cmd_svc.last_skipped_action["reason"] == "calibration_in_progress"
+
+
+@pytest.mark.asyncio
+async def test_a_safety_target_pre_empts_the_run_instead_of_being_blocked(
+    hass: HomeAssistant,
+) -> None:
+    """A storm must never wait for a calibration.
+
+    The collision this gate exists to prevent — a command landing on a coupled
+    rail mid-sweep — is better answered by standing the run down than by
+    refusing the command: the safety dispatch still goes through the policy's
+    own clearance gating, and cancelling stops the run issuing anything further,
+    so the two never race.
+    """
+    rig = _rig(hass)
+    cancelled: list[bool] = []
+    rig.cmd_svc._on_safety_preempt = lambda: cancelled.append(True)
+    rig.cmd_svc.calibrating = True
+
+    result = await rig.cmd_svc.apply_position(
+        "cover.a", 70, "test", _context(is_safety=True)
+    )
+
+    assert cancelled == [True]
+    assert result != ("skipped", "calibration_in_progress")
 
 
 @pytest.mark.asyncio

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -624,16 +624,25 @@ def _model_c_options(*, inverse: bool = False) -> dict:
     return opts
 
 
-def _model_c_rig(hass) -> _Rig:
+def _model_c_rig(hass, *, inverse: bool = False) -> _Rig:
+    """Build a Model C pair in a geometrically legal resting position.
+
+    The no-pass invariant is ``middle% >= bottom%`` in OPEN-percent, so the wire
+    numbers that satisfy it depend on the frame: upright the middle rail holds
+    the larger wire value, inverted the smaller. A fixture that ignores that
+    describes a shade whose rails have passed through each other, and the
+    clearance gate rightly refuses to restore it.
+    """
+    bottom, middle = (60, 30) if inverse else (30, 60)
     covers = {
-        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
-        "cover.middle": _FakeCover(hass, "cover.middle", position=60),
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=bottom),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=middle),
     }
     return _Rig(
         hass,
         covers,
         cover_type="cover_day_night_shade",
-        options=_model_c_options(),
+        options=_model_c_options(inverse=inverse),
     )
 
 
@@ -1088,3 +1097,40 @@ async def test_a_hard_cancel_stops_a_restore_already_under_way(
 
     assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_CANCELLED
     assert rig.cmd_svc.calibrating is False
+
+
+@pytest.mark.asyncio
+async def test_the_restore_order_flips_with_the_inversion_frame(
+    hass: HomeAssistant,
+) -> None:
+    """Which rail may move first depends on the frame, so the frame must be primed.
+
+    The clearance gate resolves a token-less caller's frame through the policy's
+    cached inversion flag. Priming the rail ROLE without it turns the gate from
+    inert into confidently backwards: it would wave the middle rail down through
+    the bottom rail on exactly the installs the inversion exists for.
+
+    Upright the covers restore upward and the middle rail leads; inverted the
+    same wire move is a lower in open-percent, so the bottom rail leads.
+    """
+    upright = _model_c_rig(hass)
+    await upright.calibrator.async_run()
+    assert upright.commands("cover.middle")[-1] == 60
+    assert upright.commands("cover.bottom")[-1] == 30
+
+    inverted = _model_c_rig(hass, inverse=True)
+    order: list[str] = []
+    for eid, cover in inverted.covers.items():
+        original = cover.command
+
+        async def _spy(entity_id, target, _orig=None, _eid="", **kw):
+            order.append(f"{_eid}:{target}")
+            await _orig(entity_id, target, **kw)
+
+        cover.command = lambda e, t, _o=original, _i=eid, **k: _spy(
+            e, t, _orig=_o, _eid=_i, **k
+        )
+    await inverted.calibrator.async_run()
+
+    restores = [step for step in order if step.endswith((":30", ":60"))]
+    assert restores == ["cover.bottom:60", "cover.middle:30"]

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -47,6 +47,7 @@ from custom_components.adaptive_cover_pro.const import (
     TRAVEL_CALIBRATION_STATUS_UNAVAILABLE,
     TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
     REASON_ASSUMED_STATE,
+    REASON_RUN_BUDGET_EXCEEDED,
     REASON_CLEARANCE_FAILED,
     REASON_NO_ENTITIES,
     REASON_NO_MOTION_OBSERVED,
@@ -64,6 +65,9 @@ pytestmark = pytest.mark.integration
 # HA CoverEntityFeature masks: OPEN(1) CLOSE(2) SET_POSITION(4) STOP(8).
 _POSITION_FEATURES = 1 | 2 | 4 | 8
 _OPEN_CLOSE_FEATURES = 1 | 2 | 8
+# SET_TILT_POSITION(128) with no SET_POSITION — a position-primary policy bound
+# to tilt-only hardware, which is where the axis question gets interesting.
+_TILT_ONLY_FEATURES = 1 | 2 | 8 | 128
 
 # Real-clock budgets, deliberately tiny: only the tests that exercise a stall or
 # a cancel ever reach them, and they should not add seconds to the suite.
@@ -122,17 +126,31 @@ class _FakeCover:
     def _position_capable(self) -> bool:
         return bool(self.features & 4)
 
+    @property
+    def _tilt_only(self) -> bool:
+        return bool(self.features & 128) and not self._position_capable
+
     def _attrs(self) -> dict:
         attrs: dict = {"supported_features": self.features}
         if self._position_capable:
             attrs["current_position"] = self.position
+        if self._tilt_only:
+            attrs["current_tilt_position"] = self.position
         if self.assumed:
             attrs["assumed_state"] = True
         return attrs
 
     def _publish(self, stamp: float, state: str | None = None) -> None:
         if state is None:
-            state = "closed" if self.position == 0 else "open"
+            # Slat-only hardware reports "open" whatever the slats are doing —
+            # the carriage never moves, so there is no closed endpoint to
+            # report. Anything reading arrival off the state alone is blind to
+            # it, which is exactly what the axis question decides.
+            state = (
+                "open"
+                if self._tilt_only
+                else ("closed" if self.position == 0 else "open")
+            )
         self.hass.states.async_set(
             self.entity_id, state, self._attrs(), timestamp=stamp
         )
@@ -1134,3 +1152,156 @@ async def test_the_restore_order_flips_with_the_inversion_frame(
 
     restores = [step for step in order if step.endswith((":30", ":60"))]
     assert restores == ["cover.bottom:60", "cover.middle:30"]
+
+
+# ------------------------------------------------------------------ #
+# Guards for fixes that were previously shipping untested
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_a_tilt_only_cover_is_measured_on_the_axis_it_is_driven_on(
+    hass: HomeAssistant,
+) -> None:
+    """The arrival check must ask about the axis actually being commanded.
+
+    ``select_default_axis`` hands a position-primary policy the TILT axis when
+    the bound hardware exposes tilt only. Asking ``position_axis_supported``
+    instead answers about ``axes[0]`` — a different axis — so the tilt reading
+    is discarded, arrival never resolves, and the cover burns a full timeout on
+    every leg and is written off as jammed.
+    """
+    cover = _FakeCover(
+        hass,
+        "cover.a",
+        features=_TILT_ONLY_FEATURES,
+        position=30,
+        open_travel=20.0,
+        close_travel=20.0,
+    )
+    rig = _Rig(hass, {"cover.a": cover})
+
+    await rig.calibrator.async_run()
+
+    assert (
+        rig.calibrator.diagnostics()["results"]["cover.a"]["status"]
+        == TRAVEL_CALIBRATION_STATUS_OK
+    )
+    assert rig.persisted["cover.a"]["full_travel_seconds"] == pytest.approx(
+        20.0, abs=_DELAY_TOLERANCE
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_leg_is_not_written_off_as_a_timeout(
+    hass: HomeAssistant,
+) -> None:
+    """Interrupted is not failed. Reporting a timeout would blame the cover for
+    the user's own Cancel.
+    """
+    rig = _rig(hass, stalled=True, move_timeout=5)
+    task = await _park_in_wait(rig)
+
+    rig.calibrator.async_cancel(restore=False)
+    await task
+
+    assert "cover.a" not in rig.calibrator.diagnostics()["results"]
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_clearance_park_is_not_written_off_either(
+    hass: HomeAssistant,
+) -> None:
+    """Same rule on the coupled path, which had the defect longest."""
+    covers = {
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=60, stalled=True),
+    }
+    rig = _Rig(
+        hass,
+        covers,
+        cover_type="cover_day_night_shade",
+        options=_model_c_options(),
+        move_timeout=5,
+    )
+    task = asyncio.ensure_future(rig.calibrator.async_run())
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if rig.commands("cover.middle"):
+            break
+    rig.calibrator.async_cancel(restore=False)
+    await task
+
+    results = rig.calibrator.diagnostics()["results"]
+    assert results.get("cover.bottom", {}).get("reason") != REASON_CLEARANCE_FAILED
+
+
+@pytest.mark.asyncio
+async def test_a_hard_abort_writes_no_config_entry_options(
+    hass: HomeAssistant,
+) -> None:
+    """An unload sets the hard abort before cancelling the run's task.
+
+    Writing options there dispatches the entry's update listeners through a task
+    HA does not scope to the entry, running a full refresh on the coordinator
+    that just shut down. The measurements are the cheaper thing to lose.
+    """
+    rig = _rig(hass, stalled=True, move_timeout=5)
+    task = await _park_in_wait(rig)
+
+    rig.calibrator.async_cancel(restore=False)
+    await task
+
+    assert rig.persisted is None
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_cancel_still_keeps_what_it_measured(
+    hass: HomeAssistant,
+) -> None:
+    """The counterpart: only a HARD abort suppresses the write.
+
+    A cover already swept produced a real measurement, and discarding it would
+    mean re-sweeping it next time.
+    """
+    covers = {
+        "cover.done": _FakeCover(hass, "cover.done"),
+        "cover.stuck": _FakeCover(hass, "cover.stuck", stalled=True),
+    }
+    rig = _Rig(hass, covers, move_timeout=5)
+    task = asyncio.ensure_future(rig.calibrator.async_run())
+    for _ in range(60):
+        await asyncio.sleep(0)
+        if rig.commands("cover.stuck"):
+            break
+    rig.calibrator.async_cancel(restore=True)
+    await task
+
+    assert rig.persisted is not None
+    assert "cover.done" in rig.persisted
+
+
+@pytest.mark.asyncio
+async def test_a_run_stands_down_when_its_whole_run_budget_is_spent(
+    hass: HomeAssistant,
+) -> None:
+    """The gate a run holds outranks safety, so the run must be time-boxed.
+
+    The per-move timeout bounds one stuck move; without this, a Model C pair of
+    stuck moves could hold the covers — and hold off a weather retract — for the
+    better part of an hour.
+    """
+    covers = {
+        "cover.a": _FakeCover(hass, "cover.a"),
+        "cover.b": _FakeCover(hass, "cover.b"),
+    }
+    rig = _Rig(hass, covers)
+    # Already spent by the time the first cover is considered.
+    rig.calibrator._run_budget = 0.0
+
+    await rig.calibrator.async_run()
+
+    assert rig.commands("cover.a") == []
+    assert rig.commands("cover.b") == []
+    assert rig.calibrator.diagnostics()["last_error"] == REASON_RUN_BUDGET_EXCEEDED
+    assert rig.cmd_svc.calibrating is False

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -548,7 +548,7 @@ async def test_a_second_trigger_while_running_is_a_no_op(hass: HomeAssistant) ->
 
 @pytest.mark.asyncio
 async def test_cancel_with_restore_puts_the_covers_back(hass: HomeAssistant) -> None:
-    rig = _rig(hass, position=42, stalled=True, move_timeout=5)
+    rig = _rig(hass, position=42, stalled=True, move_timeout=0.5)
     task = await _park_in_wait(rig)
     await _partial_move(rig, "cover.a", 10)
 
@@ -565,7 +565,7 @@ async def test_cancel_without_restore_issues_no_further_movement(
     hass: HomeAssistant,
 ) -> None:
     """What the panic stop needs: stand down, do not move anything else."""
-    rig = _rig(hass, position=42, stalled=True, move_timeout=5)
+    rig = _rig(hass, position=42, stalled=True, move_timeout=0.5)
     task = await _park_in_wait(rig)
     await _partial_move(rig, "cover.a", 10)
     before = list(rig.commands("cover.a"))
@@ -786,7 +786,7 @@ async def test_cancel_stops_the_batch_before_the_remaining_covers(
         "cover.a": _FakeCover(hass, "cover.a", stalled=True),
         "cover.b": _FakeCover(hass, "cover.b"),
     }
-    rig = _Rig(hass, covers, move_timeout=5)
+    rig = _Rig(hass, covers, move_timeout=0.5)
     task = await _park_in_wait(rig)
 
     rig.calibrator.async_cancel(restore=False)
@@ -805,7 +805,7 @@ async def test_cancel_during_the_observability_probe_is_not_a_verdict(
     would tell the user their cover is unmeasurable on the strength of having
     pressed Cancel.
     """
-    rig = _rig(hass, features=_OPEN_CLOSE_FEATURES, stalled=True, move_timeout=5)
+    rig = _rig(hass, features=_OPEN_CLOSE_FEATURES, stalled=True, move_timeout=0.5)
     rig.calibrator._probe_seconds = 5.0
     task = await _park_in_wait(rig)
 
@@ -829,3 +829,173 @@ async def test_progress_callback_fires_as_the_run_advances(
 
     assert seen
     assert seen[-1] == TRAVEL_CALIBRATION_STATE_COMPLETE
+
+
+# ------------------------------------------------------------------ #
+# Owning the covers: the gates, and who is allowed past them
+# ------------------------------------------------------------------ #
+
+
+def _context(**kw):
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        PositionContext,
+    )
+
+    defaults = {
+        "auto_control": True,
+        "manual_override": False,
+        "sun_just_appeared": False,
+        "min_change": 1,
+        "time_threshold": 0,
+        "special_positions": [],
+    }
+    return PositionContext(**{**defaults, **kw})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "context_kwargs",
+    [
+        pytest.param({}, id="ordinary"),
+        pytest.param({"force": True}, id="force"),
+        pytest.param({"is_safety": True}, id="safety"),
+        pytest.param({"bypass_auto_control": True}, id="bypass-auto-control"),
+    ],
+)
+async def test_no_command_gets_past_a_calibration_run(
+    hass: HomeAssistant, context_kwargs
+) -> None:
+    """The gate is absolute — deliberately outranking force and safety.
+
+    A safety command landing on a rail mid-sweep drives a rail into a rail, and
+    a run is bounded in minutes. The escape hatch is cancelling the run, which
+    is a decision rather than a collision.
+    """
+    rig = _rig(hass)
+    rig.cmd_svc.calibrating = True
+
+    result = await rig.cmd_svc.apply_position(
+        "cover.a", 70, "test", _context(**context_kwargs)
+    )
+
+    assert result == ("skipped", "calibration_in_progress")
+    assert rig.cmd_svc.last_skipped_action["reason"] == "calibration_in_progress"
+
+
+@pytest.mark.asyncio
+async def test_commands_flow_again_once_the_run_hands_the_covers_back(
+    hass: HomeAssistant,
+) -> None:
+    rig = _rig(hass)
+    rig.cmd_svc.calibrating = True
+    await rig.cmd_svc.apply_position("cover.a", 70, "test", _context())
+    rig.cmd_svc.calibrating = False
+
+    result = await rig.cmd_svc.apply_position("cover.a", 70, "test", _context())
+
+    assert result != ("skipped", "calibration_in_progress")
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_stands_down_during_a_run(hass: HomeAssistant) -> None:
+    """Left running it would see the run's own in-flight targets as unmet and
+    resend, racing the legs whose timings it is there to measure.
+    """
+    rig = _rig(hass)
+    rig.cmd_svc.set_target("cover.a", 100)
+    rig.cmd_svc.state("cover.a").waiting = False
+    rig.cmd_svc.calibrating = True
+
+    before = len(rig.commands("cover.a"))
+    await rig.cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert len(rig.commands("cover.a")) == before
+
+
+# ------------------------------------------------------------------ #
+# Restore ordering — the pass with no clearance plan protecting it
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_the_furthest_traveller_leads_the_restore(hass: HomeAssistant) -> None:
+    """Coupled rails cannot pass each other on the way home either.
+
+    Both rails finish a run parked on the same endpoint and travel the same way
+    out of it, so whoever has furthest to go is the one everyone else would
+    otherwise have to travel through — it must lead. On an upright Model C
+    install that works out to the middle rail, which is what a raise requires;
+    the old fixed "bottom rail first" order had it exactly backwards.
+    """
+    covers = {
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=70),
+    }
+    rig = _Rig(
+        hass, covers, cover_type="cover_day_night_shade", options=_model_c_options()
+    )
+    order: list[str] = []
+    for eid, cover in covers.items():
+        original = cover.command
+
+        async def _spy(entity_id, target, _eid=eid, _orig=None, **kw):
+            order.append(f"{_eid}:{target}")
+            await _orig(entity_id, target, **kw)
+
+        cover.command = lambda e, t, _o=original, _i=eid, **k: _spy(
+            e, t, _eid=_i, _orig=_o, **k
+        )
+
+    await rig.calibrator.async_run()
+
+    # The two restore commands are the last pair; the middle rail (origin 70,
+    # the longer haul from 0) goes first.
+    restores = [step for step in order if step.endswith(":30") or step.endswith(":70")]
+    assert restores == ["cover.middle:70", "cover.bottom:30"]
+
+
+@pytest.mark.asyncio
+async def test_the_restore_still_waits_for_each_cover_after_a_cancel(
+    hass: HomeAssistant,
+) -> None:
+    """The restore's one-at-a-time guarantee must survive the cancel path.
+
+    Its waits deliberately ignore the abort event: it runs AFTER a cancel has
+    been signalled, so racing that event would make every wait return on its
+    first scheduling and fan the whole restore out at once — on the one path
+    where coupled entities have no clearance plan protecting them.
+    """
+    covers = {
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=70),
+    }
+    rig = _Rig(
+        hass,
+        covers,
+        cover_type="cover_day_night_shade",
+        options=_model_c_options(),
+        move_timeout=0.5,
+    )
+    in_flight: list[int] = []
+    peak = 0
+    for cover in covers.values():
+        original = cover.command
+
+        async def _spy(entity_id, target, _orig=None, **kw):
+            nonlocal peak
+            in_flight.append(1)
+            peak = max(peak, len(in_flight))
+            await _orig(entity_id, target, **kw)
+            in_flight.pop()
+
+        cover.command = lambda e, t, _o=original, **k: _spy(e, t, _orig=_o, **k)
+
+    task = asyncio.ensure_future(rig.calibrator.async_run())
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if rig.covers["cover.middle"].commands:
+            break
+    rig.calibrator.async_cancel(restore=True)
+    await task
+
+    assert peak == 1, "covers must be restored one at a time, never concurrently"

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -46,15 +46,16 @@ from custom_components.adaptive_cover_pro.const import (
     TRAVEL_CALIBRATION_STATUS_TIMEOUT,
     TRAVEL_CALIBRATION_STATUS_UNAVAILABLE,
     TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
+    REASON_ASSUMED_STATE,
+    REASON_CLEARANCE_FAILED,
+    REASON_NO_ENTITIES,
+    REASON_NO_MOTION_OBSERVED,
 )
 from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.managers.cover_command import (
     CoverCommandService,
 )
 from custom_components.adaptive_cover_pro.managers.travel_calibration import (
-    REASON_ASSUMED_STATE,
-    REASON_NO_ENTITIES,
-    REASON_NO_MOTION_OBSERVED,
     TravelTimeCalibrator,
 )
 
@@ -182,6 +183,24 @@ class _Rig:
             policy=get_policy(cover_type),
         )
         self.cmd_svc._execute_command = AsyncMock(side_effect=self._dispatch)
+        self.policy = get_policy(cover_type)
+        # Attach exactly as the coordinator does at setup. Skipping it leaves a
+        # coupled policy with no sequencer and no entity list, which makes its
+        # clearance gate inert — so the rig would quietly be testing an
+        # UNCOUPLED cover while claiming to test rails.
+        self.policy.attach(
+            hass=hass,
+            logger=MagicMock(),
+            grace_mgr=MagicMock(),
+            entities=list(covers),
+            get_current_position=self.cmd_svc.get_current_position,
+            set_commanded_position=self.cmd_svc.set_target,
+            position_tolerance=3,
+            is_dry_run=lambda: False,
+            get_state=lambda eid: getattr(hass.states.get(eid), "state", None),
+            get_booked_target=lambda _eid: None,
+            cmd_svc=self.cmd_svc,
+        )
 
         async def _persist(table):
             self.persisted = table
@@ -190,7 +209,7 @@ class _Rig:
             hass,
             MagicMock(),
             cmd_svc=self.cmd_svc,
-            policy=get_policy(cover_type),
+            policy=self.policy,
             get_entities=lambda: list(covers),
             get_options=lambda: self.options,
             persist=_persist,
@@ -476,8 +495,14 @@ async def test_no_entities_reports_failure(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stale_rows_are_pruned_at_run_start(hass: HomeAssistant) -> None:
-    """A cover swapped out in the options flow must not linger in the table."""
+async def test_stale_rows_are_pruned_from_the_persisted_table(
+    hass: HomeAssistant,
+) -> None:
+    """A cover swapped out in the options flow must not linger in the table.
+
+    Pruned at persist time rather than run start, so it holds for a run that
+    was cancelled part-way as well as one that completed.
+    """
     rig = _rig(hass)
     rig.options[CONF_TRAVEL_TIME_CALIBRATION] = {
         "cover.gone": {"full_travel_seconds": 12.0}
@@ -770,7 +795,7 @@ async def test_a_partner_that_will_not_park_blocks_its_subject(
 
     result = rig.calibrator.diagnostics()["results"]["cover.bottom"]
     assert result["status"] == TRAVEL_CALIBRATION_STATUS_TIMEOUT
-    assert result["reason"] == "clearance_failed"
+    assert result["reason"] == REASON_CLEARANCE_FAILED
     # Never SWEPT: no command to its far endpoint. It is still driven to 0 later
     # on, but as the middle rail's clearance partner — a parking move, not a
     # timed traverse — which is exactly the distinction being asserted.
@@ -918,14 +943,14 @@ async def test_reconciliation_stands_down_during_a_run(hass: HomeAssistant) -> N
 
 
 @pytest.mark.asyncio
-async def test_the_furthest_traveller_leads_the_restore(hass: HomeAssistant) -> None:
+async def test_the_clearance_gate_orders_the_restore(hass: HomeAssistant) -> None:
     """Coupled rails cannot pass each other on the way home either.
 
-    Both rails finish a run parked on the same endpoint and travel the same way
-    out of it, so whoever has furthest to go is the one everyone else would
-    otherwise have to travel through — it must lead. On an upright Model C
-    install that works out to the middle rail, which is what a raise requires;
-    the old fixed "bottom rail first" order had it exactly backwards.
+    The order is not computed by the calibrator — each candidate is offered to
+    the policy's own clearance gate and only the cleared ones move, so whatever
+    is blocked waits for its blocker to land. Both rails finish a run parked at
+    wire 0 and are restored upward, and the middle rail cannot be passed, so the
+    gate holds the bottom rail back until the middle one is home.
     """
     covers = {
         "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
@@ -999,3 +1024,67 @@ async def test_the_restore_still_waits_for_each_cover_after_a_cancel(
     await task
 
     assert peak == 1, "covers must be restored one at a time, never concurrently"
+
+
+@pytest.mark.asyncio
+async def test_a_restore_that_raises_still_leaves_a_recoverable_calibrator(
+    hass: HomeAssistant,
+) -> None:
+    """A failed go-home move must not brick the feature.
+
+    Everything that makes a run recoverable happens after the restore: clearing
+    ``calibrating``, settling on a terminal state, and persisting. Letting the
+    restore's exception escape skipped all three — leaving the sensor reading
+    ``running`` forever, after which every later run early-returns at the
+    is_running guard and travel-time calibration is dead for the life of the
+    config entry.
+    """
+    rig = _rig(hass)
+    original = rig.cmd_svc._execute_command
+    calls = {"n": 0}
+
+    async def _fail_on_restore(entity_id, target, **kw):
+        calls["n"] += 1
+        # The three sweep legs succeed; the go-home move blows up.
+        if calls["n"] > 3:
+            raise ValueError("go-home exploded")
+        await original(entity_id, target, **kw)
+
+    rig.cmd_svc._execute_command = AsyncMock(side_effect=_fail_on_restore)
+
+    await rig.calibrator.async_run()
+
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_FAILED
+    assert rig.calibrator.is_running is False
+    assert rig.cmd_svc.calibrating is False
+    # The measurements it did take are kept, not thrown away with the failure.
+    assert rig.persisted is not None
+    assert "cover.a" in rig.persisted
+
+
+@pytest.mark.asyncio
+async def test_a_hard_cancel_stops_a_restore_already_under_way(
+    hass: HomeAssistant,
+) -> None:
+    """Unload and panic-stop must not sit through a per-move timeout per cover.
+
+    The restore deliberately ignores the ordinary cancel — it runs after one has
+    been raised and still has to wait for each cover in turn — so it needs the
+    stronger signal to remain interruptible at all.
+    """
+    rig = _rig(hass, position=42, stalled=True, move_timeout=30)
+    task = await _park_in_wait(rig)
+    await _partial_move(rig, "cover.a", 10)
+
+    # Ordinary cancel: the restore starts and its wait is abort-immune.
+    rig.calibrator.async_cancel(restore=True)
+    for _ in range(40):
+        await asyncio.sleep(0)
+        if len(rig.commands("cover.a")) > 1:
+            break
+    # The hard signal reaches it anyway.
+    rig.calibrator.async_cancel(restore=False)
+    await asyncio.wait_for(task, timeout=5)
+
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_CANCELLED
+    assert rig.cmd_svc.calibrating is False

--- a/tests/test_travel_calibration.py
+++ b/tests/test_travel_calibration.py
@@ -1,0 +1,831 @@
+"""Measuring how long a cover takes to move, and refusing to guess when it can't.
+
+``TravelTimeCalibrator`` sweeps each configured cover stop-to-stop twice, times
+both legs, and stores the result so later moves can be rendered as a ramp. Three
+things make it more than a stopwatch:
+
+* a cover HA can only *assume* the state of reports arrival instantly, so timing
+  it would measure a service call rather than a traverse — those are excluded;
+* physically coupled covers (day/night Model C rails) cannot sweep with their
+  partner in the way, so the policy names where the partner must be parked first;
+* the run owns the covers while it holds them, and has to give them back on
+  every exit path — success, timeout, exception, or cancel.
+
+Timings are synthetic without being fake: the stand-in cover publishes its
+states with explicit ``timestamp`` values, which HA carries through to
+``time_fired`` — the very field the calibrator measures. So a "20 second"
+traverse is exactly 20 seconds to the code under test while taking microseconds
+to run. Freezing the clock instead would deadlock every ``asyncio`` timeout in
+the module, since freezegun stops ``time.monotonic`` and the event loop is
+driven by it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONTROL_MODEL,
+    CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+    CONF_INVERSE_STATE,
+    CONF_TRAVEL_TIME_CALIBRATION,
+    DAY_NIGHT_MODEL_DUAL_ENTITY,
+    TRAVEL_CALIBRATION_SOURCE_MANUAL,
+    TRAVEL_CALIBRATION_SOURCE_MEASURED,
+    TRAVEL_CALIBRATION_STATE_CANCELLED,
+    TRAVEL_CALIBRATION_STATE_COMPLETE,
+    TRAVEL_CALIBRATION_STATE_FAILED,
+    TRAVEL_CALIBRATION_STATE_RUNNING,
+    TRAVEL_CALIBRATION_STATUS_OK,
+    TRAVEL_CALIBRATION_STATUS_TIMEOUT,
+    TRAVEL_CALIBRATION_STATUS_UNAVAILABLE,
+    TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+)
+from custom_components.adaptive_cover_pro.managers.travel_calibration import (
+    REASON_ASSUMED_STATE,
+    REASON_NO_ENTITIES,
+    REASON_NO_MOTION_OBSERVED,
+    TravelTimeCalibrator,
+)
+
+pytestmark = pytest.mark.integration
+
+# HA CoverEntityFeature masks: OPEN(1) CLOSE(2) SET_POSITION(4) STOP(8).
+_POSITION_FEATURES = 1 | 2 | 4 | 8
+_OPEN_CLOSE_FEATURES = 1 | 2 | 8
+
+# Real-clock budgets, deliberately tiny: only the tests that exercise a stall or
+# a cancel ever reach them, and they should not add seconds to the suite.
+_TEST_MOVE_TIMEOUT = 0.25
+_TEST_PROBE = 0.05
+
+# The synthetic timestamps are exact, but ``sent_at`` is taken from the real
+# clock a few microseconds earlier, so the delay split lands just off the nose.
+_DELAY_TOLERANCE = 0.5
+
+
+class _FakeCover:
+    """A cover that answers commands by publishing timestamped states.
+
+    Each command restarts from the current wall clock and lays its states out at
+    explicit offsets, so every leg is self-consistent and ``sent_at`` (which the
+    calibrator reads from the real clock) lines up with offset zero.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entity_id: str,
+        *,
+        position: int = 30,
+        features: int = _POSITION_FEATURES,
+        open_travel: float = 20.0,
+        close_travel: float = 20.0,
+        delay: float = 2.0,
+        publish_transit: bool = True,
+        assumed: bool = False,
+        stalled: bool = False,
+        stall_after: int | None = None,
+        never_arrive: bool = False,
+    ) -> None:
+        self.hass = hass
+        self.entity_id = entity_id
+        self.position = position
+        self.features = features
+        self.open_travel = open_travel
+        self.close_travel = close_travel
+        self.delay = delay
+        self.publish_transit = publish_transit
+        self.assumed = assumed
+        self.stalled = stalled
+        # Stop responding once this many commands have been accepted — lets a
+        # test stall a specific leg rather than the whole run.
+        self.stall_after = stall_after
+        # Report motion but never reach the target: a cover that starts and
+        # then jams, which is a different failure from one that never moves.
+        self.never_arrive = never_arrive
+        self.commands: list[int] = []
+        self._publish(time.time())
+
+    @property
+    def _position_capable(self) -> bool:
+        return bool(self.features & 4)
+
+    def _attrs(self) -> dict:
+        attrs: dict = {"supported_features": self.features}
+        if self._position_capable:
+            attrs["current_position"] = self.position
+        if self.assumed:
+            attrs["assumed_state"] = True
+        return attrs
+
+    def _publish(self, stamp: float, state: str | None = None) -> None:
+        if state is None:
+            state = "closed" if self.position == 0 else "open"
+        self.hass.states.async_set(
+            self.entity_id, state, self._attrs(), timestamp=stamp
+        )
+
+    async def command(self, entity_id: str, target: int, **_kw) -> None:
+        """Stand in for CoverCommandService._execute_command."""
+        self.commands.append(target)
+        if self.stalled or (
+            self.stall_after is not None and len(self.commands) > self.stall_after
+        ):
+            return
+        base = time.time()
+        rising = target > self.position
+        if self.publish_transit:
+            self._publish(base + self.delay, "opening" if rising else "closing")
+            await self.hass.async_block_till_done()
+        if self.never_arrive:
+            return
+        travel = self.open_travel if rising else self.close_travel
+        self.position = target
+        self._publish(base + self.delay + travel)
+        await self.hass.async_block_till_done()
+
+
+class _Rig:
+    """A calibrator wired to one or more fake covers."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        covers: dict[str, _FakeCover],
+        *,
+        cover_type: str = "cover_blind",
+        options: dict | None = None,
+        move_timeout: float = _TEST_MOVE_TIMEOUT,
+    ) -> None:
+        self.hass = hass
+        self.covers = covers
+        self.options = dict(options or {})
+        self.persisted: dict | None = None
+        # A real CoverCommandService so capability reads, position reads,
+        # availability and the _at_target tolerance are the production ones.
+        self.cmd_svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type=cover_type,
+            grace_mgr=MagicMock(),
+            policy=get_policy(cover_type),
+        )
+        self.cmd_svc._execute_command = AsyncMock(side_effect=self._dispatch)
+
+        async def _persist(table):
+            self.persisted = table
+
+        self.calibrator = TravelTimeCalibrator(
+            hass,
+            MagicMock(),
+            cmd_svc=self.cmd_svc,
+            policy=get_policy(cover_type),
+            get_entities=lambda: list(covers),
+            get_options=lambda: self.options,
+            persist=_persist,
+            move_timeout_seconds=move_timeout,
+            probe_seconds=_TEST_PROBE,
+        )
+
+    async def _dispatch(self, entity_id: str, target: int, **kw) -> None:
+        await self.covers[entity_id].command(entity_id, target, **kw)
+
+    def commands(self, entity_id: str) -> list[int]:
+        return self.covers[entity_id].commands
+
+
+def _rig(hass, *, move_timeout: float = _TEST_MOVE_TIMEOUT, **cover_kwargs) -> _Rig:
+    """One position-capable cover, the common case."""
+    return _Rig(
+        hass,
+        {"cover.a": _FakeCover(hass, "cover.a", **cover_kwargs)},
+        move_timeout=move_timeout,
+    )
+
+
+async def _park_in_wait(rig: _Rig) -> asyncio.Task:
+    """Start a run and let it settle into its first arrival wait."""
+    task = asyncio.ensure_future(rig.calibrator.async_run())
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if rig.commands("cover.a"):
+            break
+    assert rig.calibrator.is_running
+    return task
+
+
+async def _partial_move(rig: _Rig, entity_id: str, position: int) -> None:
+    """Move a stalled cover part-way, without it ever reaching its target.
+
+    Gives a cancel something real to undo: a cover still sitting exactly where
+    the run found it has nothing to restore, so a restore pass over it is
+    correctly a no-op and proves nothing.
+    """
+    cover = rig.covers[entity_id]
+    cover.position = position
+    cover._publish(time.time())
+    await rig.hass.async_block_till_done()
+
+
+# ------------------------------------------------------------------ #
+# The measurement itself
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_sweeps_each_endpoint_in_order(hass: HomeAssistant) -> None:
+    """Seed to closed, time the traverse open, time it back, then go home."""
+    rig = _rig(hass)
+    await rig.calibrator.async_run()
+
+    assert rig.commands("cover.a") == [0, 100, 0, 30]
+
+
+@pytest.mark.asyncio
+async def test_asymmetric_legs_are_recorded_separately(hass: HomeAssistant) -> None:
+    """A cover that drops faster than it rises must not be flattened to one figure."""
+    rig = _rig(hass, open_travel=40.0, close_travel=20.0)
+    await rig.calibrator.async_run()
+
+    row = rig.persisted["cover.a"]
+    assert row["open_seconds"] == pytest.approx(40.0, abs=_DELAY_TOLERANCE)
+    assert row["close_seconds"] == pytest.approx(20.0, abs=_DELAY_TOLERANCE)
+    assert row["full_travel_seconds"] == pytest.approx(30.0, abs=_DELAY_TOLERANCE)
+    assert row["source"] == TRAVEL_CALIBRATION_SOURCE_MEASURED
+
+
+@pytest.mark.asyncio
+async def test_start_delay_is_split_out_of_travel(hass: HomeAssistant) -> None:
+    """Actuator dead time is measured, and excluded from the travel figure.
+
+    Booking the lag as travel would make every ramp derived from it start early
+    and finish late, so the two are recorded as separate numbers.
+    """
+    rig = _rig(hass, delay=4.0, open_travel=20.0, close_travel=20.0)
+    await rig.calibrator.async_run()
+
+    row = rig.persisted["cover.a"]
+    assert row["start_delay_seconds"] == pytest.approx(4.0, abs=_DELAY_TOLERANCE)
+    assert row["full_travel_seconds"] == pytest.approx(20.0, abs=_DELAY_TOLERANCE)
+
+
+@pytest.mark.asyncio
+async def test_position_only_cover_is_timed_without_transit_states(
+    hass: HomeAssistant,
+) -> None:
+    """A cover that reports only its final position still calibrates.
+
+    Nothing here distinguishes dead time from travel — the single publish that
+    says "arrived" is the only evidence there is. The whole elapsed span books
+    as travel and the delay as zero, which is the conservative half of that
+    trade: a ramp that runs a little slow, rather than one that shows the cover
+    parked while it is in fact already moving.
+    """
+    rig = _rig(
+        hass, publish_transit=False, delay=2.0, open_travel=25.0, close_travel=25.0
+    )
+    await rig.calibrator.async_run()
+
+    row = rig.persisted["cover.a"]
+    assert row["full_travel_seconds"] == pytest.approx(27.0, abs=_DELAY_TOLERANCE)
+    assert row["start_delay_seconds"] == pytest.approx(0.0, abs=_DELAY_TOLERANCE)
+
+
+@pytest.mark.asyncio
+async def test_results_are_persisted_and_reported_ok(hass: HomeAssistant) -> None:
+    rig = _rig(hass)
+    await rig.calibrator.async_run()
+
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_COMPLETE
+    assert rig.calibrator.active_entity is None
+    assert (
+        rig.calibrator.diagnostics()["results"]["cover.a"]["status"]
+        == TRAVEL_CALIBRATION_STATUS_OK
+    )
+
+
+# ------------------------------------------------------------------ #
+# Observability — covers that cannot be measured
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_assumed_state_cover_is_never_commanded(hass: HomeAssistant) -> None:
+    """The gate fires before dispatch: an unmeasurable cover is not moved at all.
+
+    Sweeping it would put the covers through a pointless round trip to arrive at
+    a number that means nothing.
+    """
+    rig = _rig(hass, features=_OPEN_CLOSE_FEATURES, assumed=True)
+    await rig.calibrator.async_run()
+
+    assert rig.commands("cover.a") == []
+    result = rig.calibrator.diagnostics()["results"]["cover.a"]
+    assert result["status"] == TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE
+    assert result["reason"] == REASON_ASSUMED_STATE
+
+
+@pytest.mark.asyncio
+async def test_snapping_cover_without_transit_states_is_unobservable(
+    hass: HomeAssistant,
+) -> None:
+    """A position-less cover that never reports motion cannot be timed.
+
+    It reports the destination state immediately, which from the outside is
+    indistinguishable from teleporting. The probe catches it rather than
+    crediting it with an instantaneous traverse.
+    """
+    rig = _rig(
+        hass,
+        features=_OPEN_CLOSE_FEATURES,
+        publish_transit=False,
+        open_travel=0.0,
+        close_travel=0.0,
+        delay=0.0,
+    )
+    await rig.calibrator.async_run()
+
+    result = rig.calibrator.diagnostics()["results"]["cover.a"]
+    assert result["status"] == TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE
+    assert result["reason"] == REASON_NO_MOTION_OBSERVED
+    assert rig.persisted == {}
+
+
+@pytest.mark.asyncio
+async def test_open_close_cover_with_real_transit_states_calibrates(
+    hass: HomeAssistant,
+) -> None:
+    """No position, but honest opening/closing → fully supported.
+
+    This is the case the whole feature exists for: a cover that cannot report
+    where it is, but can be timed, and therefore can be animated.
+    """
+    rig = _rig(
+        hass,
+        features=_OPEN_CLOSE_FEATURES,
+        position=0,
+        open_travel=18.0,
+        close_travel=18.0,
+    )
+    await rig.calibrator.async_run()
+
+    assert rig.persisted["cover.a"]["full_travel_seconds"] == pytest.approx(
+        18.0, abs=_DELAY_TOLERANCE
+    )
+
+
+@pytest.mark.asyncio
+async def test_unavailable_cover_is_skipped(hass: HomeAssistant) -> None:
+    rig = _rig(hass)
+    hass.states.async_set("cover.a", "unavailable", {})
+    await hass.async_block_till_done()
+    await rig.calibrator.async_run()
+
+    assert rig.commands("cover.a") == []
+    assert (
+        rig.calibrator.diagnostics()["results"]["cover.a"]["status"]
+        == TRAVEL_CALIBRATION_STATUS_UNAVAILABLE
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_measured_run_leaves_a_manual_row_alone(hass: HomeAssistant) -> None:
+    """The covers that need manual entry are exactly the ones a run skips.
+
+    If a run wiped the rows it could not replace, calibrating an install with one
+    RTS blind in it would silently un-configure that blind every time.
+    """
+    manual = {
+        "full_travel_seconds": 27.0,
+        "open_seconds": None,
+        "close_seconds": None,
+        "start_delay_seconds": 0.0,
+        "calibrated_at": "2026-08-01T00:00:00+00:00",
+        "source": TRAVEL_CALIBRATION_SOURCE_MANUAL,
+    }
+    covers = {
+        "cover.rts": _FakeCover(
+            hass, "cover.rts", features=_OPEN_CLOSE_FEATURES, assumed=True
+        ),
+        "cover.good": _FakeCover(hass, "cover.good"),
+    }
+    rig = _Rig(
+        hass, covers, options={CONF_TRAVEL_TIME_CALIBRATION: {"cover.rts": manual}}
+    )
+    await rig.calibrator.async_run()
+
+    assert rig.persisted["cover.rts"] == manual
+    # …and the sibling still got measured. One skip must not void the batch.
+    assert rig.persisted["cover.good"]["source"] == TRAVEL_CALIBRATION_SOURCE_MEASURED
+
+
+# ------------------------------------------------------------------ #
+# Failure handling
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_cover_times_out_without_voiding_the_batch(
+    hass: HomeAssistant,
+) -> None:
+    covers = {
+        "cover.stuck": _FakeCover(hass, "cover.stuck", stalled=True),
+        "cover.good": _FakeCover(hass, "cover.good"),
+    }
+    rig = _Rig(hass, covers)
+    await rig.calibrator.async_run()
+
+    results = rig.calibrator.diagnostics()["results"]
+    assert results["cover.stuck"]["status"] == TRAVEL_CALIBRATION_STATUS_TIMEOUT
+    assert results["cover.good"]["status"] == TRAVEL_CALIBRATION_STATUS_OK
+    assert "cover.stuck" not in rig.persisted
+    assert "cover.good" in rig.persisted
+
+
+@pytest.mark.asyncio
+async def test_implausible_measurement_is_discarded(hass: HomeAssistant) -> None:
+    """A sub-second 'traverse' is a device echoing its target, not a fast cover."""
+    rig = _rig(hass, open_travel=0.2, close_travel=0.2, delay=0.0)
+    await rig.calibrator.async_run()
+
+    assert rig.persisted == {}
+    assert (
+        rig.calibrator.diagnostics()["results"]["cover.a"]["status"]
+        == TRAVEL_CALIBRATION_STATUS_TIMEOUT
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_entities_reports_failure(hass: HomeAssistant) -> None:
+    rig = _Rig(hass, {})
+    await rig.calibrator.async_run()
+
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_FAILED
+    assert rig.calibrator.diagnostics()["last_error"] == REASON_NO_ENTITIES
+
+
+@pytest.mark.asyncio
+async def test_stale_rows_are_pruned_at_run_start(hass: HomeAssistant) -> None:
+    """A cover swapped out in the options flow must not linger in the table."""
+    rig = _rig(hass)
+    rig.options[CONF_TRAVEL_TIME_CALIBRATION] = {
+        "cover.gone": {"full_travel_seconds": 12.0}
+    }
+    await rig.calibrator.async_run()
+
+    assert "cover.gone" not in rig.persisted
+
+
+# ------------------------------------------------------------------ #
+# Owning the covers, and giving them back
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_automation_is_suspended_and_handed_back(hass: HomeAssistant) -> None:
+    rig = _rig(hass)
+    seen: list[bool] = []
+    original = rig.covers["cover.a"].command
+
+    async def _spy(entity_id, target, **kw):
+        seen.append(rig.cmd_svc.calibrating)
+        await original(entity_id, target, **kw)
+
+    rig.covers["cover.a"].command = _spy
+    await rig.calibrator.async_run()
+
+    assert seen and all(seen), "automation must be suspended for every leg"
+    assert rig.cmd_svc.calibrating is False
+
+
+@pytest.mark.asyncio
+async def test_automation_is_handed_back_even_when_the_run_raises(
+    hass: HomeAssistant,
+) -> None:
+    """A crash mid-run must not leave the integration silently switched off."""
+    rig = _rig(hass)
+    rig.cmd_svc._execute_command = AsyncMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError):
+        await rig.calibrator.async_run()
+
+    assert rig.cmd_svc.calibrating is False
+
+
+@pytest.mark.asyncio
+async def test_covers_are_restored_to_where_the_run_found_them(
+    hass: HomeAssistant,
+) -> None:
+    rig = _rig(hass, position=42)
+    await rig.calibrator.async_run()
+
+    assert rig.commands("cover.a")[-1] == 42
+
+
+@pytest.mark.asyncio
+async def test_a_second_trigger_while_running_is_a_no_op(hass: HomeAssistant) -> None:
+    rig = _rig(hass)
+    rig.calibrator._state = TRAVEL_CALIBRATION_STATE_RUNNING
+    await rig.calibrator.async_run()
+
+    assert rig.commands("cover.a") == []
+
+
+# ------------------------------------------------------------------ #
+# Cancellation
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_cancel_with_restore_puts_the_covers_back(hass: HomeAssistant) -> None:
+    rig = _rig(hass, position=42, stalled=True, move_timeout=5)
+    task = await _park_in_wait(rig)
+    await _partial_move(rig, "cover.a", 10)
+
+    rig.calibrator.async_cancel(restore=True)
+    await task
+
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_CANCELLED
+    assert rig.cmd_svc.calibrating is False
+    assert rig.commands("cover.a")[-1] == 42
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_restore_issues_no_further_movement(
+    hass: HomeAssistant,
+) -> None:
+    """What the panic stop needs: stand down, do not move anything else."""
+    rig = _rig(hass, position=42, stalled=True, move_timeout=5)
+    task = await _park_in_wait(rig)
+    await _partial_move(rig, "cover.a", 10)
+    before = list(rig.commands("cover.a"))
+
+    rig.calibrator.async_cancel(restore=False)
+    await task
+
+    assert rig.commands("cover.a") == before
+    assert rig.calibrator.state == TRAVEL_CALIBRATION_STATE_CANCELLED
+    assert rig.cmd_svc.calibrating is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_when_idle_reports_nothing_to_cancel(hass: HomeAssistant) -> None:
+    rig = _rig(hass)
+    assert rig.calibrator.async_cancel(restore=True) is False
+
+
+# ------------------------------------------------------------------ #
+# Day/night Model C — coupled rails
+# ------------------------------------------------------------------ #
+
+
+def _model_c_options(*, inverse: bool = False) -> dict:
+    opts = {
+        CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: "cover.middle",
+    }
+    if inverse:
+        opts[CONF_INVERSE_STATE] = True
+    return opts
+
+
+def _model_c_rig(hass) -> _Rig:
+    covers = {
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=60),
+    }
+    return _Rig(
+        hass,
+        covers,
+        cover_type="cover_day_night_shade",
+        options=_model_c_options(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_c_parks_the_partner_before_each_rail(hass: HomeAssistant) -> None:
+    """Each rail's sweep is preceded by its partner vacating the track.
+
+    The bottom rail cannot rise to fully-open unless the middle rail is already
+    there; the middle rail cannot drop to fully-closed unless the bottom rail is.
+    """
+    rig = _model_c_rig(hass)
+    await rig.calibrator.async_run()
+
+    bottom = rig.commands("cover.bottom")
+    middle = rig.commands("cover.middle")
+    # The middle rail is driven fully open before the bottom rail's sweep…
+    assert middle[0] == 100
+    assert bottom[:3] == [0, 100, 0]
+    # …and the middle rail's own sweep follows, the bottom rail already parked
+    # at 0 by its own closing leg.
+    assert middle[1:4] == [0, 100, 0]
+
+
+@pytest.mark.asyncio
+async def test_model_c_calibrates_both_rails(hass: HomeAssistant) -> None:
+    rig = _model_c_rig(hass)
+    await rig.calibrator.async_run()
+
+    assert set(rig.persisted) == {"cover.bottom", "cover.middle"}
+
+
+def test_model_c_parks_flipped_endpoints_on_an_inverse_install() -> None:
+    """The parking spots are wire numbers, so inversion has to be applied.
+
+    Parking the middle rail at wire 100 on an inverse install would drive it to
+    fully CLOSED — into the bottom rail, which is the collision this frame
+    handling exists to prevent (the #993 bug class).
+    """
+    policy = get_policy("cover_day_night_shade")
+    rails = ["cover.bottom", "cover.middle"]
+
+    assert policy.travel_calibration_clearance(
+        "cover.bottom", rails, _model_c_options(inverse=True)
+    ) == {"cover.middle": 0}
+    assert policy.travel_calibration_clearance(
+        "cover.bottom", rails, _model_c_options()
+    ) == {"cover.middle": 100}
+    assert policy.travel_calibration_clearance(
+        "cover.middle", rails, _model_c_options()
+    ) == {"cover.bottom": 0}
+
+
+def test_clearance_is_empty_without_a_configured_middle_rail() -> None:
+    """An unconfigured rail role has no safe parking spot to name."""
+    policy = get_policy("cover_day_night_shade")
+    assert (
+        policy.travel_calibration_clearance(
+            "cover.bottom",
+            ["cover.bottom", "cover.middle"],
+            {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY},
+        )
+        == {}
+    )
+
+
+def test_independent_cover_types_need_no_clearance() -> None:
+    assert (
+        get_policy("cover_blind").travel_calibration_clearance(
+            "cover.a", ["cover.a", "cover.b"], {}
+        )
+        == {}
+    )
+
+
+# ------------------------------------------------------------------ #
+# Leg arithmetic edge cases
+# ------------------------------------------------------------------ #
+
+
+def test_a_motion_stamp_at_or_after_arrival_falls_back_to_the_command_time():
+    """Out-of-order publishes must not produce a zero or negative traverse.
+
+    A negative one would propagate into a ramp that runs backwards, so the
+    split falls back to timing from the command instead.
+    """
+    from custom_components.adaptive_cover_pro.managers.travel_calibration import (
+        _Arrival,
+        _Leg,
+    )
+
+    sent = dt.datetime(2026, 8, 2, 12, 0, 0, tzinfo=dt.UTC)
+    arrived = sent + dt.timedelta(seconds=20)
+    leg = _Leg.from_arrival(
+        _Arrival(arrived_at=arrived, first_motion_at=arrived + dt.timedelta(seconds=5)),
+        sent,
+    )
+
+    assert leg.travel_seconds == pytest.approx(20.0)
+    assert leg.start_delay_seconds == pytest.approx(0.0)
+
+
+# ------------------------------------------------------------------ #
+# More failure paths
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_a_leg_that_stalls_after_the_seed_is_a_timeout(
+    hass: HomeAssistant,
+) -> None:
+    """The cover reaches its start position, then jams on the timed sweep."""
+    rig = _rig(hass, stall_after=1)
+    await rig.calibrator.async_run()
+
+    assert (
+        rig.calibrator.diagnostics()["results"]["cover.a"]["status"]
+        == TRAVEL_CALIBRATION_STATUS_TIMEOUT
+    )
+    assert rig.persisted == {}
+
+
+@pytest.mark.asyncio
+async def test_a_cover_that_starts_but_never_lands_times_out(
+    hass: HomeAssistant,
+) -> None:
+    """Motion IS observed, so this is not the unobservable case — it is a jam.
+
+    The probe is satisfied by the transit state and the wait falls through to
+    the remaining per-move budget.
+    """
+    rig = _rig(hass, features=_OPEN_CLOSE_FEATURES, never_arrive=True)
+    await rig.calibrator.async_run()
+
+    result = rig.calibrator.diagnostics()["results"]["cover.a"]
+    assert result["status"] == TRAVEL_CALIBRATION_STATUS_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_a_partner_that_will_not_park_blocks_its_subject(
+    hass: HomeAssistant,
+) -> None:
+    """No clearance, no sweep.
+
+    Driving a rail stop-to-stop while its partner sits in the way is how a rail
+    gets driven into a rail, so a failed parking move must abandon the subject
+    rather than proceed hopefully.
+    """
+    covers = {
+        "cover.bottom": _FakeCover(hass, "cover.bottom", position=30),
+        "cover.middle": _FakeCover(hass, "cover.middle", position=60, stalled=True),
+    }
+    rig = _Rig(
+        hass,
+        covers,
+        cover_type="cover_day_night_shade",
+        options=_model_c_options(),
+    )
+    await rig.calibrator.async_run()
+
+    result = rig.calibrator.diagnostics()["results"]["cover.bottom"]
+    assert result["status"] == TRAVEL_CALIBRATION_STATUS_TIMEOUT
+    assert result["reason"] == "clearance_failed"
+    # Never SWEPT: no command to its far endpoint. It is still driven to 0 later
+    # on, but as the middle rail's clearance partner — a parking move, not a
+    # timed traverse — which is exactly the distinction being asserted.
+    assert 100 not in rig.commands("cover.bottom")
+
+
+@pytest.mark.asyncio
+async def test_cancel_stops_the_batch_before_the_remaining_covers(
+    hass: HomeAssistant,
+) -> None:
+    """A cancel must not merely finish the current cover and carry on."""
+    covers = {
+        "cover.a": _FakeCover(hass, "cover.a", stalled=True),
+        "cover.b": _FakeCover(hass, "cover.b"),
+    }
+    rig = _Rig(hass, covers, move_timeout=5)
+    task = await _park_in_wait(rig)
+
+    rig.calibrator.async_cancel(restore=False)
+    await task
+
+    assert rig.commands("cover.b") == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_the_observability_probe_is_not_a_verdict(
+    hass: HomeAssistant,
+) -> None:
+    """A cancelled probe must not be recorded as "this cover cannot be measured".
+
+    The probe never completed, so it has no finding to report — writing one
+    would tell the user their cover is unmeasurable on the strength of having
+    pressed Cancel.
+    """
+    rig = _rig(hass, features=_OPEN_CLOSE_FEATURES, stalled=True, move_timeout=5)
+    rig.calibrator._probe_seconds = 5.0
+    task = await _park_in_wait(rig)
+
+    rig.calibrator.async_cancel(restore=False)
+    await task
+
+    result = rig.calibrator.diagnostics()["results"].get("cover.a", {})
+    assert result.get("status") != TRAVEL_CALIBRATION_STATUS_UNOBSERVABLE
+
+
+@pytest.mark.asyncio
+async def test_progress_callback_fires_as_the_run_advances(
+    hass: HomeAssistant,
+) -> None:
+    """Drives the sensor redraw, which is how a run is watched."""
+    rig = _rig(hass)
+    seen: list[str] = []
+    rig.calibrator._on_progress = lambda: seen.append(rig.calibrator.state)
+
+    await rig.calibrator.async_run()
+
+    assert seen
+    assert seen[-1] == TRAVEL_CALIBRATION_STATE_COMPLETE

--- a/tests/test_travel_plan_surface.py
+++ b/tests/test_travel_plan_surface.py
@@ -1,0 +1,391 @@
+"""Travel plans — turning a measured travel time into a position-vs-time ramp.
+
+A cover that reports position sparsely (or not at all) leaves a dashboard card
+with nothing to animate. Once ``CONF_TRAVEL_TIME_CALIBRATION`` knows how long a
+full sweep takes, every dispatched command can carry a ``TravelPlan``: where the
+cover started, where it is going, when it was told, how long it dawdles before
+moving, and how long the move should take. The card interpolates locally; ACP
+writes two states per move instead of ticking.
+
+Sibling surface to ``transit_direction`` (tests/test_transit_direction.py) — the
+two share the ``_prepare_service_call`` write and the ``_clear_waiting`` clear,
+so their lifecycles must stay locked together.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    TRAVEL_CALIBRATION_SOURCE_MANUAL,
+    TRAVEL_CALIBRATION_SOURCE_MEASURED,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command.state_store import (
+    TravelPlan,
+    build_travel_plan,
+)
+
+pytestmark = pytest.mark.integration
+
+_T0 = dt.datetime(2026, 8, 2, 12, 0, 0, tzinfo=dt.UTC)
+
+_OPEN_CLOSE_CAPS = {
+    "has_set_position": False,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+_POSITION_CAPS = {
+    "has_set_position": True,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+
+# 40 s to raise, 20 s to drop — the gravity-assisted asymmetry that averaging
+# would throw away. 2 s of actuator dead time before either leg begins.
+_ASYMMETRIC = {
+    "full_travel_seconds": 30.0,
+    "open_seconds": 40.0,
+    "close_seconds": 20.0,
+    "start_delay_seconds": 2.0,
+    "calibrated_at": _T0.isoformat(),
+    "source": TRAVEL_CALIBRATION_SOURCE_MEASURED,
+}
+# What manual entry produces: one headline number, no per-leg detail.
+_MANUAL_ONLY = {
+    "full_travel_seconds": 30.0,
+    "open_seconds": None,
+    "close_seconds": None,
+    "start_delay_seconds": 0.0,
+    "calibrated_at": _T0.isoformat(),
+    "source": TRAVEL_CALIBRATION_SOURCE_MANUAL,
+}
+
+
+def _svc(*, calibration=None, caps=None):
+    """Build a CoverCommandService with a stubbed calibration table."""
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    table = calibration or {}
+    svc = CoverCommandService(
+        hass=h,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        position_tolerance=3,
+        get_travel_calibration=lambda eid: table.get(eid),
+    )
+    if caps is not None:
+        svc.get_cover_capabilities = lambda _eid: caps
+    return svc
+
+
+# ------------------------------------------------------------------ #
+# build_travel_plan — the pure ramp derivation
+# ------------------------------------------------------------------ #
+
+
+def test_directional_duration_uses_the_open_leg_when_rising():
+    """0→50 on a 40 s open leg is half of 40, not half of the 30 s average."""
+    plan = build_travel_plan(
+        _ASYMMETRIC, from_position=0, to_position=50, started_at=_T0, span=100
+    )
+    assert plan.duration_seconds == pytest.approx(20.0)
+
+
+def test_directional_duration_uses_the_close_leg_when_falling():
+    """100→50 on a 20 s close leg is half of 20 — the asymmetry survives."""
+    plan = build_travel_plan(
+        _ASYMMETRIC, from_position=100, to_position=50, started_at=_T0, span=100
+    )
+    assert plan.duration_seconds == pytest.approx(10.0)
+
+
+def test_manual_entry_falls_back_to_full_travel_for_both_directions():
+    rising = build_travel_plan(
+        _MANUAL_ONLY, from_position=0, to_position=50, started_at=_T0, span=100
+    )
+    falling = build_travel_plan(
+        _MANUAL_ONLY, from_position=100, to_position=50, started_at=_T0, span=100
+    )
+    assert rising.duration_seconds == pytest.approx(15.0)
+    assert falling.duration_seconds == pytest.approx(15.0)
+
+
+def test_direction_is_judged_in_wire_space_not_open_percent():
+    """The leg is picked by the raw number's direction, matching _TRANSIT_WIRE_SIGN.
+
+    An inverse-state install flips what "open" means but not which way the wire
+    number travels, and the calibration legs were measured against the wire.
+    Judging in open-percent would pick the wrong leg on exactly those installs.
+    """
+    # Wire 20 → 80 is the number RISING, so it must be the open leg (40 s),
+    # regardless of what the install calls "open".
+    plan = build_travel_plan(
+        _ASYMMETRIC, from_position=20, to_position=80, started_at=_T0, span=100
+    )
+    assert plan.duration_seconds == pytest.approx(40.0 * 0.6)
+
+
+def test_span_scales_the_fraction():
+    """Duration is a fraction of the AXIS span, never of a hardcoded 100."""
+    plan = build_travel_plan(
+        _MANUAL_ONLY, from_position=0, to_position=25, started_at=_T0, span=50
+    )
+    assert plan.duration_seconds == pytest.approx(15.0)
+
+
+def test_no_plan_without_a_calibration():
+    assert (
+        build_travel_plan(
+            None, from_position=0, to_position=50, started_at=_T0, span=100
+        )
+        is None
+    )
+
+
+def test_no_plan_for_a_zero_length_move():
+    assert (
+        build_travel_plan(
+            _ASYMMETRIC, from_position=50, to_position=50, started_at=_T0, span=100
+        )
+        is None
+    )
+
+
+# ------------------------------------------------------------------ #
+# TravelPlan.position_at — the ramp itself
+# ------------------------------------------------------------------ #
+
+
+def _ramp(**kw):
+    defaults = {
+        "from_position": 0,
+        "to_position": 100,
+        "started_at": _T0,
+        "start_delay_seconds": 2.0,
+        "duration_seconds": 40.0,
+    }
+    return TravelPlan(**{**defaults, **kw})
+
+
+def test_position_holds_at_origin_during_the_start_delay():
+    """The actuator has not moved yet, so neither may the rendered position."""
+    plan = _ramp()
+    assert plan.position_at(_T0) == 0
+    assert plan.position_at(_T0 + dt.timedelta(seconds=1.9)) == 0
+
+
+def test_position_ramps_linearly_after_the_delay():
+    plan = _ramp()
+    # 2 s delay + half of 40 s = the midpoint.
+    assert plan.position_at(_T0 + dt.timedelta(seconds=22)) == 50
+
+
+def test_position_clamps_at_the_target_and_never_overshoots():
+    plan = _ramp()
+    assert plan.position_at(_T0 + dt.timedelta(seconds=42)) == 100
+    assert plan.position_at(_T0 + dt.timedelta(seconds=600)) == 100
+
+
+def test_position_ramps_downward_too():
+    plan = _ramp(from_position=100, to_position=0)
+    assert plan.position_at(_T0 + dt.timedelta(seconds=22)) == 50
+    assert plan.position_at(_T0 + dt.timedelta(seconds=600)) == 0
+
+
+# ------------------------------------------------------------------ #
+# Recording at the dispatch chokepoint
+# ------------------------------------------------------------------ #
+
+
+def test_plan_recorded_on_dispatch(monkeypatch):
+    svc = _svc(calibration={"cover.a": _ASYMMETRIC}, caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+
+    svc._prepare_service_call("cover.a", 50)
+
+    plan = svc.state("cover.a").travel_plan
+    assert plan is not None
+    assert (plan.from_position, plan.to_position) == (0, 50)
+    assert plan.duration_seconds == pytest.approx(20.0)
+    assert plan.start_delay_seconds == pytest.approx(2.0)
+
+
+def test_no_plan_recorded_when_the_cover_is_uncalibrated(monkeypatch):
+    svc = _svc(caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+
+    svc._prepare_service_call("cover.a", 50)
+
+    assert svc.state("cover.a").travel_plan is None
+
+
+def test_no_plan_recorded_when_the_origin_is_unknown(monkeypatch):
+    """No from-position means no ramp — an estimate needs both ends."""
+    svc = _svc(calibration={"cover.a": _ASYMMETRIC}, caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: None)
+
+    svc._prepare_service_call("cover.a", 50)
+
+    assert svc.state("cover.a").travel_plan is None
+
+
+def test_assumed_position_supplies_the_origin_for_a_no_feedback_cover(monkeypatch):
+    """The whole point of manual entry: a cover with no position still ramps.
+
+    The live read is None, so the display-only assumed position (#888) is the
+    only origin available. It must be read BEFORE _record_assumed_if_blind
+    overwrites it with this command's own target.
+    """
+    svc = _svc(calibration={"cover.a": _MANUAL_ONLY}, caps=_OPEN_CLOSE_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: None)
+    svc.record_assumed_position("cover.a", 100)
+
+    svc._prepare_service_call("cover.a", 0)
+
+    plan = svc.state("cover.a").travel_plan
+    assert plan is not None
+    assert (plan.from_position, plan.to_position) == (100, 0)
+
+
+# ------------------------------------------------------------------ #
+# Lifecycle — locked to `waiting`, exactly like transit_direction
+# ------------------------------------------------------------------ #
+
+
+def test_plan_cleared_when_waiting_clears(monkeypatch):
+    svc = _svc(calibration={"cover.a": _ASYMMETRIC}, caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+    svc._prepare_service_call("cover.a", 50)
+
+    svc._clear_waiting(svc.state("cover.a"))
+
+    assert svc.state("cover.a").travel_plan is None
+
+
+def test_travel_plans_gated_on_waiting(monkeypatch):
+    svc = _svc(calibration={"cover.a": _ASYMMETRIC}, caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+    svc._prepare_service_call("cover.a", 50)
+    assert "cover.a" in svc.travel_plans()
+
+    svc.state("cover.a").waiting = False
+    assert svc.travel_plans() == {}
+
+
+def test_travel_plans_payload_shape(monkeypatch):
+    """The card's wire contract — keys are load-bearing, so pin them."""
+    svc = _svc(calibration={"cover.a": _ASYMMETRIC}, caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+    svc._prepare_service_call("cover.a", 50)
+
+    payload = svc.travel_plans()["cover.a"]
+    assert set(payload) == {
+        "from",
+        "to",
+        "started_at",
+        "start_delay_seconds",
+        "duration_seconds",
+    }
+    assert payload["from"] == 0
+    assert payload["to"] == 50
+    # Serialisable — the attribute is JSON'd into the state machine.
+    assert isinstance(payload["started_at"], str)
+
+
+def test_estimated_positions_only_covers_entities_with_a_live_plan(monkeypatch):
+    svc = _svc(
+        calibration={"cover.a": _ASYMMETRIC, "cover.b": _ASYMMETRIC},
+        caps=_POSITION_CAPS,
+    )
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+    svc._prepare_service_call("cover.a", 100)
+
+    now = svc.state("cover.a").travel_plan.started_at + dt.timedelta(seconds=22)
+    assert svc.estimated_positions(now) == {"cover.a": 50}
+    assert svc.estimated_position("cover.b", now) is None
+
+
+def test_has_travel_plans_drives_the_proxy_tick(monkeypatch):
+    """The 1 s proxy timer starts and stops on this predicate — it must be exact."""
+    svc = _svc(calibration={"cover.a": _ASYMMETRIC}, caps=_POSITION_CAPS)
+    monkeypatch.setattr(svc, "_read_position_with_capabilities", lambda *a, **k: 0)
+    assert svc.has_travel_plans() is False
+
+    svc._prepare_service_call("cover.a", 50)
+    assert svc.has_travel_plans() is True
+
+    svc._clear_waiting(svc.state("cover.a"))
+    assert svc.has_travel_plans() is False
+
+
+# ------------------------------------------------------------------ #
+# Malformed stored rows
+#
+# This table is persisted user-editable config. An older build, a hand-edited
+# .storage file or a half-written row can all put nonsense here, and every
+# consumer is on the command-dispatch path — so a bad row must cost the ramp,
+# never the command.
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        pytest.param({}, id="no-full-travel-key"),
+        pytest.param({"full_travel_seconds": "abc"}, id="non-numeric"),
+        pytest.param({"full_travel_seconds": None}, id="null"),
+        pytest.param({"full_travel_seconds": 0}, id="zero"),
+        pytest.param({"full_travel_seconds": -5}, id="negative"),
+    ],
+)
+def test_an_unusable_row_yields_no_plan_rather_than_raising(row):
+    assert (
+        build_travel_plan(
+            row, from_position=0, to_position=50, started_at=_T0, span=100
+        )
+        is None
+    )
+
+
+def test_a_corrupt_leg_falls_back_to_the_headline_figure():
+    row = {"full_travel_seconds": 30.0, "open_seconds": "nope", "close_seconds": 0}
+    rising = build_travel_plan(
+        row, from_position=0, to_position=100, started_at=_T0, span=100
+    )
+    falling = build_travel_plan(
+        row, from_position=100, to_position=0, started_at=_T0, span=100
+    )
+    assert rising.duration_seconds == pytest.approx(30.0)
+    assert falling.duration_seconds == pytest.approx(30.0)
+
+
+def test_a_corrupt_start_delay_is_treated_as_none():
+    row = {"full_travel_seconds": 30.0, "start_delay_seconds": "soon"}
+    plan = build_travel_plan(
+        row, from_position=0, to_position=100, started_at=_T0, span=100
+    )
+    assert plan.start_delay_seconds == 0.0
+
+
+def test_a_zero_duration_ramp_reports_the_target_immediately():
+    """Degenerate but reachable — a stored row rounded down to nothing."""
+    plan = TravelPlan(
+        from_position=0,
+        to_position=100,
+        started_at=_T0,
+        start_delay_seconds=0.0,
+        duration_seconds=0.0,
+    )
+    assert plan.position_at(_T0 + dt.timedelta(seconds=1)) == 100

--- a/tests/test_unique_id_snapshot.py
+++ b/tests/test_unique_id_snapshot.py
@@ -92,6 +92,7 @@ EXPECTED_UNIQUE_ID_SUFFIXES = sorted(
         "manual_override_end_time",
         "position_verification",
         "motion_status",
+        "travel_calibration",
         "climate_status",
         "position_forecast",
         # --- switch platform (uses display switch_name, not translation key) ---


### PR DESCRIPTION
## Summary

Adds a travel-time calibration pass and uses the result to report where a cover **is** while it is moving, so dashboards can animate instead of jumping to the end.

A run sweeps each cover to both mechanical stops and times the traverse in each direction, splitting actuator dead time out of the travel figure and keeping the two legs separate — gravity-assisted covers routinely close faster than they open. Results land in a new additive `travel_time_calibration` option.

Covers whose state HA can only *assume* report arrival the instant they are commanded, so there is nothing to time. Those are excluded rather than credited with an instantaneous traverse, and get a manual-entry field — they are also the covers with most to gain, since their live reading is absent entirely.

Day/night Model C rails share one track and cannot sweep past each other, so a new `travel_calibration_clearance` policy hook names where the partner must be parked first, and the go-home pass offers each cover to the policy's own `await_dispatch_clearance` rather than computing an order.

Each dispatch now carries a `TravelPlan` — origin, target, dead time, duration — recorded at the existing command chokepoint and cleared with `waiting`, exactly like the synthetic transit direction beside it. A card interpolates it locally, so a move costs two state writes rather than a ticking loop. The opt-in proxy cover republishes the modelled position while a plan is live, which is what makes ordinary HA cover cards animate.

Reachable only from the options flow, under a new **Calibration** menu that also absorbs the existing position-interpolation page: that page was already called "Position Calibration", so the parent owns the word and the children say which is which. Deliberately not a button — a multi-minute full sweep of every cover does not belong on a dashboard where it can be misclicked.

While a run holds the covers it blocks every command, safety included, because one landing on a coupled rail mid-sweep drives a rail into a rail. That is only acceptable because the run says so throughout: the control status reads `calibrating`, the options flow shows the state and offers Cancel, and a run budget ends it regardless.

## Testing

- ✅ 12,499 tests passing (4 skipped, 17 xfailed)
- Six audit rounds; every fix mutation-checked, i.e. verified to fail when the fix it covers is reverted
- `state_store.py` 100% coverage, `travel_calibration.py` 98%
- Ruff + black clean, translation parity (en/de/fr) intact

## Notes

- Additive option key, no config-entry version change — rollback-safe.
- The wiki page is a stable-release obligation and is not in this PR.