### PR TITLE
feat: raise the slat depth and distance cap to 50 cm

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -436,8 +436,8 @@ OSCILLATING_ARC_SCAN_SAMPLES = 1801
 # =============================================================================
 # Slat dimensions used to compute tilt angle, plus min/max tilt clamps.
 
-CONF_TILT_DEPTH = "slat_depth"  # slat depth, cm (range 0.1-30.0)
-CONF_TILT_DISTANCE = "slat_distance"  # vertical slat spacing, cm (0.1-30.0)
+CONF_TILT_DEPTH = "slat_depth"  # slat depth, cm (range 0.1-50.0)
+CONF_TILT_DISTANCE = "slat_distance"  # vertical slat spacing, cm (0.1-50.0)
 CONF_TILT_MODE = "tilt_mode"  # tilt strategy identifier
 CONF_TILT_ANGLE_0 = "tilt_angle_0"  # raw slat angle at 0% tilt, degrees
 CONF_TILT_ANGLE_100 = "tilt_angle_100"  # raw slat angle at 100% tilt, degrees
@@ -2322,8 +2322,8 @@ _RANGE_MAX_SLAT_ANGLE = (0, 180)  # CONF_MAX_SLAT_ANGLE, degrees (0 = use tilt m
 MIN_USABLE_SLAT_ANGLE_DEG = 1
 
 # Geometry — tilt / venetian slats.
