### PR TITLE
feat: show custom slot names in the config summary rules (#1190)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1559,11 +1559,11 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "manual.transit_timeout": "transit timeout: {seconds}s",
     # --- Custom positions ---
     "rules.custom_tilt_only": (
-        "🎯 Custom #{slot}: if {trigger} is on → tilt only "
+        "🎯 {label}: if {trigger} is on → tilt only "
         "(slat fixed at {slat}%; position driven by sun tracking)"
     ),
     "rules.custom": (
-        "🎯 Custom #{slot}: if {trigger} is on → {target}{cp_min}{tilt_note}"
+        "🎯 {label}: if {trigger} is on → {target}{cp_min}{tilt_note}"
         " — bypasses delta gates and auto-control{safety}"
     ),
     "custom.tilt_note": ", tilt {tilt}%",
@@ -1574,16 +1574,20 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "custom.tilt_bound_max": ", tilt at most {max}%",
     "custom.tilt_bound_range": ", tilt {min}–{max}%",
     "custom.no_position_claim": "the calculated position",
+    # Fallback slot label when no custom_position_name_N is configured
+    # (issue #1190) — the exact "Custom #{slot}" fragment extracted verbatim
+    # from the five templates below, so the no-name path stays byte-identical.
+    "custom.slot_label_default": "Custom #{slot}",
     "warnings.custom_position_bound_conflict": (
-        "⚠️ Custom #{slot}: the maximum ({max}%) is below the minimum ({min}%) — "
+        "⚠️ {label}: the maximum ({max}%) is below the minimum ({min}%) — "
         "the minimum wins and the maximum is ignored."
     ),
     "warnings.custom_tilt_only_conflict": (
-        "⚠️ Custom #{slot}: tilt only is on — "
+        "⚠️ {label}: tilt only is on — "
         "Use as minimum / Use My position are ignored for this slot."
     ),
     "warnings.custom_and_no_sensors": (
-        "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are "
+        "⚠️ {label}: combine mode AND is set but no trigger sensors are "
         "configured — the template alone activates the slot."
     ),
     # NOTE: the safety-priority bypass warning moved to the shared triage engine
@@ -2429,6 +2433,14 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             _tilt_only,
             _has_trigger,
         ) in _custom_slots:
+            # Configured name replaces the generic "Custom #{slot}" label
+            # outright (issue #1190) — computed once per slot and reused by
+            # every .format() call site below, mirroring the precedent
+            # already shipped for the Decision Priority chain
+            # (priority_chain.py, issue #910).
+            _slot_label = _custom_slot_names.get(_slot) or L[
+                "custom.slot_label_default"
+            ].format(slot=_slot)
             tilt_note = (
                 L["custom.tilt_note"].format(tilt=_slot_tilt)
                 if _slot_tilt is not None
@@ -2448,7 +2460,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                     _pri,
                     _order,
                     L["rules.custom_tilt_only"].format(
-                        slot=_slot, trigger=_trigger, slat=slat
+                        label=_slot_label, trigger=_trigger, slat=slat
                     ),
                 )
             else:
@@ -2492,7 +2504,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                     _pri,
                     _order,
                     L["rules.custom"].format(
-                        slot=_slot,
+                        label=_slot_label,
                         trigger=_trigger,
                         target=target,
                         cp_min=cp_min,
@@ -2511,7 +2523,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 ):
                     _sub(
                         L["warnings.custom_position_bound_conflict"].format(
-                            slot=_slot, max=_pos_max, min=_pos
+                            label=_slot_label, max=_pos_max, min=_pos
                         )
                     )
             # Mutual-exclusion warning: tilt_only wins over min_mode / use_my
@@ -2520,7 +2532,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             if _tilt_only and (
                 config.get(f"custom_position_min_mode_{_slot}") or _use_my
             ):
-                _sub(L["warnings.custom_tilt_only_conflict"].format(slot=_slot))
+                _sub(L["warnings.custom_tilt_only_conflict"].format(label=_slot_label))
             # Footgun (issue #711): a safety-priority slot with a live trigger
             # bypasses the auto-control toggle, manual override, and the time
             # window — it can move the cover at any hour with automation off.
@@ -2541,7 +2553,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             # Footgun warning: AND combine mode with no sensors — the template
             # gates nothing and the slot degenerates to template-only OR.
             if _slot in _and_no_sensor_slots:
-                _sub(L["warnings.custom_and_no_sensors"].format(slot=_slot))
+                _sub(L["warnings.custom_and_no_sensors"].format(label=_slot_label))
 
     # Motion timeout (75)
     timeout_mode = config.get(CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE)

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -30,8 +30,8 @@
   "rules": {
     "weather": "🌧️ Wetterschutz: wenn {wx_condition} → Beschattungen fahren auf {weather_pos}%{weather_min}{delay}{bypass}",
     "manual": "✋ Manuelle Übersteuerung: pausiert automatische Steuerung, wenn du die Beschattung bewegst{detail}",
-    "custom_tilt_only": "🎯 Benutzerdefiniert #{slot}: wenn {trigger} aktiv ist → nur Neigung (Lamelle fest bei {slat}%; Position gesteuert durch Sonnenverfolgung)",
-    "custom": "🎯 Benutzerdefiniert #{slot}: wenn {trigger} aktiv ist → {target}{cp_min}{tilt_note} — umgeht Delta-Gatter und automatische Steuerung{safety}",
+    "custom_tilt_only": "🎯 {label}: wenn {trigger} aktiv ist → nur Neigung (Lamelle fest bei {slat}%; Position gesteuert durch Sonnenverfolgung)",
+    "custom": "🎯 {label}: wenn {trigger} aktiv ist → {target}{cp_min}{tilt_note} — umgeht Delta-Gatter und automatische Steuerung{safety}",
     "motion": "🚶 Belegung: Falls keine Belegung für {motion_timeout}s ({sources}) → {action}",
     "cloud": "☁️ Wolkenunterdrückung: überspringt Sonnenverfolgung{cloud} → {fallback}",
     "climate": "🌡️ Klimamodus: passt Strategie für Heizung/Kühlung an{detail}",
@@ -75,18 +75,19 @@
     "tilt_bound_min": ", Neigung mindestens {min}%",
     "tilt_bound_max": ", Neigung höchstens {max}%",
     "tilt_bound_range": ", Neigung {min}–{max}%",
-    "no_position_claim": "die berechnete Position"
+    "no_position_claim": "die berechnete Position",
+    "slot_label_default": "Benutzerdefiniert #{slot}"
   },
   "warnings": {
-    "custom_position_bound_conflict": "⚠️ Benutzerdefiniert #{slot}: Das Maximum ({max}%) liegt unter dem Minimum ({min}%) — das Minimum gewinnt und das Maximum wird ignoriert.",
-    "custom_tilt_only_conflict": "⚠️ Benutzerdefiniert #{slot}: Nur Neigung ist aktiviert — Als Minimum verwenden / Meine Position verwenden werden für diesen Slot ignoriert.",
+    "custom_position_bound_conflict": "⚠️ {label}: Das Maximum ({max}%) liegt unter dem Minimum ({min}%) — das Minimum gewinnt und das Maximum wird ignoriert.",
+    "custom_tilt_only_conflict": "⚠️ {label}: Nur Neigung ist aktiviert — Als Minimum verwenden / Meine Position verwenden werden für diesen Slot ignoriert.",
     "motion_hold_no_sensors": "⚠️ Der Modus Position halten ist eingestellt, aber es sind keine Belegungsquellen konfiguriert – die Einstellung hat keine Auswirkungen, bis eine Belegungsquelle hinzugefügt wird",
     "cloudy_pos_ignored": "⚠️ Bewölkte Position ({pos}%) konfiguriert, aber Wolkenunterdrückung ist deaktiviert — Wert wird ignoriert.",
     "sun_track_min_below_floor": "⚠️ Sonnenverfolgung Min {sun_min}% < Min Position {min_pos}% — Immer-aktiver Boden dominiert; Sonnenverfolgungsboden wird auf {min_pos}% erhöht.",
     "mode2_min_position": "⚠️ Neigung MODE2 + Min Position {min_pos}% — im MODE2 ist der offene (horizontale) Lamellenwinkel 50%, also jede Min Position ≥ 50 kollabiert jede Klimamodus/Blendungszone-Entscheidung zum Boden und die Beschattung stoppt, Wärme zu blockieren.",
     "somfy_my_unset": "⚠️ Somfy My-Preset ist für ein oder mehrere Ziele aktiviert, aber My Preset Value ist nicht gesetzt — fällt auf konfiguriertes % zurück.",
     "proxy_no_min": "⚠️ Proxy-Beschattung ist aktiviert, aber kein benutzerdefinierter Positionsslot hat Als Minimum verwenden aktiviert — die verwaltete Beschattung wird nicht begrenzt.",
-    "custom_and_no_sensors": "⚠️ Benutzerdefiniert #{slot}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
+    "custom_and_no_sensors": "⚠️ {label}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
     "group_empty": "⚠️ Diese Gruppe hat keine Mitglieder – sie wird nichts steuern.",
     "forecast_source_no_weather_entity": "⚠️ Außentemperaturquelle basiert auf Vorhersage, aber es ist keine Wetter-Entität konfiguriert — die Vorhersage wird stillschweigend auf den Live-Messwert zurückfallen. Konfigurieren Sie eine Wetter-Entität unter Wetter, Licht & Wolken.",
     "travel_time_unmeasurable": "⚠️ {entities} melden einen angenommenen Zustand, daher kann ihre Laufzeit nicht gemessen werden und keine wurde eingegeben — Dashboards zeigen keine Bewegung. Geben Sie eine Zeit unter Kalibrierung → Laufzeit ein."

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -30,8 +30,8 @@
   "rules": {
     "weather": "🌧️ Weather safety: if {wx_condition} → covers retract to {weather_pos}%{weather_min}{delay}{bypass}",
     "manual": "✋ Manual override: pauses automatic control when you move the cover{detail}",
-    "custom_tilt_only": "🎯 Custom #{slot}: if {trigger} is on → tilt only (slat fixed at {slat}%; position driven by sun tracking)",
-    "custom": "🎯 Custom #{slot}: if {trigger} is on → {target}{cp_min}{tilt_note} — bypasses delta gates and auto-control{safety}",
+    "custom_tilt_only": "🎯 {label}: if {trigger} is on → tilt only (slat fixed at {slat}%; position driven by sun tracking)",
+    "custom": "🎯 {label}: if {trigger} is on → {target}{cp_min}{tilt_note} — bypasses delta gates and auto-control{safety}",
     "motion": "🚶 Occupancy: if no occupancy for {motion_timeout}s ({sources}) → {action}",
     "cloud": "☁️ Cloud suppression: skips sun tracking{cloud} → {fallback}",
     "climate": "🌡️ Climate mode: adjusts strategy for heating/cooling{detail}",
@@ -75,18 +75,19 @@
     "tilt_bound_min": ", tilt at least {min}%",
     "tilt_bound_max": ", tilt at most {max}%",
     "tilt_bound_range": ", tilt {min}–{max}%",
-    "no_position_claim": "the calculated position"
+    "no_position_claim": "the calculated position",
+    "slot_label_default": "Custom #{slot}"
   },
   "warnings": {
-    "custom_position_bound_conflict": "⚠️ Custom #{slot}: the maximum ({max}%) is below the minimum ({min}%) — the minimum wins and the maximum is ignored.",
-    "custom_tilt_only_conflict": "⚠️ Custom #{slot}: tilt only is on — Use as minimum / Use My position are ignored for this slot.",
+    "custom_position_bound_conflict": "⚠️ {label}: the maximum ({max}%) is below the minimum ({min}%) — the minimum wins and the maximum is ignored.",
+    "custom_tilt_only_conflict": "⚠️ {label}: tilt only is on — Use as minimum / Use My position are ignored for this slot.",
     "motion_hold_no_sensors": "⚠️ hold_position mode is set but no occupancy sources are configured — the setting has no effect until an occupancy source is added",
     "cloudy_pos_ignored": "⚠️ Cloudy position ({pos}%) configured but cloud suppression is disabled — value will be ignored.",
     "sun_track_min_below_floor": "⚠️ Sun-tracking min {sun_min}% < min position {min_pos}% — always-on floor dominates; sun-tracking floor will be raised to {min_pos}%.",
     "mode2_min_position": "⚠️ Tilt MODE2 + min position {min_pos}% — in MODE2 the open (horizontal) slat angle IS 50%, so any min position ≥ 50 collapses every climate/glare-control decision to the floor and the cover stops blocking heat.",
     "somfy_my_unset": "⚠️ Somfy My preset is enabled for one or more targets but My Preset Value is not set — falls back to configured %.",
     "proxy_no_min": "⚠️ Proxy cover is enabled but no custom-position slot has Use as minimum on — the managed cover will not clamp.",
-    "custom_and_no_sensors": "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are configured — the template alone activates the slot.",
+    "custom_and_no_sensors": "⚠️ {label}: combine mode AND is set but no trigger sensors are configured — the template alone activates the slot.",
     "group_empty": "⚠️ This group has no members — it will not command anything.",
     "forecast_source_no_weather_entity": "⚠️ Outdoor-temperature source is forecast-based but no weather entity is configured — the forecast will silently fall back to the live reading. Configure a weather entity in Weather, Light & Cloud.",
     "travel_time_unmeasurable": "⚠️ {entities} report an assumed state, so their travel time cannot be measured and none has been entered — dashboards will not show them moving. Enter a time under Calibration → Travel Time."

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -30,8 +30,8 @@
   "rules": {
     "weather": "🌧️ Sécurité météo : si {wx_condition} → stores se rétractent à {weather_pos}%{weather_min}{delay}{bypass}",
     "manual": "✋ Dérogation manuelle : pause le contrôle automatique quand vous bougez le store{detail}",
-    "custom_tilt_only": "🎯 Personnalisé #{slot} : si {trigger} est activé → inclinaison seulement (lamelle fixée à {slat}% ; position pilotée par le suivi solaire)",
-    "custom": "🎯 Personnalisé #{slot} : si {trigger} est activé → {target}{cp_min}{tilt_note} — contourne les portes delta et le contrôle automatique{safety}",
+    "custom_tilt_only": "🎯 {label} : si {trigger} est activé → inclinaison seulement (lamelle fixée à {slat}% ; position pilotée par le suivi solaire)",
+    "custom": "🎯 {label} : si {trigger} est activé → {target}{cp_min}{tilt_note} — contourne les portes delta et le contrôle automatique{safety}",
     "motion": "**Occupation** (🚶 {motion_timeout}s)\n\nLorsque l'occupation est détectée dans les capteurs sélectionnés:\n- {sources} (alimentation détectée)\n- {action}",
     "cloud": "☁️ Suppression de nuages : ignore le suivi solaire{cloud} → {fallback}",
     "climate": "🌡️ Mode climatique : ajuste la stratégie pour le chauffage/refroidissement{detail}",
@@ -75,18 +75,19 @@
     "tilt_bound_min": ", inclinaison d'au moins {min}%",
     "tilt_bound_max": ", inclinaison d'au plus {max}%",
     "tilt_bound_range": ", inclinaison {min}–{max}%",
-    "no_position_claim": "la position calculée"
+    "no_position_claim": "la position calculée",
+    "slot_label_default": "Personnalisé #{slot}"
   },
   "warnings": {
-    "custom_position_bound_conflict": "⚠️ Personnalisé #{slot} : le maximum ({max}%) est inférieur au minimum ({min}%) — le minimum l'emporte et le maximum est ignoré.",
-    "custom_tilt_only_conflict": "⚠️ Personnalisé #{slot} : inclinaison seulement est activé — Utiliser comme minimum / Utiliser ma position sont ignorés pour cet emplacement.",
+    "custom_position_bound_conflict": "⚠️ {label} : le maximum ({max}%) est inférieur au minimum ({min}%) — le minimum l'emporte et le maximum est ignoré.",
+    "custom_tilt_only_conflict": "⚠️ {label} : inclinaison seulement est activé — Utiliser comme minimum / Utiliser ma position sont ignorés pour cet emplacement.",
     "motion_hold_no_sensors": "Aucun capteur d'occupation configuré. La détection d'occupation est désactivée.",
     "cloudy_pos_ignored": "⚠️ Position nuageux ({pos}%) configurée mais suppression de nuages est désactivée — la valeur sera ignorée.",
     "sun_track_min_below_floor": "⚠️ Min suivi solaire {sun_min}% < position min {min_pos}% — le plancher toujours actif domine ; le plancher suivi solaire sera relevé à {min_pos}%.",
     "mode2_min_position": "⚠️ Inclinaison MODE2 + position min {min_pos}% — en MODE2 l'angle de lamelle ouvert (horizontal) EST 50%, donc toute position min ≥ 50 réduit à néant chaque décision de contrôle climatique/éblouissement au plancher et le store cesse de bloquer la chaleur.",
     "somfy_my_unset": "⚠️ Préréglage Somfy My est activé pour une ou plusieurs cibles mais Valeur du préréglage My n'est pas définie — revient au % configuré.",
     "proxy_no_min": "⚠️ Store mandataire est activé mais aucun emplacement de position personnalisée n'a Utiliser comme minimum activé — le store géré ne limitera pas.",
-    "custom_and_no_sensors": "⚠️ Personnalisé #{slot} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
+    "custom_and_no_sensors": "⚠️ {label} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
     "group_empty": "⚠️ Ce groupe n'a pas de membres — il ne commandera rien.",
     "forecast_source_no_weather_entity": "⚠️ La source de température extérieure est basée sur les prévisions mais aucune entité météo n'est configurée — les prévisions vont silencieusement revenir au relevé en direct. Configurez une entité météo dans Météo, lumière & nuages.",
     "travel_time_unmeasurable": "⚠️ {entities} signalent un état supposé, donc leur temps de course ne peut pas être mesuré et aucun n'a été entré — les tableaux de bord ne les montreront pas en mouvement. Entrez une durée sous Étalonnage → Temps de course."

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -4213,3 +4213,114 @@ def test_both_gates_render_through_the_one_shared_helper():
 
     src = inspect.getsource(cf._build_config_summary)
     assert src.count("_render_condition_gate_summary(") == 2
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Custom slot names in the How It Decides rule line (issue #1190)
+#
+# #910 (PR #915) already made the Decision Priority chain and the priority
+# ladder preview name-aware. This is the separate "How It Decides" narrative
+# rule line (`rules.custom` / `rules.custom_tilt_only`) and its three inline
+# footgun warnings, which #910 never touched — the exact surface the
+# reporter's screenshot shows.
+# ---------------------------------------------------------------------------
+
+
+def test_custom_rule_line_uses_configured_name_instead_of_slot_number():
+    """A configured custom_position_name_N replaces the generic '#N' label in
+    the primary rule line — the name REPLACES the slot number outright,
+    matching the priority_chain.py precedent from #910.
+    """
+    cfg = {
+        "custom_position_sensors_4": ["binary_sensor.terrace"],
+        "custom_position_4": 82,
+        "custom_position_priority_4": 82,
+        "custom_position_name_4": "Terrace access",
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "Terrace access" in summary
+    assert "Custom #4" not in summary
+
+
+def test_custom_tilt_only_rule_line_uses_configured_name():
+    """The tilt-only variant of the rule line also substitutes the name."""
+    cfg = {
+        "custom_position_sensors_4": ["binary_sensor.terrace"],
+        "custom_position_4": 82,
+        "custom_position_priority_4": 82,
+        "custom_position_tilt_4": 30,
+        "custom_position_tilt_only_4": True,
+        "custom_position_name_4": "Terrace access",
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    assert "Terrace access" in summary
+    assert "Custom #4" not in summary
+
+
+def test_custom_rule_line_falls_back_to_slot_number_when_no_name():
+    """No configured name -> the generic '#N' label, byte-identical to today.
+
+    Regression lock for the "unnamed" path — mirrors the existing no-name
+    fixtures (e.g. test_safety_priority_slot_shown_with_position).
+    """
+    cfg = {
+        "custom_position_sensors_4": ["binary_sensor.terrace"],
+        "custom_position_4": 82,
+        "custom_position_priority_4": 82,
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "Custom #4" in summary
+
+
+def test_custom_warning_bound_conflict_uses_configured_name():
+    """The min>max footgun warning substitutes the configured name too."""
+    cfg = {
+        "custom_position_sensors_4": ["binary_sensor.terrace"],
+        "custom_position_4": 70,
+        "custom_position_min_mode_4": True,
+        "custom_position_position_max_4": 40,
+        "custom_position_priority_4": 82,
+        "custom_position_name_4": "Terrace access",
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    warn_line = next(
+        ln for ln in summary.splitlines() if "⚠️" in ln and "maximum" in ln
+    )
+    assert "Terrace access" in warn_line
+    assert "Custom #4" not in warn_line
+
+
+def test_custom_warning_tilt_only_conflict_uses_configured_name():
+    """The tilt_only mutual-exclusion warning substitutes the configured name."""
+    cfg = {
+        "custom_position_sensors_4": ["binary_sensor.terrace"],
+        "custom_position_4": 80,
+        "custom_position_priority_4": 82,
+        "custom_position_tilt_4": 30,
+        "custom_position_tilt_only_4": True,
+        "custom_position_min_mode_4": True,
+        "custom_position_name_4": "Terrace access",
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    warn_line = next(
+        ln for ln in summary.splitlines() if "⚠️" in ln and "tilt only" in ln.lower()
+    )
+    assert "Terrace access" in warn_line
+    assert "Custom #4" not in warn_line
+
+
+def test_custom_warning_and_no_sensors_uses_configured_name():
+    """The AND-combine-mode-with-no-sensors warning substitutes the name."""
+    cfg = {
+        "custom_position_template_4": "{{ true }}",
+        "custom_position_template_mode_4": "and",
+        "custom_position_4": 80,
+        "custom_position_priority_4": 82,
+        "custom_position_name_4": "Terrace access",
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    warn_line = next(
+        ln for ln in summary.splitlines() if "⚠️" in ln and "combine mode" in ln.lower()
+    )
+    assert "Terrace access" in warn_line
+    assert "Custom #4" not in warn_line

--- a/tests/test_config_flow_summary_i18n.py
+++ b/tests/test_config_flow_summary_i18n.py
@@ -54,11 +54,17 @@ SUMMARY_I18N_DIR = (
 def test_labels_override_text_appears_and_template_fills() -> None:
     """A non-default labels dict overrides text AND a templated line still
     fills its format fields.
+
+    The ``rules.custom`` template's slot identifier is filled via a
+    ``{label}`` field (issue #1190) rather than a bare ``{slot}`` — the
+    resolved label REPLACES the slot number outright, and with no
+    ``custom_position_name_5`` configured it resolves to the default
+    ``custom.slot_label_default`` fragment ("Custom #5").
     """
     overrides = {
         "headers.your_cover": "MEINE BESCHATTUNG",
         "rules.custom": (
-            "CUSTOM #{slot} if {trigger} on -> {target}{cp_min}{tilt_note}{safety}"
+            "CUSTOM {label} if {trigger} on -> {target}{cp_min}{tilt_note}{safety}"
         ),
         "custom.trigger_sensors": "any of {n} sensors",
     }
@@ -73,7 +79,7 @@ def test_labels_override_text_appears_and_template_fills() -> None:
     # Overridden header text appears.
     assert "MEINE BESCHATTUNG" in summary
     # Templated custom-position line filled its fields from config.
-    assert "CUSTOM #5 if any of 2 sensors on -> 80%" in summary
+    assert "CUSTOM Custom #5 if any of 2 sensors on -> 80%" in summary
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The "How It Decides" section of the configuration summary labelled every custom-position rule as `Custom #N`, even when the slot had a user-configured name. The name was already collected into `_custom_slot_names` but only reached the compact Decision-Priority chain (issue #910's fix), never the verbose rule line or its three footgun warnings.

`_build_config_summary()` now computes a single `_slot_label` per slot: the configured name when there is one, otherwise the new translated `custom.slot_label_default` fallback. That label is passed to all five templates (`rules.custom`, `rules.custom_tilt_only`, and the three `warnings.custom_*`) in place of the raw slot number.

The fallback string was lifted verbatim from the existing templates, so the no-name path renders byte-identically in English, German, and French.

## Testing
- ✅ 11484 tests passing

## Related Issues
Refs #1190