-_RANGE_TILT_DEPTH = (0.1, 30.0)  # CONF_TILT_DEPTH, cm (raised to 300 mm for #830)
-_RANGE_TILT_DISTANCE = (0.1, 30.0)  # CONF_TILT_DISTANCE, cm (raised to 300 mm, #830)
+_RANGE_TILT_DEPTH = (0.1, 50.0)  # CONF_TILT_DEPTH, cm (raised to 500 mm for #1184)
+_RANGE_TILT_DISTANCE = (0.1, 50.0)  # CONF_TILT_DISTANCE, cm (raised to 500 mm, #1184)
 _RANGE_MAX_TILT = (0, 100)  # CONF_MAX_TILT, percent
 _RANGE_MIN_TILT = (0, 100)  # CONF_MIN_TILT, percent
 _RANGE_TILT_SAFETY_MARGIN = (

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -29,6 +29,7 @@ from ..const import (
     DEFAULT_VENETIAN_TILT_TRANSFORM,
     MAX_TILT_SAFETY_MARGIN,
     MIN_TILT_SAFETY_MARGIN,
+    OPTION_RANGES,
     TILT_HORIZONTAL_DEG,
     VENETIAN_TILT_TRANSFORMS,
 )
@@ -105,15 +106,17 @@ def tilt_limits_schema() -> dict:
 
 def geometry_tilt_schema(hass: HomeAssistant | None = None) -> vol.Schema:
     """Tilt-only geometry schema. ``hass=None`` → metric labels."""
+    depth_lo, depth_hi = OPTION_RANGES[CONF_TILT_DEPTH]
+    distance_lo, distance_hi = OPTION_RANGES[CONF_TILT_DISTANCE]
     return vol.Schema(
         {
             vol.Required(
                 CONF_TILT_DEPTH, default=slat_default(_DEFAULT_TILT_DEPTH_CM, hass)
-            ): slat_selector(hass, min_cm=0.1, max_cm=30),
+            ): slat_selector(hass, min_cm=depth_lo, max_cm=depth_hi),
             vol.Required(
                 CONF_TILT_DISTANCE,
                 default=slat_default(_DEFAULT_TILT_DISTANCE_CM, hass),
-            ): slat_selector(hass, min_cm=0.1, max_cm=30),
+            ): slat_selector(hass, min_cm=distance_lo, max_cm=distance_hi),
             vol.Required(CONF_TILT_MODE, default="mode2"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=["mode1", "mode2", "specify_angles"],

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1265,21 +1265,21 @@ set_geometry:
           unit_of_measurement: "°"
     slat_depth:
       name: Slat depth
-      description: "Venetian slat depth in centimetres (0.1–15 cm, canonical metric regardless of HA locale). Tilt only."
+      description: "Venetian slat depth in centimetres (0.1–50 cm, canonical metric regardless of HA locale). Tilt only."
       selector:
         number:
           min: 0.1
-          max: 15
+          max: 50
           step: 0.1
           mode: slider
           unit_of_measurement: cm
     slat_distance:
       name: Slat distance
-      description: "Distance between venetian slats in centimetres (0.1–15 cm, canonical metric regardless of HA locale). Tilt only."
+      description: "Distance between venetian slats in centimetres (0.1–50 cm, canonical metric regardless of HA locale). Tilt only."
       selector:
         number:
           min: 0.1
-          max: 15
+          max: 50
           step: 0.1
           mode: slider
           unit_of_measurement: cm

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1696,11 +1696,11 @@
           "name": "Fensterbrett-Höhe"
         },
         "slat_depth": {
-          "description": "Lamellentiefe in Zentimetern (0,1–15 cm, kanonisch metrisch, unabhängig vom HA-Gebietsschema). Nur Neigung.",
+          "description": "Lamellentiefe in Zentimetern (0,1–50 cm, kanonisch metrisch, unabhängig vom HA-Gebietsschema). Nur Neigung.",
           "name": "Lamellen-Tiefe"
         },
         "slat_distance": {
-          "description": "Abstand zwischen Lamellen in Zentimetern (0,1–15 cm, kanonisch metrisch, unabhängig vom HA-Gebietsschema). Nur Neigung.",
+          "description": "Abstand zwischen Lamellen in Zentimetern (0,1–50 cm, kanonisch metrisch, unabhängig vom HA-Gebietsschema). Nur Neigung.",
           "name": "Lamellen-Abstand"
         },
         "tilt_mode": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -2046,11 +2046,11 @@
         },
         "slat_depth": {
           "name": "Slat depth",
-          "description": "Venetian slat depth in centimetres (0.1–15 cm, canonical metric regardless of HA locale). Tilt only."
+          "description": "Venetian slat depth in centimetres (0.1–50 cm, canonical metric regardless of HA locale). Tilt only."
         },
         "slat_distance": {
           "name": "Slat distance",
-          "description": "Distance between slats in centimetres (0.1–15 cm, canonical metric regardless of HA locale). Tilt only."
+          "description": "Distance between slats in centimetres (0.1–50 cm, canonical metric regardless of HA locale). Tilt only."
         },
         "tilt_mode": {
           "name": "Tilt mode",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1696,11 +1696,11 @@
           "name": "Hauteur de l'appui"
         },
         "slat_depth": {
-          "description": "Profondeur de lamelle de vénitienne en centimètres (0,1–15 cm, métrique canonique, indépendamment de la locale HA). Inclinaison uniquement.",
+          "description": "Profondeur de lamelle de vénitienne en centimètres (0,1–50 cm, métrique canonique, indépendamment de la locale HA). Inclinaison uniquement.",
           "name": "Profondeur de la lamelle"
         },
         "slat_distance": {
-          "description": "Distance entre les lamelles en centimètres (0,1–15 cm, métrique canonique, indépendamment de la locale HA). Inclinaison uniquement.",
+          "description": "Distance entre les lamelles en centimètres (0,1–50 cm, métrique canonique, indépendamment de la locale HA). Inclinaison uniquement.",
           "name": "Distance entre les lamelles"
         },
         "tilt_mode": {

--- a/tests/test_cover_types/test_louvered_roof.py
+++ b/tests/test_cover_types/test_louvered_roof.py
@@ -67,15 +67,39 @@ def _schema_value_validator(schema: vol.Schema, key: str):
 
 
 def test_tilt_schema_accepts_value_at_raised_slat_cap() -> None:
-    # The shared slat depth/spacing cap was raised to 30 cm globally, so the
-    # interior tilt/venetian schema must validate a value at the new cap too.
+    # The shared slat depth/spacing cap was raised to 50 cm globally (#1184),
+    # so the interior tilt/venetian schema must validate a value at the new
+    # cap too, for both slat depth and slat distance, and reject anything
+    # just above it.
     from custom_components.adaptive_cover_pro.cover_types.tilt import (
         geometry_tilt_schema,
     )
 
     schema = geometry_tilt_schema()
     depth_validator = _schema_value_validator(schema, CONF_TILT_DEPTH)
-    assert depth_validator(30.0) == 30.0
+    distance_validator = _schema_value_validator(schema, CONF_TILT_DISTANCE)
+    assert depth_validator(50.0) == 50.0
+    assert distance_validator(50.0) == 50.0
+    with pytest.raises(vol.MultipleInvalid):
+        schema({CONF_TILT_DEPTH: 50.1})
+    with pytest.raises(vol.MultipleInvalid):
+        schema({CONF_TILT_DISTANCE: 50.1})
+
+
+def test_geometry_tilt_schema_selector_max_matches_option_ranges() -> None:
+    # Regression guard for #1184: the selector bound in geometry_tilt_schema()
+    # must be sourced from OPTION_RANGES, not a hardcoded literal, so the
+    # selector and the options-service validator can never drift apart again.
+    from custom_components.adaptive_cover_pro.const import OPTION_RANGES
+    from custom_components.adaptive_cover_pro.cover_types.tilt import (
+        geometry_tilt_schema,
+    )
+
+    schema = geometry_tilt_schema()
+    depth_validator = _schema_value_validator(schema, CONF_TILT_DEPTH)
+    distance_validator = _schema_value_validator(schema, CONF_TILT_DISTANCE)
+    assert depth_validator.config["max"] == OPTION_RANGES[CONF_TILT_DEPTH][1]
+    assert distance_validator.config["max"] == OPTION_RANGES[CONF_TILT_DISTANCE][1]
 
 
 class TestLouveredRoofPolicy:


### PR DESCRIPTION
## Summary
Raises the tilt/venetian slat depth and slat distance range from 15 cm (30 cm on develop) to 50 cm, so bioclimatic pergola louvers fit. The reporter runs 21 cm blades on a 23 cm pitch; commercial pergola blades run 130-250 mm, so that is an ordinary size rather than an outlier.

The cap turned out to live in four places that had already drifted. #830 raised `const.OPTION_RANGES` to 30 cm and left `services.yaml` and the translated field descriptions on 15, so the options flow and the `set_geometry` service disagreed about what a legal slat was. All four now move together.

`cover_types/tilt.py` was why they could drift: it hardcoded `max_cm=30` as a literal instead of reading `OPTION_RANGES`, the documented single source of truth for numeric bounds. It now reads each key's own range, mirroring `louvered_roof.py`, and a new test pins the selector max to the constant so a fifth copy cannot appear.

DE/FR descriptions take the numeric swap only; the sentences are unchanged, so there was nothing to retranslate.

## Testing
- ✅ 11478 tests passing (4 skipped, 17 xfailed; +1 vs the 11477 baseline, matching the one new test)

## Related Issues
Refs #1184