### PR TITLE
feat: serialize commands across covers via a named queue

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_AWNING_SHADE_MODE,
     CONF_BUILDING_PROFILE_ID,
     CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_COMMAND_QUEUE_GAP,
     CONF_DAYTIME_GATE_SENSORS,
     CONF_DAYTIME_GATE_TEMPLATE,
     CONF_SUN_TRACKING_GATE_SENSORS,
@@ -68,6 +69,7 @@ from .const import (
     CONF_WINDOW_WIDTH,
     CUSTOM_POSITION_SAFETY_PRIORITY,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_COMMAND_QUEUE_GAP,
     DIAG_CACHE_KEY,
     DOMAIN,
     POSITION_CLOSED,
@@ -80,6 +82,7 @@ from .const import (
 )
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
+from .managers.cover_command.queue import get_command_queue, normalize_queue_name
 from .group_coordinator import GroupCoordinator
 from .helpers import (
     copy_legacy_slot_sensors_to_list,
@@ -343,6 +346,66 @@ def _register_option_template_trackers(
     )
 
 
+def _command_queue_for_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Return the shared queue a Command Queue entry owns, or ``None``.
+
+    Identity is the entry's CREATION-TIME name (``entry.data["name"]``),
+    normalized — never its ``entry_id``. That is what makes a name usable
+    before, and after, any entry exists to own it: a cover naming a queue
+    nobody created still serializes at the default gap, and deleting the entry
+    reverts its members to that default rather than breaking them.
+    """
+    name = normalize_queue_name(entry.data.get("name"))
+    if not name:
+        return None
+    return get_command_queue(hass, name)
+
+
+def _command_queue_gap(entry: ConfigEntry) -> float:
+    """Return the gap this queue entry configures, defaulted from one constant."""
+    return entry.options.get(CONF_COMMAND_QUEUE_GAP, DEFAULT_COMMAND_QUEUE_GAP)
+
+
+def _setup_command_queue_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Bind a Command Queue entry's gap onto the shared queue (issue #1189).
+
+    No platforms, no coordinator: the entry exists only to own a gap and give
+    the queue a place in the UI. It attaches to the queue like any member, so a
+    queue whose covers are all unloaded still survives while its own entry is
+    loaded — and disappears when nothing references it at all.
+    """
+    queue = _command_queue_for_entry(hass, entry)
+    if queue is None:
+        return
+    queue.attach()
+    queue.set_gap(_command_queue_gap(entry))
+    entry.async_on_unload(entry.add_update_listener(_async_command_queue_update))
+
+    def _release() -> None:
+        # Reverting the gap before detaching matters: members may still hold
+        # references, and they must fall back to the default rather than keep
+        # the gap of an entry that is gone.
+        queue.set_gap(None)
+        queue.detach()
+
+    entry.async_on_unload(_release)
+
+
+async def _async_command_queue_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Re-apply a Command Queue entry's gap in place — members are NOT reloaded.
+
+    Members read ``queue.gap_seconds`` live at release time rather than copying
+    it at setup, so editing the gap takes effect on the very next transmission
+    without tearing down every cover on the queue. Reloading them would be the
+    obvious implementation and the wrong one: on the 16-instance install this
+    feature was built for it would restart sixteen coordinators to change one
+    number.
+    """
+    queue = _command_queue_for_entry(hass, entry)
+    if queue is not None:
+        queue.set_gap(_command_queue_gap(entry))
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> bool:
     """Set up Adaptive Cover Pro from a config entry."""
 
@@ -356,6 +419,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     # platforms.
     policy = get_policy(entry.data[CONF_SENSOR_TYPE])
     if not policy.controls_cover:
+        # Two virtual entry types share ``controls_cover == False``, and they
+        # want opposite things from setup, so the second capability flag splits
+        # them (never the cover-type string).
+        if policy.is_command_queue:
+            _setup_command_queue_entry(hass, entry)
+            return True
         entry.async_on_unload(entry.add_update_listener(_async_profile_propagate))
         return True
 
@@ -616,9 +685,16 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
     Also drops the entry's last-good diagnostics snapshot from the hass.data cache
     (written each update cycle, kept across reloads) so it does not leak.
+
+    A deleted Command Queue entry gets NO sweep at all (issue #1189): its
+    members reference it by name, not by ``entry_id``, and a dangling name is a
+    working configuration — the covers keep serializing against each other at
+    the default gap. Stripping the assignment would silently un-serialize a
+    radio the user is still sharing, which is the original bug.
     """
     hass.data.get(DIAG_CACHE_KEY, {}).pop(entry.entry_id, None)
-    if get_policy(entry.data.get(CONF_SENSOR_TYPE)).controls_cover:
+    policy = get_policy(entry.data.get(CONF_SENSOR_TYPE))
+    if policy.controls_cover or policy.is_command_queue:
         return
     for cover in _covers_linked_to(hass, entry):
         hass.config_entries.async_update_entry(
@@ -1034,6 +1110,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # ignores the three it does not know, reverting to the plain bool toggle.
     new_minor = _advance_noop_minor(new_version, new_minor, 16)
 
+    # v3.16 → v3.17: added the additive named command-queue options —
+    # command_queue on covers, command_queue_gap on the new Command Queue entry
+    # type (issue #1189). An absent key already reads as "no queue", which is
+    # exactly the dispatch behaviour every existing install has today, so
+    # nothing needs seeding; this is a no-op minor bump kept only to advance
+    # entries sitting at minor 16 to 17 so they stop re-triggering migration
+    # every restart (the v3.15 → v3.16 precedent). Rollback-safe: an older build
+    # finds every key exactly as it left it and ignores the one it does not
+    # know, reverting to unserialized dispatch.
+    new_minor = _advance_noop_minor(new_version, new_minor, 17)
+
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor
     )
@@ -1104,9 +1191,12 @@ async def _async_profile_propagate(hass: HomeAssistant, entry: ConfigEntry) -> N
     cleared key from the linked covers happens at save time instead, where the
     transition is still visible — ``propagate_profile_clears`` (issue #1085).
     """
-    # Guard: only profiles (virtual, controls_cover == False) propagate. A real
-    # cover reaching here would be a wiring bug — its own listener handles reloads.
-    if get_policy(entry.data.get(CONF_SENSOR_TYPE)).controls_cover:
+    # Guard: only profiles propagate. A real cover reaching here would be a
+    # wiring bug — its own listener handles reloads — and so would a Command
+    # Queue, which shares ``controls_cover == False`` but owns a gap, not a set
+    # of shared sensors, and has its own listener (issue #1189).
+    policy = get_policy(entry.data.get(CONF_SENSOR_TYPE))
+    if policy.controls_cover or policy.is_command_queue:
         return
     for cover in _covers_linked_to(hass, entry):
         _copy_profile_to_cover(hass, entry, cover)

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -262,6 +262,9 @@ SECTION_DEBUG = "debug"
 # section never renders in a cover's options flow — it exists so group
 # numeric fields feed OPTION_RANGES / FIELD_VALIDATORS like every other one.
 SECTION_GROUP = "group"
+# Command-queue-only fields (issue #1189). Same arrangement as SECTION_GROUP:
+# out of COMMON_SECTION_ORDER, present so the gap gets its bounds row.
+SECTION_COMMAND_QUEUE = "command_queue"
 
 
 # =============================================================================
@@ -855,6 +858,40 @@ _AUTOMATION_SPECS = _spec(
         SECTION_AUTOMATION,
         ValidatorKind.TIME,
         make_selector=_time(),
+    ),
+    # Named dispatch queue (issue #1189). Lives on Movement & Schedule with the
+    # two sibling rate limiters above: like them it gates an ALREADY-DECIDED
+    # command rather than influencing which position is picked, which is exactly
+    # what that page's own description scopes it to. The selector is built
+    # dynamically in ``async_step_automation`` — its option list is drawn from
+    # the other loaded entries, which a static schema cannot see — so no
+    # ``make_selector`` here; this spec exists to register the key.
+    FieldSpec(
+        const.CONF_COMMAND_QUEUE,
+        SECTION_AUTOMATION,
+        ValidatorKind.NONE,
+        clearable=True,
+    ),
+)
+
+
+# Command-queue entry fields (issue #1189). Not in COMMON_SECTION_ORDER — the
+# section never renders on a cover's options flow — so this mirrors
+# ``_GROUP_SPECS``: it exists so the queue's numeric field feeds OPTION_RANGES
+# and FIELD_VALIDATORS like every other one.
+_COMMAND_QUEUE_SPECS = _spec(
+    FieldSpec(
+        const.CONF_COMMAND_QUEUE_GAP,
+        SECTION_COMMAND_QUEUE,
+        ValidatorKind.RANGE,
+        rng=const._RANGE_COMMAND_QUEUE_GAP,
+        default=const.DEFAULT_COMMAND_QUEUE_GAP,
+        make_selector=_number(
+            minimum=const._RANGE_COMMAND_QUEUE_GAP[0],
+            maximum=const._RANGE_COMMAND_QUEUE_GAP[1],
+            step=0.5,
+            unit="seconds",
+        ),
     ),
 )
 
@@ -2102,6 +2139,7 @@ _ALL_SPEC_GROUPS: tuple[list[FieldSpec], ...] = (
     _PIPELINE_PRIORITY_SPECS,
     _DEBUG_SPECS,
     _GROUP_SPECS,
+    _COMMAND_QUEUE_SPECS,
 )
 
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -48,6 +48,8 @@ from .const import (
     CONF_CLOUD_SUPPRESSION,
     CONF_CLOUD_SUPPRESSION_HOLD_TIME,
     CONF_CLOUDY_POSITION,
+    CONF_COMMAND_QUEUE,
+    CONF_COMMAND_QUEUE_GAP,
     CONF_DAYTIME_GATE_SENSORS,
     CONF_DAYTIME_GATE_TEMPLATE,
     CONF_DAYTIME_GATE_TEMPLATE_MODE,
@@ -225,6 +227,7 @@ from .const import (
     DEFAULT_DELTA_TIME,
     DEFAULT_GROUP_ENABLE_COVER_ENTITY,
     DEFAULT_GROUP_ENABLE_SENSOR,
+    DEFAULT_COMMAND_QUEUE_GAP,
     DEFAULT_GROUP_STAGGER_DELAY,
     DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MANUAL_OVERRIDE_DURATION_MODE,
@@ -375,8 +378,10 @@ from .pipeline.handlers import (  # noqa: E402
     resolve_handler_priority,
 )
 from .priority_chain import build_priority_chain  # noqa: E402
+from .managers.cover_command.queue import normalize_queue_name  # noqa: E402
 from .profile_link import (  # noqa: E402
     _building_profile_entries,
+    _command_queue_entries,
     _copy_profile_to_cover,
     _cover_entries,
     _covers_linked_to,
@@ -538,6 +543,107 @@ BUILDING_PROFILE_CREATE_SCHEMA = vol.Schema(
     {
         vol.Required("name"): selector.TextSelector(),
         **building_profile_sensors_schema().schema,
+    }
+)
+
+
+def known_command_queue_names(hass) -> list[str]:
+    """Every queue name in use, deduped by normalization, in first-seen casing.
+
+    The union of two sources, because a queue exists as soon as ONE cover names
+    it: the ``command_queue`` stored on every cover entry, and the name of every
+    Command Queue entry. Neither alone is the truth — a user may create the
+    entry first, or may never create one at all.
+
+    Deduping on the normalized key while DISPLAYING the original casing is the
+    whole mitigation for the free-text typo class: "Facade South" and "facade
+    south" collapse to one row, so the second cover picks the existing name
+    instead of silently minting a near-miss.
+    """
+    seen: dict[str, str] = {}
+    for entry in _cover_entries(hass):
+        raw = entry.options.get(CONF_COMMAND_QUEUE)
+        key = normalize_queue_name(raw)
+        if key:
+            seen.setdefault(key, str(raw).strip())
+    for entry in _command_queue_entries(hass):
+        raw = entry.data.get("name")
+        key = normalize_queue_name(raw)
+        if key:
+            seen.setdefault(key, str(raw).strip())
+    return [seen[key] for key in sorted(seen)]
+
+
+def _covers_on_command_queue(hass, queue_entry) -> list:
+    """Every cover entry whose queue name normalizes to this queue's.
+
+    By NORMALIZED name, never ``entry_id`` — that is the linkage the runtime
+    uses, so this list is exactly the membership that will serialize.
+    """
+    key = normalize_queue_name(queue_entry.data.get("name"))
+    if not key:
+        return []
+    return [
+        entry
+        for entry in _cover_entries(hass)
+        if normalize_queue_name(entry.options.get(CONF_COMMAND_QUEUE)) == key
+    ]
+
+
+def command_queue_selector(hass) -> selector.SelectSelector:
+    """Build the cover-side queue picker: known names, plus free text.
+
+    ``custom_value=True`` so only the FIRST cover on a queue has to type the
+    name; every cover after it picks the existing row.
+    """
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=[
+                {"value": name, "label": name}
+                for name in known_command_queue_names(hass)
+            ],
+            mode=selector.SelectSelectorMode.DROPDOWN,
+            custom_value=True,
+        )
+    )
+
+
+def command_queue_gap_for(hass, name: str) -> float:
+    """Resolve the gap a queue NAME uses: its owning entry's, or the default.
+
+    The single statement of the resolution the runtime performs (a member reads
+    ``queue.gap_seconds``, which is the entry's value while one is bound and the
+    default otherwise). Restating it in the summary rather than sharing it is
+    how the displayed number drifts from the transmitted one.
+    """
+    key = normalize_queue_name(name)
+    if hass is not None and key:
+        for entry in _command_queue_entries(hass):
+            if normalize_queue_name(entry.data.get("name")) == key:
+                return entry.options.get(
+                    CONF_COMMAND_QUEUE_GAP, DEFAULT_COMMAND_QUEUE_GAP
+                )
+    return DEFAULT_COMMAND_QUEUE_GAP
+
+
+def command_queue_gap_schema() -> vol.Schema:
+    """Build the gap field alone — the create form and settings step share it.
+
+    Built from the registry ``FieldSpec``, so the bounds, step and default come
+    from ``const`` exactly once and the create form can never drift from the
+    edit form.
+    """
+    spec = config_fields.FIELD_SPECS[CONF_COMMAND_QUEUE_GAP]
+    marker, sel = spec.to_marker(None, {})
+    return vol.Schema({marker: sel})
+
+
+# Command Queue create form (issue #1189): the name covers will reference, and
+# the gap the queue holds the air for after each member transmits.
+COMMAND_QUEUE_CREATE_SCHEMA = vol.Schema(
+    {
+        vol.Required("name"): selector.TextSelector(),
+        **command_queue_gap_schema().schema,
     }
 )
 
@@ -1799,6 +1905,8 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
         "collapses every climate/glare-control decision to the floor "
         "and the cover stops blocking heat."
     ),
+    # --- Named command queue (issue #1189) ---
+    "movement.queue": '🚦 Commands serialized on queue "{queue}" ({gap}s gap)',
     # --- My preset / Somfy ---
     "my.entities_enabled": "🎛️ My-preset entities: enabled",
     "my.entities_disabled": "🎛️ My-preset entities: disabled",
@@ -3148,6 +3256,23 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         lines.append(L["headers.position_limits"])
         lines.append(L["limits.separator"].join(limit_parts))
 
+    # Named command queue (issue #1189). Its own line rather than a
+    # ``limit_parts`` fragment: the other entries there are numeric limits on
+    # this cover alone, while this one names a constraint SHARED with other
+    # config entries, and the gap it reports may be owned by an entry the user
+    # has to go elsewhere to edit. The gap is resolved exactly the way the
+    # runtime resolves it — the owning entry's value, or the default when no
+    # entry owns the name — so the summary can never promise a number the
+    # dispatcher would not use.
+    _queue_name = str(config.get(CONF_COMMAND_QUEUE) or "").strip()
+    if _queue_name:
+        lines.append(
+            L["movement.queue"].format(
+                queue=_queue_name,
+                gap=command_queue_gap_for(hass, _queue_name),
+            )
+        )
+
     # Footgun: a cover whose state Home Assistant only assumes can never be
     # measured, so leaving it without a hand-entered time silently means "this
     # cover will never animate" — exactly the kind of quiet no-op the summary
@@ -3446,6 +3571,12 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_START_ENTITY,
             CONF_END_TIME,
             CONF_END_ENTITY,
+            # Issue #1189. The one option whose whole point is that many covers
+            # share a value — Copy-to-covers fans one queue assignment across a
+            # whole facade in a single gesture, which for the 16-instance
+            # install this feature exists for is the difference between usable
+            # and not.
+            CONF_COMMAND_QUEUE,
         }
     ),
     "manual_override": frozenset(
@@ -4362,7 +4493,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     # 3.15 (issue #1138): the same shape again for the additive
     # day_night_external_command_interlock option — absent reads as "on", so the
     # v3.14→v3.15 block is a no-op bump and nothing else.
-    MINOR_VERSION = 16
+    MINOR_VERSION = 17
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()
@@ -4392,9 +4523,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         choices. The duplicate option only appears when prior entries exist.
         """
         acp_entries = _cover_entries(self.hass)
-        menu_options = ["create_new", "create_building_profile", "create_group"] + (
-            ["duplicate_existing"] if acp_entries else []
-        )
+        menu_options = [
+            "create_new",
+            "create_building_profile",
+            "create_group",
+            "create_command_queue",
+        ] + (["duplicate_existing"] if acp_entries else [])
         return self.async_show_menu(step_id="user", menu_options=menu_options)
 
     async def async_step_create_new(self, user_input: dict[str, Any] | None = None):
@@ -4458,6 +4592,31 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
+            },
+        )
+
+    async def async_step_create_command_queue(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Create a Command Queue entry from a single combined form (issue #1189).
+
+        One step collects the queue name together with its gap, then delegates
+        to the shared finalize (``async_step_update``) — the same path the
+        Building Profile and Cover Group flows use.
+
+        Creating a queue is entirely optional: a cover can name a queue that has
+        no entry behind it and still serialize, at the default gap. This entry
+        exists to change that gap and to show which covers joined.
+        """
+        if user_input is not None:
+            self.config = dict(user_input)
+            self.type_blind = CoverType.COMMAND_QUEUE
+            return await self.async_step_update()
+        return self.async_show_form(
+            step_id="create_command_queue",
+            data_schema=COMMAND_QUEUE_CREATE_SCHEMA,
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Automation"
             },
         )
 
@@ -4920,6 +5079,25 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
+        # Command Queue entries own one number and a membership view. Routed
+        # BEFORE the profile branch below, because both virtual entry types
+        # report ``controls_cover == False`` and the profile menu would
+        # otherwise swallow this one (issue #1189).
+        if get_policy(self.sensor_type).is_command_queue:
+            return self.async_show_menu(
+                step_id="init",
+                menu_options=[
+                    "queue_settings",
+                    "queue_overview",
+                    "done",
+                ],
+                description_placeholders={
+                    "instance_name": self._config_entry.title,
+                    "coffee_url": "https://www.buymeacoffee.com/jrhubott",
+                    "profile_line": "",
+                },
+            )
+
         # Building Profile entries have no cover, geometry, or handlers to
         # configure — show a small menu (edit shared sensors, view the overview
         # of linked covers) instead of the full cover-options menu.
@@ -5804,6 +5982,15 @@ class OptionsFlowHandler(OptionsFlow):
         """Manage automation options."""
         if user_input is not None:
             self.optional_entities([CONF_START_ENTITY, CONF_END_ENTITY], user_input)
+            # A blank queue means "no queue", and that must be storable —
+            # otherwise a cover could join one but never leave. Same strip
+            # pattern as the time keys below: drop it from the submission AND
+            # from the stored options, since the suggested-values path can
+            # re-add it. Stored EXACTLY as typed (normalization is a match-time
+            # concern) so the dropdown can keep showing the user's own casing.
+            if not str(user_input.get(CONF_COMMAND_QUEUE) or "").strip():
+                user_input.pop(CONF_COMMAND_QUEUE, None)
+                self.options.pop(CONF_COMMAND_QUEUE, None)
             # A cleared TimeSelector either omits the key or coerces to the blank
             # sentinel "00:00:00". Treat both as "unset": drop the key from the
             # submission and from any previously-stored option so it never
@@ -5821,10 +6008,18 @@ class OptionsFlowHandler(OptionsFlow):
                     self.options.pop(time_key, None)
             self.options.update(user_input)
             return await self.async_step_init()
+        # The queue picker is appended here rather than declared in the static
+        # AUTOMATION_SCHEMA because its options are drawn from the OTHER loaded
+        # config entries, which a module-level schema cannot see.
+        schema = AUTOMATION_SCHEMA.extend(
+            {
+                vol.Optional(CONF_COMMAND_QUEUE): command_queue_selector(self.hass),
+            }
+        )
         return self.async_show_form(
             step_id="automation",
             data_schema=self.add_suggested_values_to_schema(
-                AUTOMATION_SCHEMA, user_input or self.options
+                schema, user_input or self.options
             ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Automation"
@@ -6188,6 +6383,53 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="profile_overview",
             data_schema=vol.Schema({}),
             description_placeholders={"overview": overview_text},
+        )
+
+    async def async_step_queue_settings(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the gap this Command Queue holds after each member transmits.
+
+        The only editable setting a queue has. Members read it live, so saving
+        takes effect on the next transmission without reloading any cover.
+        """
+        if user_input is not None:
+            self.options.update(user_input)
+            return await self.async_step_init()
+        return self.async_show_form(
+            step_id="queue_settings",
+            data_schema=self.add_suggested_values_to_schema(
+                command_queue_gap_schema(), self.options
+            ),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Automation"
+            },
+        )
+
+    async def async_step_queue_overview(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Read-only list of the covers currently on this queue.
+
+        Membership is resolved the same way the runtime resolves it — by
+        NORMALIZED name — so a cover that typed a different casing shows up
+        here exactly as it will be serialized in practice. That is the point of
+        the page: it is where a user finds out whether the name they typed
+        actually joined the queue they meant.
+        """
+        if user_input is not None:
+            return await self.async_step_init()
+        members = _covers_on_command_queue(self.hass, self._config_entry)
+        gap = self.options.get(CONF_COMMAND_QUEUE_GAP, DEFAULT_COMMAND_QUEUE_GAP)
+        lines = [f"**{self._config_entry.data.get('name')}** — {gap}s gap", ""]
+        if members:
+            lines.extend(f"- 🪟 {entry.title}" for entry in members)
+        else:
+            lines.append("_No covers are assigned to this queue._")
+        return self.async_show_form(
+            step_id="queue_overview",
+            data_schema=vol.Schema({}),
+            description_placeholders={"overview": "\n".join(lines)},
         )
 
     async def async_step_profile_overrides(

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4607,8 +4607,22 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         Creating a queue is entirely optional: a cover can name a queue that has
         no entry behind it and still serialize, at the default gap. This entry
         exists to change that gap and to show which covers joined.
+
+        The NAME is the identity, which is why a duplicate is refused outright
+        rather than merely discouraged. A Building Profile links by ``entry_id``
+        and can afford two entries with one title; this entry binds itself to a
+        shared runtime object by normalized name, so two of them both
+        ``attach()`` and both ``set_gap()`` — the bound gap becomes whichever
+        loaded last, and unloading or deleting EITHER reverts the queue to the
+        5 s default while the surviving entry's UI still shows its own value.
         """
         if user_input is not None:
+            key = normalize_queue_name(user_input.get("name"))
+            if key and any(
+                normalize_queue_name(entry.data.get("name")) == key
+                for entry in _command_queue_entries(self.hass)
+            ):
+                return self.async_abort(reason="already_configured")  # type: ignore[return-value]
             self.config = dict(user_input)
             self.type_blind = CoverType.COMMAND_QUEUE
             return await self.async_step_update()

--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -736,6 +736,11 @@ class TrackingSlice:
     # instead of set_cover_position(100/0). Falls back to set_cover_position
     # when the cover lacks open/close; never applies to a tilt-only axis.
     endpoint_use_open_close: bool = True
+    # Name of the shared dispatch queue this cover belongs to (issue #1189).
+    # ``None``/blank — the default — means no queue: the cover transmits the
+    # moment it decides to, exactly as before the queue existed. Read at setup
+    # only, deliberately: changing it is wiring, so it must take a full reload.
+    command_queue: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -794,6 +799,7 @@ class RuntimeConfig:
             CONF_CLIMATE_TEMP_HOLD_TIME,
             CONF_CLOUD_SUPPRESSION,
             CONF_CLOUD_SUPPRESSION_HOLD_TIME,
+            CONF_COMMAND_QUEUE,
             CONF_DAYTIME_GATE_SENSORS,
             CONF_DAYTIME_GATE_TEMPLATE,
             CONF_DAYTIME_GATE_TEMPLATE_MODE,
@@ -918,6 +924,7 @@ class RuntimeConfig:
                     CONF_ENDPOINT_USE_OPEN_CLOSE,
                     DEFAULT_ENDPOINT_USE_OPEN_CLOSE,
                 ),
+                command_queue=options.get(CONF_COMMAND_QUEUE),
             ),
             manual_override=ManualOverrideSlice(
                 reset=options.get(CONF_MANUAL_OVERRIDE_RESET, False),

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -156,6 +156,24 @@ _RANGE_COMMAND_QUEUE_GAP = (0.0, 60.0)
 # withheld. Wider than the worst backend queue #1139 measured (33.7 s) would be
 # pointless; narrower than it would expire routinely.
 COMMAND_QUEUE_MAX_WAIT_SECONDS = 30.0
+# How much of its OWN interval one reconciliation pass may spend waiting on the
+# queue, in total across every entity it resends. The pass is not a dispatch: it
+# is the retry loop, and HA re-arms the interval listener before dispatching each
+# fire as its own background task, so a pass still running when the next one
+# starts leaves two of them mutating the same ``PerEntityState``.
+#
+# A whole-PASS allowance rather than a per-entity one, because the per-entity
+# ceiling above bounds the wrong thing here: N entities each waiting up to
+# COMMAND_QUEUE_MAX_WAIT_SECONDS is N x 30 s against a 60 s interval. Half the
+# interval leaves the other half as slack for the transmissions themselves —
+# ``async_call`` against a slow backend was measured at 33.7 s in #1139 — and for
+# scheduler jitter, so the bound holds without having to model either.
+#
+# At the shipped 1-minute interval and 5 s gap that is 30 s of spacing per pass,
+# i.e. seven covers resent per minute on one queue. Raising it buys throughput
+# out of the overlap margin; it is not an option because the trade is between two
+# invariants, not two preferences.
+COMMAND_QUEUE_PASS_BUDGET_FRACTION = 0.5
 
 # The scene select's "no scene" option (wire-stable select state). Not a
 # GroupScene member — it is the absence of a scene: choosing it clears the

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -67,6 +67,13 @@ DOMAIN = "adaptive_cover_pro"  # HA integration domain; must match manifest.json
 # outside the coordinator so it survives a reload (when entry.runtime_data is
 # briefly unset) and can be served by the diagnostics download as a stale fallback.
 DIAG_CACHE_KEY = f"{DOMAIN}_last_diagnostics"
+# hass.data slot holding the named cover-command dispatch queues, keyed by the
+# NORMALIZED queue name (issue #1189). Cross-entry shared state by construction:
+# a queue serializes commands across independent config entries, so it must
+# outlive any single member's reload and therefore cannot live on
+# ``entry.runtime_data``. Members attach/detach with a refcount; the key is
+# dropped when the last one leaves.
+COMMAND_QUEUE_REGISTRY_KEY = f"{DOMAIN}_command_queues"
 LOGGER = logging.getLogger(__package__)  # package-scoped logger
 _LOGGER = logging.getLogger(__name__)  # module-scoped; also imported by button.py
 
@@ -126,6 +133,29 @@ OPT_OUT_ALL_SCENES = "*"
 CONF_GROUP_STAGGER_DELAY = "group_stagger_delay"
 DEFAULT_GROUP_STAGGER_DELAY = 0.0
 _RANGE_GROUP_STAGGER = (0.0, 30.0)
+
+# ── Named cover-command dispatch queue (issue #1189) ─────────────────────────
+# A cover names the queue it belongs to; every cover naming the same queue
+# transmits one at a time, the queue staying busy for ``gap`` seconds after each
+# send. Deliberately disjoint from the group stagger above: that one is
+# group-scoped AND group-triggered (it only spaces a group fan-out), this one
+# spaces a cover's OWN routine dispatch across independent config entries.
+#
+# The name is stored on the cover (blank = no queue = today's behaviour); the
+# gap lives on the optional "Command Queue" config entry that owns the name. A
+# name with no matching entry still serializes, at DEFAULT_COMMAND_QUEUE_GAP —
+# naming a queue must never require creating one.
+CONF_COMMAND_QUEUE = "command_queue"
+CONF_COMMAND_QUEUE_GAP = "command_queue_gap"
+DEFAULT_COMMAND_QUEUE_GAP = 5.0
+_RANGE_COMMAND_QUEUE_GAP = (0.0, 60.0)
+# Hard ceiling on how long any one command may sit in a queue. NOT an option in
+# v1: it is the bounded-wait invariant, not a preference. A queue wait is a
+# long-blocking dispatch inside the coordinator's update cycle — exactly issue
+# #756's shape — so on expiry the command transmits anyway rather than being
+# withheld. Wider than the worst backend queue #1139 measured (33.7 s) would be
+# pointless; narrower than it would expire routinely.
+COMMAND_QUEUE_MAX_WAIT_SECONDS = 30.0
 
 # The scene select's "no scene" option (wire-stable select state). Not a
 # GroupScene member — it is the absence of a scene: choosing it clears the
@@ -2552,6 +2582,11 @@ class CoverType(StrEnum):
     # (``controls_cover = True``) but is not geometry-driven: setup branches
     # on ``is_orchestrator`` to a ``GroupCoordinator`` (issue #790).
     GROUP = "cover_group"
+    # Virtual entry type — owns the gap for ONE named dispatch queue (issue
+    # #1189). Controls nothing itself (``controls_cover = False``); covers join
+    # by naming it, and a name with no matching entry still serializes, at the
+    # default gap. Registers no platforms and builds no coordinator.
+    COMMAND_QUEUE = "cover_command_queue"
 
     @property
     def display_name(self) -> str:
@@ -2574,6 +2609,7 @@ class CoverType(StrEnum):
             self.DUAL_PANEL: "Dual Panel Shade",
             self.BUILDING_PROFILE: "Building Profile",
             self.GROUP: "Cover Group",
+            self.COMMAND_QUEUE: "Command Queue",
         }[self]
 
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -135,6 +135,11 @@ from .managers.cover_command import (
     PositionContext,
     build_special_positions,
 )
+from .managers.cover_command.queue import (
+    CommandQueue,
+    get_command_queue,
+    normalize_queue_name,
+)
 from .managers.grace_period import GracePeriodManager
 from .managers.manual_override import (
     STARTED_AT_SOURCE_ENGAGED,
@@ -290,6 +295,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     """Adaptive cover data update coordinator."""
 
     config_entry: AdaptiveConfigEntry
+
+    # The shared dispatch queue this entry belongs to, or None when the cover
+    # names no queue — which is the overwhelmingly common case (issue #1189).
+    # Declared at class level, with the unqueued default, so it is a real
+    # attribute of the type: ``__init__`` only ever narrows it, and every
+    # consumer (diagnostics, the command service) can read it unconditionally.
+    _command_queue: CommandQueue | None = None
 
     # Default capabilities for covers when entity not ready
     _DEFAULT_CAPABILITIES = {
@@ -625,6 +637,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # key — correctly, since none of them has a coordinator to read from.
         self.manual_override_duration_mode = _rc_attach.manual_override.duration_mode
 
+        # Named dispatch queue (issue #1189). Resolved once, at setup: the queue
+        # is cross-entry shared state, so it is looked up in the hass.data
+        # registry and refcounted rather than constructed here. Deliberately
+        # absent from ``_RUNTIME_APPLICABLE_OPTIONS``, so changing the
+        # assignment full-reloads the entry — it is setup wiring (this
+        # constructor argument, this refcount), not a value the running
+        # coordinator can re-read.
+        _queue_name = normalize_queue_name(_rc_attach.tracking.command_queue)
+        if _queue_name:
+            self._command_queue = get_command_queue(self.hass, _queue_name)
+            self._command_queue.attach()
+            self.config_entry.async_on_unload(self._command_queue.detach)
+
         # Cover command service — self-contained: owns positioning, target tracking,
         # and the reconciliation timer (started in async_config_entry_first_refresh).
         # on_tick keeps time window transition checks running on the same 1-min interval
@@ -665,6 +690,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             get_travel_calibration=lambda eid: (
                 self.config_entry.options.get(CONF_TRAVEL_TIME_CALIBRATION) or {}
             ).get(eid),
+            command_queue=self._command_queue,
         )
 
         # Wire the manual-override engine's edge + origin seams once. Any
@@ -4714,6 +4740,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             ),
             event_timeline=self._event_buffer.snapshot() or None,
             cover_command_state=self._cmd_svc.get_all_entity_state_snapshots() or None,
+            command_queue=self._command_queue,
             debug_config={
                 "dry_run": self.config_entry.options.get(CONF_DRY_RUN, False),
                 "debug_mode": self.config_entry.options.get(CONF_DEBUG_MODE, False),

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -767,6 +767,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             backrotate_publish_lag_seconds=(
                 _rc_attach.venetian.backrotate_publish_lag_seconds
             ),
+            # Lets a dual-axis policy report its own tilt frames to this
+            # instance's command queue (issue #1189). The settle+tilt tail runs
+            # outside the queue slot by design, so without this the queue would
+            # believe the air was free while the tail was still keying it.
+            mark_air_busy=self._cmd_svc.mark_queue_external_transmit,
             invert_tilt=lambda: self._inverse_tilt,
             get_min_change=lambda: self.min_change,
             get_enforce_delta_at_endpoints=lambda: self._enforce_delta_at_endpoints,

--- a/custom_components/adaptive_cover_pro/cover_types/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/__init__.py
@@ -29,9 +29,12 @@ from .dual_panel import DualPanelPolicy
 # registry-derived menus (``SENSOR_TYPE_MENU`` follows registration order).
 # The building profile is not a physical cover (``controls_cover = False``);
 # the group controls covers but is an orchestrator (``is_orchestrator =
-# True``) — both are filtered out of the cover-type picker by capability.
+# True``); the command queue is not a cover either (``is_command_queue = True``,
+# issue #1189) — all three are filtered out of the cover-type picker by
+# capability.
 from .building_profile import BuildingProfilePolicy
 from .group import GroupPolicy
+from .command_queue import CommandQueuePolicy
 
 
 def get_policy(cover_type) -> CoverTypePolicy:
@@ -93,6 +96,7 @@ __all__ = [
     "AwningPolicy",
     "BlindPolicy",
     "BuildingProfilePolicy",
+    "CommandQueuePolicy",
     "CoverTypePolicy",
     "DayNightShadePolicy",
     "DualPanelPolicy",

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -430,6 +430,15 @@ class CoverTypePolicy(ABC):
     # ``controls_cover`` (issue #790).
     is_orchestrator: ClassVar[bool] = False
 
+    # Whether this policy is a named command queue rather than anything that
+    # moves. Only the Command Queue entry type sets this ``True`` (issue #1189).
+    # It shares ``controls_cover = False`` with the Building Profile, so the
+    # existing "virtual entry type" branches would otherwise treat it as a
+    # profile — propagating sensor keys to nothing and offering it in the
+    # profile-link dropdown. A third capability flag keeps that discrimination
+    # off the cover-type string, exactly as ``is_orchestrator`` does for groups.
+    is_command_queue: ClassVar[bool] = False
+
     def __init_subclass__(cls, *, register: bool = False, **kwargs: Any) -> None:
         """Auto-register a concrete policy by its ``cover_type``.
 

--- a/custom_components/adaptive_cover_pro/cover_types/command_queue.py
+++ b/custom_components/adaptive_cover_pro/cover_types/command_queue.py
@@ -1,0 +1,34 @@
+"""Command Queue virtual entry-type policy (issue #1189).
+
+A command queue is not a cover and does not control one: it exists so a named
+dispatch queue has somewhere to keep its gap, and so the user has a place to see
+which covers are on it. Covers join a queue by NAME, never by ``entry_id`` —
+which is what lets a name work with no entry behind it at all (at the default
+gap) and lets a queue entry be deleted without breaking the covers that
+reference it.
+
+Its config entry registers no platforms and builds no coordinator: setup
+short-circuits in ``__init__.async_setup_entry`` on ``controls_cover``, then
+splits to the queue branch on ``is_command_queue``. The policy exists only so
+the registry/menu machinery treats the queue uniformly with real cover types.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ..const import CoverType
+from .base import CoverAxis, CoverTypePolicy
+
+
+class CommandQueuePolicy(CoverTypePolicy, register=True):
+    """Virtual entry type owning one named dispatch queue's gap."""
+
+    cover_type = CoverType.COMMAND_QUEUE
+    controls_cover: ClassVar[bool] = False
+    is_command_queue: ClassVar[bool] = True
+    axes: ClassVar[tuple[CoverAxis, ...]] = ()
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+        """Never called — queue setup short-circuits before any engine build."""
+        raise NotImplementedError  # pragma: no cover

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -1456,6 +1456,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             invert_tilt=kwargs.get("invert_tilt"),
             get_min_change=kwargs.get("get_min_change"),
             get_enforce_delta_at_endpoints=kwargs.get("get_enforce_delta_at_endpoints"),
+            mark_air_busy=kwargs.get("mark_air_busy"),
         )
         self._schedule_refresh_after = kwargs.get("schedule_refresh_after")
 

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -917,6 +917,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
                 "backrotate_publish_lag_seconds",
                 DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
             ),
+            mark_air_busy=kwargs.get("mark_air_busy"),
         )
         # Drift-reset scope (issue #808) is a policy-level gate: the policy owns
         # the ControlMethod == SOLAR decision (cover-type knowledge stays inside

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -148,6 +148,7 @@ class DualAxisSequencer:
         backrotate_publish_lag_seconds: float = (
             DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS
         ),
+        mark_air_busy: Callable[[], None] | None = None,
     ) -> None:
         """Bind HA + cmd_svc dependencies; per-entity timestamps start empty.
 
@@ -169,6 +170,12 @@ class DualAxisSequencer:
         self._hass = hass
         self._logger = logger
         self._grace_mgr = grace_mgr
+        # Reports a tilt frame to the instance's command queue (issue #1189).
+        # Every tilt send is a transmission the queue never gated: the tail runs
+        # outside the slot by design, and the pre-send runs inside one it is
+        # about to hand back. ``None`` for an unqueued instance and for the
+        # sequencers unit tests build directly.
+        self._mark_air_busy = mark_air_busy
         self._get_current_position = get_current_position
         self._set_commanded_position = set_commanded_position
         self._position_tolerance = position_tolerance
@@ -832,6 +839,21 @@ class DualAxisSequencer:
                 trigger=reason,
             )
             return False
+
+        # A tilt frame keys the radio and the command queue never gated it
+        # (issue #1189). The post-settle tail runs OUTSIDE the slot on purpose —
+        # ``_wait_for_position_settle`` is capped at
+        # ``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS`` (60 s), and holding the
+        # slot across that would starve every other member, while #1115's
+        # day/night guard depends on the tail not holding it — so by the time
+        # this frame goes out the queue believes the air is free and the next
+        # member is free to key on top of it. Reported here, at the one
+        # chokepoint every real tilt send passes through, exactly as
+        # ``StopTracker.call_stop_cover`` reports a stop. Deduped, dry-run and
+        # min-delta-gated sends returned above and report nothing: they owe the
+        # air only what they actually used.
+        if self._mark_air_busy is not None:
+            self._mark_air_busy()
 
         self._record_event(
             "tilt_command_sent",

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -129,6 +129,10 @@ class DiagnosticContext:
         None  # deprecated alias; use event_timeline
     )
     cover_command_state: dict[str, dict] | None = None
+    # The shared dispatch queue this entry belongs to, or None when unqueued
+    # (issue #1189). The live object, not a snapshot: its depth and gap are read
+    # at build time so a downloaded snapshot shows the queue as it actually was.
+    command_queue: Any = None
     debug_config: dict | None = None
 
     # Meta — integration identity and coordinator health
@@ -739,6 +743,25 @@ class DiagnosticsBuilder:
         return diagnostics
 
     @staticmethod
+    def build_command_queue_block(queue) -> dict | None:
+        """Describe the dispatch queue this entry belongs to, or ``None``.
+
+        ``gap_source`` is the field that actually answers support questions: a
+        queue named by covers but owned by no Command Queue entry reports
+        ``default``, which is the difference between "your 12-second gap is not
+        being applied" and "you never created the entry that holds it".
+        """
+        if queue is None:
+            return None
+        return {
+            "name": queue.name,
+            "gap_seconds": queue.gap_seconds,
+            "gap_source": queue.gap_source,
+            "attached_members": queue.attached,
+            "current_depth": queue.depth,
+        }
+
+    @staticmethod
     def _build_last_action(ctx: DiagnosticContext) -> dict:
         """Build last action diagnostics."""
         diagnostics: dict = {}
@@ -788,6 +811,13 @@ class DiagnosticsBuilder:
 
         # Always emit cover_commands (empty dict when nothing active)
         diagnostics["cover_commands"] = ctx.cover_command_state or {}
+
+        # Named dispatch queue (issue #1189). Omitted entirely for the
+        # overwhelmingly common unqueued cover, so an existing snapshot's shape
+        # is unchanged.
+        queue_block = DiagnosticsBuilder.build_command_queue_block(ctx.command_queue)
+        if queue_block is not None:
+            diagnostics["command_queue"] = queue_block
 
         # Issue #33 Phase 5 cross-axis publish-lag suppression counts.
         # Surfaced only when non-empty so the field stays out of the way

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -2374,11 +2374,23 @@ class CoverCommandService:
 
         ``proceed`` is False when this reservation lost its place to a fresher
         decision for the SAME entity, and the caller must then record a
-        ``superseded_in_queue`` skip having booked nothing. ``resend=True``
-        marks a reconciliation re-booking, which additionally STANDS DOWN for a
-        live dispatch already waiting on this entity rather than displacing it:
-        the resend carries the older number, and evicting the newer one would
-        put a stale frame on a one-way radio.
+        ``superseded_in_queue`` skip having booked nothing.
+
+        ``resend=True`` marks a reconciliation re-booking, and changes the
+        acquisition in two ways, both because that pass IS the retry loop:
+
+        * It STANDS DOWN for a live dispatch already waiting on this entity
+          rather than displacing it — the resend carries the older number, and
+          evicting the newer one would put a stale frame on a one-way radio.
+        * It never waits (``wait=False``). A resend that blocked would hold the
+          pass open per entity for the full ``COMMAND_QUEUE_MAX_WAIT_SECONDS``
+          against a one-minute interval that HA re-arms before dispatching each
+          fire, so overlapping passes would mutate the same per-entity state —
+          the same overlap the ``wait=False`` clearance gate in
+          ``run_reconciliation_pass`` exists to prevent, reached by a different
+          road. Standing down costs nothing: the next pass re-asks, and it does
+          not burn a retry because the pass reads
+          :meth:`_resend_stands_down` before counting one.
 
         ``grant`` is None both when there is no queue and on the dry-run path,
         so the release below is a no-op there. A dry run is skipped
@@ -2391,16 +2403,39 @@ class CoverCommandService:
         """
         if self._queue is None or self._dry_run:
             return True, None
-        if resend and self._queue.defers_to_pending(entity_id):
+        # The SAME predicate the reconciliation pass reads before it counts a
+        # retry, not a second copy of the rule — the two must never disagree
+        # about whether this resend goes out. ``wait=not resend`` below is the
+        # structural backstop that keeps the non-blocking half true even for a
+        # caller that never asked.
+        if resend and self._resend_stands_down(entity_id):
             return False, None
         grant = await self._queue.acquire(
             entity_id,
             head_of_line=head_of_line,
             budget=COMMAND_QUEUE_MAX_WAIT_SECONDS,
+            wait=not resend,
         )
         if grant is None:
             return False, None
         return True, grant
+
+    def _resend_stands_down(self, entity_id: str) -> bool:
+        """Whether a reconciliation resend for this entity would yield its turn.
+
+        Asked by the pass BEFORE the retry is counted, for exactly the reason
+        the clearance gate above it is: a resend that is never transmitted must
+        not burn one of the pass's attempts, or repeated stand-downs reach
+        ``gave_up`` and warn "max retries exceeded" about a cover that was
+        never resent. With the resend now non-blocking that is the ordinary
+        case on a busy queue rather than a corner one.
+
+        Unqueued and dry-run instances never stand down, so the pass behaves
+        exactly as it did before the queue existed.
+        """
+        if self._queue is None or self._dry_run:
+            return False
+        return self._queue.resend_stands_down(entity_id)
 
     def _queue_diagnostic_fields(self, grant: QueueGrant | None) -> dict:
         """Return the four per-dispatch queue fields, or ``{}`` when unqueued.
@@ -2858,6 +2893,29 @@ class CoverCommandService:
                 )
                 continue
 
+            # 10. The command queue's stand-down (issue #1189), asked HERE for
+            # the same two reasons the clearance gate above it is.
+            #
+            # Before the count: a resend that never reaches the wire must not
+            # burn one of the pass's three attempts. Repeated stand-downs would
+            # otherwise reach ``gave_up`` and log "max retries exceeded" about a
+            # cover that was never resent — and on a saturated queue standing
+            # down is the ordinary outcome, not a corner case.
+            #
+            # Without waiting: ``_execute_command`` acquires with ``wait=False``,
+            # so the answer here is the answer it will get. A resend that
+            # blocked for the queue's 30 s budget per entity would leave this
+            # pass running into the next one — HA re-arms the interval listener
+            # before dispatching each fire as its own task — and the two would
+            # mutate the same ``PerEntityState``.
+            if self._resend_stands_down(entity_id):
+                self._logger.debug(
+                    "Reconcile: %s stood down for the command queue — the slot "
+                    "is not free and this pass must not block on it",
+                    entity_id,
+                )
+                continue
+
             s.retry_count += 1
             self._logger.debug(
                 "Reconcile: %s missed target (actual=%s target=%s) — retry %d/%d",
@@ -3227,19 +3285,28 @@ class CoverCommandService:
         command queue too (issue #1189) — through the SAME acquire/release pair
         ``apply_position`` uses, and ahead of ``_prepare_service_call`` for the
         same reason: that call books ``sent_at`` and the grace window, both of
-        which must clock from the real transmit time. It queues in the ROUTINE
-        tier: a retry of a command that already had its chance has no claim on
-        the head of the line ahead of a fresh safety decision. It also queues as
-        a ``resend``, which is the direction on the supersede rule: it yields to
-        a live dispatch already waiting on this entity instead of evicting it,
-        because the number it re-books is by definition the older one.
+        which must clock from the real transmit time.
+
+        Unlike a live dispatch it never QUEUES for that turn: it acquires as a
+        ``resend``, which takes the slot only when it is free this instant and
+        otherwise stands down. Two consequences, both deliberate. It yields to a
+        live dispatch already waiting on this entity instead of evicting it,
+        because the number it re-books is by definition the older one. And it
+        cannot hold the reconciliation pass open — a blocking wait here would
+        cost up to ``COMMAND_QUEUE_MAX_WAIT_SECONDS`` per entity against a
+        one-minute interval HA re-arms before dispatching each fire, leaving
+        two passes running over one ``PerEntityState``. The next pass re-asks
+        in a minute; the pass exists to retry.
         """
         proceed, grant = await self._acquire_queue_slot(
             entity_id, head_of_line=False, resend=True
         )
         if not proceed:
-            # A live dispatch for this entity holds — or is waiting for — this
-            # entity's place, and it carries a fresher target than this resend.
+            # Either a live dispatch for this entity carries a fresher target,
+            # or the slot is not free right now. ``run_reconciliation_pass``
+            # already asked the same question through ``_resend_stands_down``
+            # and skipped without counting a retry; this is the seam that holds
+            # the rule for every caller.
             return
         transmitted = False
         try:

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
 
 from ...const import (
+    COMMAND_QUEUE_MAX_WAIT_SECONDS,
     DEFAULT_ENDPOINT_USE_OPEN_CLOSE,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     MAX_POSITION_RETRIES,
@@ -38,6 +39,7 @@ from ...helpers import (
 from . import gates
 from .diagnostics import DiagnosticsRecorder
 from .position_context import PositionContextTracker
+from .queue import CommandQueue, QueueGrant
 from .routing import ServiceCallPlan, build_special_positions, route_service_call
 from .state_classifier import StateClassifier
 from .state_store import (
@@ -119,6 +121,7 @@ class CoverCommandService:
         debug_log=None,
         on_command_sent=None,
         get_travel_calibration=None,
+        command_queue: CommandQueue | None = None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -170,6 +173,14 @@ class CoverCommandService:
                 per cycle) would serve stale numbers until the next reload.
                 Omitted, no travel plans are recorded and every estimated-position
                 surface stays empty — the pre-calibration behaviour.
+            command_queue: The shared :class:`CommandQueue` this entry's cover
+                was assigned to, or ``None`` for the overwhelmingly common
+                unqueued cover (issue #1189). Shared ACROSS config entries —
+                the whole point is that independent instances driving the same
+                one-way radio take turns — so it is looked up in the registry
+                and refcounted by the coordinator, never owned here. ``None``
+                keeps the dispatch path byte-identical to the behaviour before
+                the queue existed: no await, no allocation, no registry touch.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -199,6 +210,10 @@ class CoverCommandService:
         self._on_tick = on_tick
         self._on_command_sent = on_command_sent
         self._get_travel_calibration = get_travel_calibration
+        # Cross-entry dispatch queue (issue #1189). Set before the StopTracker
+        # below, which reads it through a live lambda so an ACP-issued stop can
+        # tell the queue the air is busy without taking a turn in it.
+        self._queue: CommandQueue | None = command_queue
 
         # True while a travel-time calibration run owns the covers. Blocks every
         # outbound command from ``apply_position`` and stands the reconciliation
@@ -228,6 +243,7 @@ class CoverCommandService:
             logger,
             dry_run_fn=lambda: self._dry_run,
             is_in_transit_fn=self._is_cover_in_transit,
+            queue_fn=lambda: self._queue,
         )
 
         # Position-context tracker mirrors the stop tracker for the
@@ -1750,14 +1766,22 @@ class CoverCommandService:
         # check_cover_features + route_service_call work entirely for a
         # value it would never read (issue #1095 audit finding 4).
         # route_service_call is pure/side-effect-free (routing.py's module
-        # docstring), and nothing between this line and either of its uses
-        # (this gate, and the dispatch call further down that reuses this
-        # same `_plan`/`_caps_for_plan`) can invalidate it. The one await
-        # that can intervene is the physical-clearance gate below, and a
-        # policy with no coupled entities returns from it without ever
-        # suspending; a policy that does suspend is waiting on ANOTHER
-        # entity's travel, not on this one's `supported_features`, which is
-        # all `_plan` is derived from.
+        # docstring), and nothing between this line and its use by this gate
+        # can invalidate it.
+        #
+        # TWO awaits can intervene between here and the dispatch call further
+        # down, and they are treated differently on purpose:
+        #
+        # - The physical-clearance gate below is safe to reuse `_plan` across: a
+        #   policy with no coupled entities returns from it without ever
+        #   suspending, and a policy that does suspend is waiting on ANOTHER
+        #   entity's travel, not on this one's `supported_features`, which is
+        #   all `_plan` is derived from.
+        # - The command-queue wait (issue #1189) is NOT. It can last tens of
+        #   seconds while unrelated covers transmit, which is ample time for
+        #   this entity to reload with different capabilities. So the queued
+        #   path re-derives `_caps_for_plan`/`_plan` immediately after its wait
+        #   rather than reusing what was computed here.
         _caps_for_plan = self.get_cover_capabilities(entity_id)
         _axis_for_plan = self._policy.select_default_axis(_caps_for_plan)
         _plan = route_service_call(
@@ -2072,12 +2096,91 @@ class CoverCommandService:
                 current_position=_current,
             )
 
+        # ----- command-queue gate (issue #1189) -----
+        # Take this cover's turn on its named dispatch queue, so covers sharing
+        # a one-way radio never key a frame at the same moment. Unqueued covers
+        # — the overwhelming majority — return from the helper without
+        # suspending, which is what makes "zero regression for the 99%" a
+        # property of the code rather than an aspiration.
+        #
+        # Placement is load-bearing in BOTH directions, and neither boundary is
+        # a matter of taste:
+        #
+        # - AFTER ``await_dispatch_clearance`` above, or Model C day/night
+        #   DEADLOCKS (issue #1115): the middle rail would hold the queue slot
+        #   while waiting for the bottom rail, and the bottom rail could not
+        #   acquire the slot to transmit. The clearance gate's own timeout would
+        #   eventually break it — after a spurious ``policy_deferred`` skip on
+        #   every raise.
+        # - BEFORE ``_prepare_service_call`` below, because that call BOOKS the
+        #   command: ``sent_at`` (which ``_check_time_delta`` reads — issue
+        #   #853), ``waiting``, and the 5 s command grace window (issue #1139,
+        #   whose reporter measured backend queue waits of 10.6 / 20.9 / 33.7 s
+        #   — 2× to 7× that window). A wait placed after the booking would start
+        #   both clocks at DECISION time, silently shortening the min-interval
+        #   cooldown and landing every queued command outside its own grace
+        #   window. Booking after the wait means both clock from real transmit
+        #   time and #1139 is untouched.
+        #
+        # ``dispatch_token`` was captured above, before either await, for the
+        # documented reason that a policy's per-cycle view can be restated
+        # across one — so #1115's provenance rule holds unchanged with a second
+        # await here (#1138).
+        _proceed, _queue_grant = await self._acquire_queue_slot(
+            entity_id,
+            head_of_line=context.is_safety or context.user_command,
+        )
+        if not _proceed:
+            # A newer decision for this same entity took our place while we
+            # waited. Skipping is the point: transmitting now would put a
+            # 20-second-stale target on the air.
+            return self._skip(
+                entity_id,
+                "superseded_in_queue",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=_current,
+            )
+        if _queue_grant is not None:
+            # Two staleness mitigations, both consequences of the wait above:
+            #
+            # The cover may have gone away while we waited. Nothing has been
+            # booked yet, so this is a clean skip with nothing to unwind — the
+            # same reason the clearance gate sits ahead of the booking.
+            if self.is_entity_unavailable(entity_id):
+                self._release_queue_slot(entity_id, _queue_grant, transmitted=False)
+                return self._skip(
+                    entity_id,
+                    "cover_unavailable",
+                    position,
+                    trigger=_trigger,
+                    inverse_state=_inverse,
+                    current_position=_current,
+                )
+            # And the routing decision is re-derived rather than reused. The
+            # comment where `_plan` is first built enumerates the ONE await that
+            # could intervene; the queue wait is a second, and unlike the
+            # clearance gate it can last tens of seconds — long enough for the
+            # entity to reload with a different `supported_features`.
+            _caps_for_plan = self.get_cover_capabilities(entity_id)
+            _axis_for_plan = self._policy.select_default_axis(_caps_for_plan)
+            _plan = route_service_call(
+                entity_id,
+                position,
+                _caps_for_plan,
+                axis=_axis_for_plan,
+                use_my_position=context.use_my_position,
+                open_close_threshold=self._open_close_threshold,
+                endpoint_use_open_close=self._endpoint_use_open_close,
+            )
+
         # ----- send command -----
         # Reuses _caps_for_plan/_plan from the gate above (issue #1095 audit
         # finding 5) instead of a fresh get_cover_capabilities +
         # route_service_call — safe for the reason spelled out where `_plan` is
-        # built: nothing that can intervene between there and here changes this
-        # entity's capabilities.
+        # built, and re-derived just above on the one path (a queue wait) where
+        # that reasoning no longer holds.
         service, service_data, supports_position = self._prepare_service_call(
             entity_id,
             position,
@@ -2089,6 +2192,7 @@ class CoverCommandService:
             dispatch_token=dispatch_token,
         )
         if service is None:
+            self._release_queue_slot(entity_id, _queue_grant, transmitted=False)
             return self._skip(
                 entity_id,
                 "no_capable_service",
@@ -2127,64 +2231,87 @@ class CoverCommandService:
             position,
         )
 
-        # Cover-type policy hook: dual-axis covers (venetian) pre-send tilt
-        # on opening transitions so the actuator's slats are at the target
-        # angle before the carriage starts moving (issue #33). Default
-        # policies are no-ops. Pure SIDE EFFECT — the go/no-go decision was
-        # settled by ``await_dispatch_clearance`` above, before anything about
-        # this command was recorded.
-        if context.policy is not None:
-            await context.policy.before_position_command(
-                self,
-                entity_id,
-                service=service,
-                position=position,
-                context=context,
-                reason=reason,
-            )
-
-        ctx = Context()
-        self._position_context_tracker.record(ctx.id)
+        # Everything from here to the position service call runs INSIDE the
+        # queue slot, and the ``finally`` hands it back the moment that call
+        # returns. Deliberately narrow: the venetian settle+tilt tail in
+        # ``after_position_command`` below can take seconds, and holding the
+        # slot across it would starve every other cover on the queue. Its tilt
+        # frame then transmits inside its OWN cover's gap window, which is not a
+        # cross-cover collision.
         try:
-            await self._hass.services.async_call(
-                COVER_DOMAIN, service, service_data, context=ctx
-            )
-        except HomeAssistantError as err:
-            self._logger.warning(
-                "Service call %s.%s failed for %s: %s",
-                COVER_DOMAIN,
-                service,
-                entity_id,
-                err,
-            )
-            # The target was booked (with ``waiting``) before the call, because
-            # a command normally IS in flight by the time control reaches here.
-            # This one demonstrably is not, and leaving the flag set claims a
-            # motion nobody can observe ending: the transit-timeout backstop
-            # holds it for ~45 s, during which a physically coupled cover type
-            # reads it as "the partner rail is on its way" and releases a
-            # follower into a rail that never moved.
-            #
-            # The TARGET is deliberately kept, but NOT because anything is
-            # guaranteed to resend it — ``run_reconciliation_pass`` is gated on
-            # ``enable_position_matching``, which defaults OFF (#591), so on a
-            # default install nothing does. It is kept because it is still the
-            # honest record of what this entity was last asked for: the delta
-            # gates, the diagnostics and a later resend all read it, and
-            # dropping it would make ACP forget a command the user gave. Only
-            # the CLAIM OF MOTION is false here, so only that is withdrawn.
-            self.set_waiting(entity_id, False)
-            return self._skip(
-                entity_id,
-                "service_call_failed",
-                position,
-                trigger=_trigger,
-                inverse_state=_inverse,
-                current_position=_current,
-            )
+            # Cover-type policy hook: dual-axis covers (venetian) pre-send tilt
+            # on opening transitions so the actuator's slats are at the target
+            # angle before the carriage starts moving (issue #33). Default
+            # policies are no-ops. Pure SIDE EFFECT — the go/no-go decision was
+            # settled by ``await_dispatch_clearance`` above, before anything
+            # about this command was recorded. Inside the slot because on a
+            # venetian it is itself a transmission.
+            if context.policy is not None:
+                await context.policy.before_position_command(
+                    self,
+                    entity_id,
+                    service=service,
+                    position=position,
+                    context=context,
+                    reason=reason,
+                )
+
+            ctx = Context()
+            self._position_context_tracker.record(ctx.id)
+            try:
+                await self._hass.services.async_call(
+                    COVER_DOMAIN, service, service_data, context=ctx
+                )
+            except HomeAssistantError as err:
+                self._logger.warning(
+                    "Service call %s.%s failed for %s: %s",
+                    COVER_DOMAIN,
+                    service,
+                    entity_id,
+                    err,
+                )
+                # The target was booked (with ``waiting``) before the call,
+                # because a command normally IS in flight by the time control
+                # reaches here. This one demonstrably is not, and leaving the
+                # flag set claims a motion nobody can observe ending: the
+                # transit-timeout backstop holds it for ~45 s, during which a
+                # physically coupled cover type reads it as "the partner rail is
+                # on its way" and releases a follower into a rail that never
+                # moved.
+                #
+                # The TARGET is deliberately kept, but NOT because anything is
+                # guaranteed to resend it — ``run_reconciliation_pass`` is gated
+                # on ``enable_position_matching``, which defaults OFF (#591), so
+                # on a default install nothing does. It is kept because it is
+                # still the honest record of what this entity was last asked
+                # for: the delta gates, the diagnostics and a later resend all
+                # read it, and dropping it would make ACP forget a command the
+                # user gave. Only the CLAIM OF MOTION is false here, so only
+                # that is withdrawn.
+                self.set_waiting(entity_id, False)
+                return self._skip(
+                    entity_id,
+                    "service_call_failed",
+                    position,
+                    trigger=_trigger,
+                    inverse_state=_inverse,
+                    current_position=_current,
+                )
+        finally:
+            # Released with ``transmitted=True`` even on the failure path: HA
+            # raising does not prove the backend never keyed the radio, and
+            # claiming the air was free when it may not have been is the one
+            # error this feature exists to avoid. The gap is cheap; a collision
+            # is not.
+            self._release_queue_slot(entity_id, _queue_grant, transmitted=True)
 
         self._track_action(
-            entity_id, service, position, supports_position, context.inverse_state
+            entity_id,
+            service,
+            position,
+            supports_position,
+            context.inverse_state,
+            queue_grant=_queue_grant,
         )
 
         # Anti-relay latch bookkeeping (#897/#507). Arm the latch to the forced
@@ -2210,6 +2337,85 @@ class CoverCommandService:
             )
 
         return "sent", service
+
+    # ------------------------------------------------------------------ #
+    # Command-queue slot (issue #1189)
+    #
+    # ONE acquire and ONE release, shared by every seam that transmits a
+    # position: the main dispatch in ``apply_position`` and the reconciliation
+    # resend in ``_execute_command``. Mirroring the acquire/release pair per
+    # call site is exactly how one of them ends up forgetting to release.
+    # ------------------------------------------------------------------ #
+
+    async def _acquire_queue_slot(
+        self, entity_id: str, *, head_of_line: bool
+    ) -> tuple[bool, QueueGrant | None]:
+        """Take this entity's turn on its command queue, if it has one.
+
+        Returns ``(proceed, grant)``.
+
+        ``proceed`` is False in exactly one case — a newer reservation for the
+        SAME entity superseded this one while it waited — and the caller must
+        then record a ``superseded_in_queue`` skip having booked nothing.
+
+        ``grant`` is None both when there is no queue and on the dry-run path,
+        so the release below is a no-op there. A dry run is skipped
+        deliberately: it sends nothing, so taking a turn would make a simulated
+        cycle delay every real one.
+
+        An unqueued cover never suspends here — this coroutine returns without
+        awaiting anything — which is what keeps its dispatch path identical to
+        the behaviour before the queue existed.
+        """
+        if self._queue is None or self._dry_run:
+            return True, None
+        grant = await self._queue.acquire(
+            entity_id,
+            head_of_line=head_of_line,
+            budget=COMMAND_QUEUE_MAX_WAIT_SECONDS,
+        )
+        if grant is None:
+            return False, None
+        return True, grant
+
+    def _queue_diagnostic_fields(self, grant: QueueGrant | None) -> dict:
+        """Return the four per-dispatch queue fields, or ``{}`` when unqueued.
+
+        "Why did this cover move eight seconds late" is the question this
+        feature creates, and it needs an answer in the data rather than in a
+        log guess. ``waited_seconds`` is exactly ``0.0`` when nothing was
+        awaited, which is what makes ``immediate`` a fact rather than a
+        threshold.
+        """
+        if self._queue is None or grant is None:
+            return {}
+        if grant.budget_expired:
+            outcome = "budget_expired"
+        elif grant.waited_seconds > 0.0:
+            outcome = "waited"
+        else:
+            outcome = "immediate"
+        return {
+            "queue_name": self._queue.name,
+            # THIS dispatch's own wait, not the whole gap: the spacing clock
+            # started at the previous transmit, so the sleep taken here is the
+            # remainder of it.
+            "queue_wait_seconds": round(grant.waited_seconds, 3),
+            "queue_outcome": outcome,
+            "queue_depth_at_enqueue": grant.depth_at_enqueue,
+        }
+
+    def _release_queue_slot(
+        self, entity_id: str, grant: QueueGrant | None, *, transmitted: bool
+    ) -> None:
+        """Hand the queue slot back. No-op for an unqueued or dry-run dispatch.
+
+        ``transmitted`` is what starts the gap: a command that never went out
+        owes the next member nothing, so a withheld dispatch must not make
+        everyone else wait for air that was never used.
+        """
+        if grant is not None and self._queue is not None:
+            self._queue.release(entity_id, transmitted=transmitted)
 
     # ------------------------------------------------------------------ #
     # Position-tolerance helpers
@@ -2972,37 +3178,55 @@ class CoverCommandService:
         NB: callers are responsible for entity-loaded-ness. Reconciliation only
         runs for entities that already passed the cover_unavailable gate in
         ``apply_position`` (issue #342), so no duplicate gate is needed here.
+
+        A resend is a transmission like any other, so it takes its turn on the
+        command queue too (issue #1189) — through the SAME acquire/release pair
+        ``apply_position`` uses, and ahead of ``_prepare_service_call`` for the
+        same reason: that call books ``sent_at`` and the grace window, both of
+        which must clock from the real transmit time. It queues in the ROUTINE
+        tier: a retry of a command that already had its chance has no claim on
+        the head of the line ahead of a fresh safety decision.
         """
-        service, service_data, _ = self._prepare_service_call(
-            entity_id,
-            target,
-            reset_retries=False,
-            dispatch_token=dispatch_token,
-        )
-        if service is None:
+        proceed, grant = await self._acquire_queue_slot(entity_id, head_of_line=False)
+        if not proceed:
+            # A live dispatch for this entity replaced our reservation; it
+            # carries a fresher target than this resend does.
             return
-        if self._dry_run:
-            self._logger.info(
-                "[dry_run] reconciliation would send cover.%s %s → %s%%",
-                service,
+        transmitted = False
+        try:
+            service, service_data, _ = self._prepare_service_call(
                 entity_id,
                 target,
+                reset_retries=False,
+                dispatch_token=dispatch_token,
             )
-            return
-        ctx = Context()
-        self._position_context_tracker.record(ctx.id)
-        try:
-            await self._hass.services.async_call(
-                COVER_DOMAIN, service, service_data, context=ctx
-            )
-        except HomeAssistantError as err:
-            self._logger.warning(
-                "Reconciliation service call %s.%s failed for %s: %s",
-                COVER_DOMAIN,
-                service,
-                entity_id,
-                err,
-            )
+            if service is None:
+                return
+            if self._dry_run:
+                self._logger.info(
+                    "[dry_run] reconciliation would send cover.%s %s → %s%%",
+                    service,
+                    entity_id,
+                    target,
+                )
+                return
+            ctx = Context()
+            self._position_context_tracker.record(ctx.id)
+            transmitted = True
+            try:
+                await self._hass.services.async_call(
+                    COVER_DOMAIN, service, service_data, context=ctx
+                )
+            except HomeAssistantError as err:
+                self._logger.warning(
+                    "Reconciliation service call %s.%s failed for %s: %s",
+                    COVER_DOMAIN,
+                    service,
+                    entity_id,
+                    err,
+                )
+        finally:
+            self._release_queue_slot(entity_id, grant, transmitted=transmitted)
 
     def _track_action(
         self,
@@ -3025,6 +3249,7 @@ class CoverCommandService:
         pipeline_bypass_auto_control: bool | None = None,
         decision_trace_at_call: list | None = None,
         gates_evaluated: dict | None = None,
+        queue_grant: QueueGrant | None = None,
     ) -> None:
         """Update last_cover_action diagnostic dict and record to event buffer."""
         self._diag.record_action(
@@ -3050,4 +3275,5 @@ class CoverCommandService:
             pipeline_bypass_auto_control=pipeline_bypass_auto_control,
             decision_trace_at_call=decision_trace_at_call,
             gates_evaluated=gates_evaluated,
+            queue_fields=self._queue_diagnostic_fields(queue_grant),
         )

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -2142,110 +2142,126 @@ class CoverCommandService:
                 inverse_state=_inverse,
                 current_position=_current,
             )
-        if _queue_grant is not None:
-            # Two staleness mitigations, both consequences of the wait above:
-            #
-            # The cover may have gone away while we waited. Nothing has been
-            # booked yet, so this is a clean skip with nothing to unwind — the
-            # same reason the clearance gate sits ahead of the booking.
-            if self.is_entity_unavailable(entity_id):
-                self._release_queue_slot(entity_id, _queue_grant, transmitted=False)
+        # Everything from the grant to the position service call runs INSIDE the
+        # queue slot, and the single ``finally`` below hands it back on EVERY
+        # path out — the early skips, an exception, and an outright task
+        # cancellation alike. One acquire, one release: a second release for the
+        # same dispatch would hand the NEXT member's slot away, and a missed one
+        # strands the slot until this entity happens to dispatch again, at which
+        # point every other member burns its whole budget before transmitting —
+        # unspaced and simultaneous, the exact collision this feature prevents.
+        #
+        # Deliberately narrow at the far end: the venetian settle+tilt tail in
+        # ``after_position_command`` below waits for a physical rail (capped at
+        # ``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS`` = 60 s) before it keys its
+        # tilt frame, so holding the slot across it would starve every other
+        # cover on the queue — and issue #1115's day/night guard depends on the
+        # tail NOT holding it. The tail therefore reports its own frame to the
+        # queue instead (``mark_external_transmit``, from ``_send_tilt_command``)
+        # so the next member spaces against it rather than keying on top of it.
+        _transmitted = False
+        try:
+            if _queue_grant is not None:
+                # Two staleness mitigations, both consequences of the wait above:
+                #
+                # The cover may have gone away while we waited. Nothing has been
+                # booked yet, so this is a clean skip with nothing to unwind —
+                # the same reason the clearance gate sits ahead of the booking.
+                if self.is_entity_unavailable(entity_id):
+                    return self._skip(
+                        entity_id,
+                        "cover_unavailable",
+                        position,
+                        trigger=_trigger,
+                        inverse_state=_inverse,
+                        current_position=_current,
+                    )
+                # And the routing decision is re-derived rather than reused. The
+                # comment where `_plan` is first built enumerates the ONE await
+                # that could intervene; the queue wait is a second, and unlike
+                # the clearance gate it can last tens of seconds — long enough
+                # for the entity to reload with a different `supported_features`.
+                _caps_for_plan = self.get_cover_capabilities(entity_id)
+                _axis_for_plan = self._policy.select_default_axis(_caps_for_plan)
+                _plan = route_service_call(
+                    entity_id,
+                    position,
+                    _caps_for_plan,
+                    axis=_axis_for_plan,
+                    use_my_position=context.use_my_position,
+                    open_close_threshold=self._open_close_threshold,
+                    endpoint_use_open_close=self._endpoint_use_open_close,
+                )
+
+            # ----- send command -----
+            # Reuses _caps_for_plan/_plan from the gate above (issue #1095 audit
+            # finding 5) instead of a fresh get_cover_capabilities +
+            # route_service_call — safe for the reason spelled out where `_plan`
+            # is built, and re-derived just above on the one path (a queue wait)
+            # where that reasoning no longer holds.
+            service, service_data, supports_position = self._prepare_service_call(
+                entity_id,
+                position,
+                context.inverse_state,
+                caps=_caps_for_plan,
+                plan=_plan,
+                is_safety=context.is_safety,
+                use_my_position=context.use_my_position,
+                dispatch_token=dispatch_token,
+            )
+            if service is None:
                 return self._skip(
                     entity_id,
-                    "cover_unavailable",
+                    "no_capable_service",
                     position,
                     trigger=_trigger,
                     inverse_state=_inverse,
                     current_position=_current,
                 )
-            # And the routing decision is re-derived rather than reused. The
-            # comment where `_plan` is first built enumerates the ONE await that
-            # could intervene; the queue wait is a second, and unlike the
-            # clearance gate it can last tens of seconds — long enough for the
-            # entity to reload with a different `supported_features`.
-            _caps_for_plan = self.get_cover_capabilities(entity_id)
-            _axis_for_plan = self._policy.select_default_axis(_caps_for_plan)
-            _plan = route_service_call(
-                entity_id,
-                position,
-                _caps_for_plan,
-                axis=_axis_for_plan,
-                use_my_position=context.use_my_position,
-                open_close_threshold=self._open_close_threshold,
-                endpoint_use_open_close=self._endpoint_use_open_close,
-            )
 
-        # ----- send command -----
-        # Reuses _caps_for_plan/_plan from the gate above (issue #1095 audit
-        # finding 5) instead of a fresh get_cover_capabilities +
-        # route_service_call — safe for the reason spelled out where `_plan` is
-        # built, and re-derived just above on the one path (a queue wait) where
-        # that reasoning no longer holds.
-        service, service_data, supports_position = self._prepare_service_call(
-            entity_id,
-            position,
-            context.inverse_state,
-            caps=_caps_for_plan,
-            plan=_plan,
-            is_safety=context.is_safety,
-            use_my_position=context.use_my_position,
-            dispatch_token=dispatch_token,
-        )
-        if service is None:
-            self._release_queue_slot(entity_id, _queue_grant, transmitted=False)
-            return self._skip(
-                entity_id,
-                "no_capable_service",
-                position,
-                trigger=_trigger,
-                inverse_state=_inverse,
-                current_position=_current,
-            )
+            # ----- dry-run gate -----
+            if self._dry_run:
+                self._logger.info(
+                    "[dry_run] would send cover.%s %s → %s%%",
+                    service,
+                    entity_id,
+                    position,
+                )
+                self._track_action(
+                    entity_id,
+                    service,
+                    position,
+                    supports_position,
+                    context.inverse_state,
+                )
+                self._diag.last_cover_action["dry_run"] = True
+                return self._skip(
+                    entity_id,
+                    "dry_run",
+                    position,
+                    trigger=_trigger,
+                    inverse_state=_inverse,
+                    current_position=_current,
+                    extras={"would_send_service": service},
+                )
 
-        # ----- dry-run gate -----
-        if self._dry_run:
             self._logger.info(
-                "[dry_run] would send cover.%s %s → %s%%",
-                service,
+                "[%s] Positioning %s → %s%%",
+                reason,
                 entity_id,
                 position,
             )
-            self._track_action(
-                entity_id, service, position, supports_position, context.inverse_state
-            )
-            self._diag.last_cover_action["dry_run"] = True
-            return self._skip(
-                entity_id,
-                "dry_run",
-                position,
-                trigger=_trigger,
-                inverse_state=_inverse,
-                current_position=_current,
-                extras={"would_send_service": service},
-            )
 
-        self._logger.info(
-            "[%s] Positioning %s → %s%%",
-            reason,
-            entity_id,
-            position,
-        )
-
-        # Everything from here to the position service call runs INSIDE the
-        # queue slot, and the ``finally`` hands it back the moment that call
-        # returns. Deliberately narrow: the venetian settle+tilt tail in
-        # ``after_position_command`` below can take seconds, and holding the
-        # slot across it would starve every other cover on the queue. Its tilt
-        # frame then transmits inside its OWN cover's gap window, which is not a
-        # cross-cover collision.
-        try:
             # Cover-type policy hook: dual-axis covers (venetian) pre-send tilt
             # on opening transitions so the actuator's slats are at the target
             # angle before the carriage starts moving (issue #33). Default
             # policies are no-ops. Pure SIDE EFFECT — the go/no-go decision was
             # settled by ``await_dispatch_clearance`` above, before anything
             # about this command was recorded. Inside the slot because on a
-            # venetian it is itself a transmission.
+            # venetian it is itself a transmission — and that frame reports
+            # itself to the queue, so an exception raised here still leaves the
+            # spacing honest without this dispatch having to claim a position
+            # frame it never sent.
             if context.policy is not None:
                 await context.policy.before_position_command(
                     self,
@@ -2258,6 +2274,13 @@ class CoverCommandService:
 
             ctx = Context()
             self._position_context_tracker.record(ctx.id)
+            # Set BEFORE the await, so the release below reports a transmission
+            # on the failure path too: HA raising — or the task being cancelled
+            # mid-call — does not prove the backend never keyed the radio, and
+            # claiming the air was free when it may not have been is the one
+            # error this feature exists to avoid. The gap is cheap; a collision
+            # is not.
+            _transmitted = True
             try:
                 await self._hass.services.async_call(
                     COVER_DOMAIN, service, service_data, context=ctx
@@ -2298,12 +2321,7 @@ class CoverCommandService:
                     current_position=_current,
                 )
         finally:
-            # Released with ``transmitted=True`` even on the failure path: HA
-            # raising does not prove the backend never keyed the radio, and
-            # claiming the air was free when it may not have been is the one
-            # error this feature exists to avoid. The gap is cheap; a collision
-            # is not.
-            self._release_queue_slot(entity_id, _queue_grant, transmitted=True)
+            self._release_queue_slot(_queue_grant, transmitted=_transmitted)
 
         self._track_action(
             entity_id,
@@ -2348,15 +2366,19 @@ class CoverCommandService:
     # ------------------------------------------------------------------ #
 
     async def _acquire_queue_slot(
-        self, entity_id: str, *, head_of_line: bool
+        self, entity_id: str, *, head_of_line: bool, resend: bool = False
     ) -> tuple[bool, QueueGrant | None]:
         """Take this entity's turn on its command queue, if it has one.
 
         Returns ``(proceed, grant)``.
 
-        ``proceed`` is False in exactly one case — a newer reservation for the
-        SAME entity superseded this one while it waited — and the caller must
-        then record a ``superseded_in_queue`` skip having booked nothing.
+        ``proceed`` is False when this reservation lost its place to a fresher
+        decision for the SAME entity, and the caller must then record a
+        ``superseded_in_queue`` skip having booked nothing. ``resend=True``
+        marks a reconciliation re-booking, which additionally STANDS DOWN for a
+        live dispatch already waiting on this entity rather than displacing it:
+        the resend carries the older number, and evicting the newer one would
+        put a stale frame on a one-way radio.
 
         ``grant`` is None both when there is no queue and on the dry-run path,
         so the release below is a no-op there. A dry run is skipped
@@ -2369,6 +2391,8 @@ class CoverCommandService:
         """
         if self._queue is None or self._dry_run:
             return True, None
+        if resend and self._queue.defers_to_pending(entity_id):
+            return False, None
         grant = await self._queue.acquire(
             entity_id,
             head_of_line=head_of_line,
@@ -2405,17 +2429,37 @@ class CoverCommandService:
             "queue_depth_at_enqueue": grant.depth_at_enqueue,
         }
 
+    def mark_queue_external_transmit(self) -> None:
+        """Tell the command queue about a frame the slot did not gate.
+
+        The counterpart to :meth:`_release_queue_slot` for transmissions that
+        deliberately run outside a slot: a stop (interactive, must not wait out
+        someone else's gap) and the dual-axis tilt tail (waits on a physical
+        rail for up to a minute, so holding the slot across it would starve the
+        queue). Both still key the radio, so both report it and the NEXT queued
+        member spaces against them instead of assuming the air was free.
+
+        No-op for an unqueued instance, which is what lets the transmitting
+        code call it unconditionally.
+        """
+        if self._queue is not None:
+            self._queue.mark_external_transmit()
+
     def _release_queue_slot(
-        self, entity_id: str, grant: QueueGrant | None, *, transmitted: bool
+        self, grant: QueueGrant | None, *, transmitted: bool
     ) -> None:
         """Hand the queue slot back. No-op for an unqueued or dry-run dispatch.
 
         ``transmitted`` is what starts the gap: a command that never went out
         owes the next member nothing, so a withheld dispatch must not make
         everyone else wait for air that was never used.
+
+        Keyed on the GRANT, never on the entity id: two acquisitions for one
+        entity can be live at once, and only the grant knows which of them
+        actually holds the slot.
         """
         if grant is not None and self._queue is not None:
-            self._queue.release(entity_id, transmitted=transmitted)
+            self._queue.release(grant, transmitted=transmitted)
 
     # ------------------------------------------------------------------ #
     # Position-tolerance helpers
@@ -3185,12 +3229,17 @@ class CoverCommandService:
         same reason: that call books ``sent_at`` and the grace window, both of
         which must clock from the real transmit time. It queues in the ROUTINE
         tier: a retry of a command that already had its chance has no claim on
-        the head of the line ahead of a fresh safety decision.
+        the head of the line ahead of a fresh safety decision. It also queues as
+        a ``resend``, which is the direction on the supersede rule: it yields to
+        a live dispatch already waiting on this entity instead of evicting it,
+        because the number it re-books is by definition the older one.
         """
-        proceed, grant = await self._acquire_queue_slot(entity_id, head_of_line=False)
+        proceed, grant = await self._acquire_queue_slot(
+            entity_id, head_of_line=False, resend=True
+        )
         if not proceed:
-            # A live dispatch for this entity replaced our reservation; it
-            # carries a fresher target than this resend does.
+            # A live dispatch for this entity holds — or is waiting for — this
+            # entity's place, and it carries a fresher target than this resend.
             return
         transmitted = False
         try:
@@ -3226,7 +3275,7 @@ class CoverCommandService:
                     err,
                 )
         finally:
-            self._release_queue_slot(entity_id, grant, transmitted=transmitted)
+            self._release_queue_slot(grant, transmitted=transmitted)
 
     def _track_action(
         self,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Iterable, Iterator
+from time import monotonic
 from typing import Any
 
 from homeassistant.components.cover.const import DOMAIN as COVER_DOMAIN
@@ -18,6 +19,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from ...const import (
     COMMAND_QUEUE_MAX_WAIT_SECONDS,
+    COMMAND_QUEUE_PASS_BUDGET_FRACTION,
     DEFAULT_ENDPOINT_USE_OPEN_CLOSE,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     MAX_POSITION_RETRIES,
@@ -2366,7 +2368,12 @@ class CoverCommandService:
     # ------------------------------------------------------------------ #
 
     async def _acquire_queue_slot(
-        self, entity_id: str, *, head_of_line: bool, resend: bool = False
+        self,
+        entity_id: str,
+        *,
+        head_of_line: bool,
+        resend: bool = False,
+        budget: float = COMMAND_QUEUE_MAX_WAIT_SECONDS,
     ) -> tuple[bool, QueueGrant | None]:
         """Take this entity's turn on its command queue, if it has one.
 
@@ -2376,21 +2383,14 @@ class CoverCommandService:
         decision for the SAME entity, and the caller must then record a
         ``superseded_in_queue`` skip having booked nothing.
 
-        ``resend=True`` marks a reconciliation re-booking, and changes the
-        acquisition in two ways, both because that pass IS the retry loop:
-
-        * It STANDS DOWN for a live dispatch already waiting on this entity
-          rather than displacing it — the resend carries the older number, and
-          evicting the newer one would put a stale frame on a one-way radio.
-        * It never waits (``wait=False``). A resend that blocked would hold the
-          pass open per entity for the full ``COMMAND_QUEUE_MAX_WAIT_SECONDS``
-          against a one-minute interval that HA re-arms before dispatching each
-          fire, so overlapping passes would mutate the same per-entity state —
-          the same overlap the ``wait=False`` clearance gate in
-          ``run_reconciliation_pass`` exists to prevent, reached by a different
-          road. Standing down costs nothing: the next pass re-asks, and it does
-          not burn a retry because the pass reads
-          :meth:`_resend_stands_down` before counting one.
+        ``resend=True`` marks a reconciliation re-booking. It changes the
+        acquisition in one way and one way only: the resend STANDS DOWN for a
+        live dispatch already waiting on this entity rather than displacing it,
+        because the resend carries the older number and evicting the newer one
+        would put a stale frame on a one-way radio. It otherwise queues and
+        waits exactly like a dispatch — what keeps the pass bounded is
+        ``budget``, which the pass sizes from what is left of its OWN
+        allowance, not a refusal to wait at all.
 
         ``grant`` is None both when there is no queue and on the dry-run path,
         so the release below is a no-op there. A dry run is skipped
@@ -2403,39 +2403,64 @@ class CoverCommandService:
         """
         if self._queue is None or self._dry_run:
             return True, None
-        # The SAME predicate the reconciliation pass reads before it counts a
-        # retry, not a second copy of the rule — the two must never disagree
-        # about whether this resend goes out. ``wait=not resend`` below is the
-        # structural backstop that keeps the non-blocking half true even for a
-        # caller that never asked.
-        if resend and self._resend_stands_down(entity_id):
+        # The SAME predicate the reconciliation pass reads, not a second copy of
+        # the rule — the two must never disagree about whether this resend even
+        # attempts its turn. Re-asserted here so the guarantee holds for every
+        # caller of this seam, including one that never asked.
+        if resend and self._resend_stands_down(entity_id, budget=budget):
             return False, None
         grant = await self._queue.acquire(
             entity_id,
             head_of_line=head_of_line,
-            budget=COMMAND_QUEUE_MAX_WAIT_SECONDS,
-            wait=not resend,
+            budget=budget,
         )
         if grant is None:
             return False, None
         return True, grant
 
-    def _resend_stands_down(self, entity_id: str) -> bool:
+    def _resend_stands_down(self, entity_id: str, *, budget: float) -> bool:
         """Whether a reconciliation resend for this entity would yield its turn.
 
-        Asked by the pass BEFORE the retry is counted, for exactly the reason
-        the clearance gate above it is: a resend that is never transmitted must
-        not burn one of the pass's attempts, or repeated stand-downs reach
-        ``gave_up`` and warn "max retries exceeded" about a cover that was
-        never resent. With the resend now non-blocking that is the ordinary
-        case on a busy queue rather than a corner one.
+        ``budget`` is what remains of the pass's own wait allowance. Standing
+        down means "this turn costs more than the pass can still afford", NOT
+        "the queue is not idle this instant" — the spacing a pass's own previous
+        resend started is exactly the wait it should be willing to sit out, and
+        treating it as a refusal is what limited a pass to a single frame.
+
+        Advisory. The pass asks it to avoid entering a wait it cannot pay for;
+        whether a retry was consumed is decided by what ``_execute_command``
+        reports afterwards, so this reading going stale during the wait costs
+        nothing.
 
         Unqueued and dry-run instances never stand down, so the pass behaves
         exactly as it did before the queue existed.
         """
         if self._queue is None or self._dry_run:
             return False
-        return self._queue.resend_stands_down(entity_id)
+        return self._queue.resend_stands_down(entity_id, budget=budget)
+
+    def _reconciliation_queue_budget(self) -> float:
+        """Total seconds one reconciliation pass may spend waiting on the queue.
+
+        A fraction of the pass's OWN interval, so a user who slows reconciliation
+        down gets proportionally more room rather than the same fixed sliver.
+        The remainder of the interval is deliberate slack: the transmissions
+        themselves happen outside this allowance, and a pass must still finish
+        before the next one starts.
+        """
+        return self._check_interval_minutes * 60.0 * COMMAND_QUEUE_PASS_BUDGET_FRACTION
+
+    def _resend_wait_allowance(self, deadline: float) -> float:
+        """Cap one resend's wait at the pass's remainder and the per-command ceiling.
+
+        Two ceilings, because they bound different failures. ``deadline`` is the
+        pass's own overlap guard — the whole pass, summed across every entity it
+        resends. ``COMMAND_QUEUE_MAX_WAIT_SECONDS`` is the per-command bounded-wait
+        invariant, which still applies to each acquisition individually: a pass
+        running on a 30-minute interval must not let one entity sit in the queue
+        for a quarter of an hour just because its allowance would permit it.
+        """
+        return min(max(0.0, deadline - monotonic()), COMMAND_QUEUE_MAX_WAIT_SECONDS)
 
     def _queue_diagnostic_fields(self, grant: QueueGrant | None) -> dict:
         """Return the four per-dispatch queue fields, or ``{}`` when unqueued.
@@ -2681,6 +2706,14 @@ class CoverCommandService:
         # before its middle rail, which cannot physically travel past it.
         # Identity for every cover type whose entities are independent.
         recorded = dict(self.iter_targets())
+        # The pass's own overlap guard (issue #1189). One allowance for the whole
+        # pass, spent across every entity it resends, rather than a fresh
+        # per-entity ceiling: N entities each entitled to
+        # COMMAND_QUEUE_MAX_WAIT_SECONDS is N x 30 s against a 60 s interval, and
+        # HA re-arms that interval listener before dispatching each fire as its
+        # own background task — so an unbounded pass is still running when the
+        # next one starts and the two mutate the same ``PerEntityState``.
+        queue_deadline = monotonic() + self._reconciliation_queue_budget()
         for entity_id in self._policy.order_for_dispatch(recorded):
             target = recorded[entity_id]
             s = self.state(entity_id)
@@ -2893,25 +2926,60 @@ class CoverCommandService:
                 )
                 continue
 
-            # 10. The command queue's stand-down (issue #1189), asked HERE for
-            # the same two reasons the clearance gate above it is.
+            # 10. The command queue (issue #1189). Unlike the clearance gate
+            # above, this is NOT a refusal to wait — a resend takes its turn and
+            # sits out the spacing like any other transmission, which is what
+            # lets one pass reconcile every off-target cover it owns instead of
+            # only the first. What is bounded is the pass, not the entity: each
+            # resend may spend what is left of ``queue_deadline``, so N covers
+            # cost N gaps in total and the pass still finishes inside its own
+            # interval.
             #
-            # Before the count: a resend that never reaches the wire must not
-            # burn one of the pass's three attempts. Repeated stand-downs would
-            # otherwise reach ``gave_up`` and log "max retries exceeded" about a
-            # cover that was never resent — and on a saturated queue standing
-            # down is the ordinary outcome, not a corner case.
-            #
-            # Without waiting: ``_execute_command`` acquires with ``wait=False``,
-            # so the answer here is the answer it will get. A resend that
-            # blocked for the queue's 30 s budget per entity would leave this
-            # pass running into the next one — HA re-arms the interval listener
-            # before dispatching each fire as its own task — and the two would
-            # mutate the same ``PerEntityState``.
-            if self._resend_stands_down(entity_id):
+            # Asked before the acquisition purely to avoid entering a wait the
+            # pass cannot pay for. It is not what protects the retry counter —
+            # that is the ``_execute_command`` return below, which reports what
+            # actually happened rather than what this reading predicted.
+            wait_allowance = self._resend_wait_allowance(queue_deadline)
+            if self._resend_stands_down(entity_id, budget=wait_allowance):
                 self._logger.debug(
-                    "Reconcile: %s stood down for the command queue — the slot "
-                    "is not free and this pass must not block on it",
+                    "Reconcile: %s stood down for the command queue — its turn "
+                    "costs more than the %.1fs this pass has left to spend",
+                    entity_id,
+                    wait_allowance,
+                )
+                if self._event_buffer is not None:
+                    self._event_buffer.record(
+                        {
+                            "ts": dt.datetime.now(dt.UTC).isoformat(),
+                            "event": "reconcile_queue_stood_down",
+                            "entity_id": entity_id,
+                            "actual_position": actual,
+                            "target_position": resend_target,
+                            "queue_wait_allowance": round(wait_allowance, 3),
+                            "queue_projected_wait": (
+                                round(self._queue.projected_wait_seconds(), 3)
+                                if self._queue is not None
+                                else 0.0
+                            ),
+                        }
+                    )
+                continue
+
+            # Counted AFTER the fact, on what the resend reports. It has to be:
+            # the acquisition suspends, so no reading taken before it can promise
+            # the frame goes out, and a stand-down that burned an attempt would
+            # reach ``gave_up`` and warn "max retries exceeded" about a cover
+            # that was never resent. Every outcome except a queue withhold counts
+            # — including a dry run, which would otherwise never give up.
+            if not await self._execute_command(
+                entity_id,
+                resend_target,
+                dispatch_token=resend_token,
+                queue_budget=wait_allowance,
+            ):
+                self._logger.debug(
+                    "Reconcile: %s withheld by the command queue after waiting "
+                    "— no retry counted",
                     entity_id,
                 )
                 continue
@@ -2924,9 +2992,6 @@ class CoverCommandService:
                 resend_target,
                 s.retry_count,
                 self._max_retries,
-            )
-            await self._execute_command(
-                entity_id, resend_target, dispatch_token=resend_token
             )
 
     # ------------------------------------------------------------------ #
@@ -3261,9 +3326,24 @@ class CoverCommandService:
         return plan.service, plan.service_data, plan.supports_position
 
     async def _execute_command(
-        self, entity_id: str, target: int, *, dispatch_token: Any = None
-    ) -> None:
+        self,
+        entity_id: str,
+        target: int,
+        *,
+        dispatch_token: Any = None,
+        queue_budget: float = COMMAND_QUEUE_MAX_WAIT_SECONDS,
+    ) -> bool:
         """Send command directly, bypassing gate checks (reconciliation use only).
+
+        Returns whether this call consumed an ATTEMPT — True for every outcome
+        that reached the send decision (including a dry run and a service call
+        that raised), False only when the command queue withheld the resend
+        before anything was booked. ``run_reconciliation_pass`` counts its retry
+        on that answer rather than on a prediction made before the acquisition,
+        because the acquisition suspends: no reading taken beforehand can promise
+        the frame goes out, and an attempt burned by a withheld resend reaches
+        ``gave_up`` and warns "max retries exceeded" about a cover that was never
+        resent.
 
         Does NOT reset the retry count — the caller
         (``run_reconciliation_pass``) owns that.
@@ -3287,27 +3367,23 @@ class CoverCommandService:
         same reason: that call books ``sent_at`` and the grace window, both of
         which must clock from the real transmit time.
 
-        Unlike a live dispatch it never QUEUES for that turn: it acquires as a
-        ``resend``, which takes the slot only when it is free this instant and
-        otherwise stands down. Two consequences, both deliberate. It yields to a
-        live dispatch already waiting on this entity instead of evicting it,
-        because the number it re-books is by definition the older one. And it
-        cannot hold the reconciliation pass open — a blocking wait here would
-        cost up to ``COMMAND_QUEUE_MAX_WAIT_SECONDS`` per entity against a
-        one-minute interval HA re-arms before dispatching each fire, leaving
-        two passes running over one ``PerEntityState``. The next pass re-asks
-        in a minute; the pass exists to retry.
+        It acquires as a ``resend``, which differs from a live dispatch in one
+        respect: it yields to a live dispatch already WAITING on this entity
+        instead of evicting it, because the number it re-books is by definition
+        the older one. It otherwise queues and waits like any transmission —
+        ``queue_budget`` is what bounds it, and the caller sizes that from what
+        is left of the pass's own allowance so N resends cost N gaps in total
+        rather than N full clearance budgets.
         """
         proceed, grant = await self._acquire_queue_slot(
-            entity_id, head_of_line=False, resend=True
+            entity_id, head_of_line=False, resend=True, budget=queue_budget
         )
         if not proceed:
             # Either a live dispatch for this entity carries a fresher target,
-            # or the slot is not free right now. ``run_reconciliation_pass``
-            # already asked the same question through ``_resend_stands_down``
-            # and skipped without counting a retry; this is the seam that holds
-            # the rule for every caller.
-            return
+            # or the turn costs more than the caller's remaining allowance.
+            # Nothing was booked, so nothing has to be unwound — and the caller
+            # counts no attempt against this entity.
+            return False
         transmitted = False
         try:
             service, service_data, _ = self._prepare_service_call(
@@ -3317,7 +3393,7 @@ class CoverCommandService:
                 dispatch_token=dispatch_token,
             )
             if service is None:
-                return
+                return True
             if self._dry_run:
                 self._logger.info(
                     "[dry_run] reconciliation would send cover.%s %s → %s%%",
@@ -3325,7 +3401,7 @@ class CoverCommandService:
                     entity_id,
                     target,
                 )
-                return
+                return True
             ctx = Context()
             self._position_context_tracker.record(ctx.id)
             transmitted = True
@@ -3343,6 +3419,7 @@ class CoverCommandService:
                 )
         finally:
             self._release_queue_slot(grant, transmitted=transmitted)
+        return True
 
     def _track_action(
         self,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/diagnostics.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/diagnostics.py
@@ -151,6 +151,7 @@ class DiagnosticsRecorder:
         pipeline_bypass_auto_control: bool | None = None,
         decision_trace_at_call: list | None = None,
         gates_evaluated: dict | None = None,
+        queue_fields: dict | None = None,
     ) -> None:
         """Update last_cover_action and push a ``cover_command_sent`` event.
 
@@ -158,6 +159,10 @@ class DiagnosticsRecorder:
         ``PerEntityState.target`` for this entity — used as ``position`` in
         the snapshot when the cover lacks set_position (open/close routing
         records 0 or 100, not the requested state).
+
+        ``queue_fields`` carries the command-queue outcome for this dispatch
+        (issue #1189) and is merged in ONLY for a queued cover, so an unqueued
+        cover's record keeps exactly the shape it had before the queue existed.
         """
         ts = dt.datetime.now(dt.UTC).isoformat()
         position = state if supports_position else recorded_target
@@ -184,20 +189,23 @@ class DiagnosticsRecorder:
             "decision_trace_at_call": decision_trace_at_call,
             "gates_evaluated": gates_evaluated,
         }
+        if queue_fields:
+            self.last_cover_action.update(queue_fields)
         if self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": ts,
-                    "event": "cover_command_sent",
-                    "entity_id": entity,
-                    "service": service,
-                    "position": position,
-                    "calculated_position": state,
-                    "inverse_state_applied": inverse_state,
-                    "supports_position": supports_position,
-                    "trigger": trigger,
-                    "target_source": target_source,
-                    "force": force,
-                    "is_safety": is_safety,
-                }
-            )
+            event = {
+                "ts": ts,
+                "event": "cover_command_sent",
+                "entity_id": entity,
+                "service": service,
+                "position": position,
+                "calculated_position": state,
+                "inverse_state_applied": inverse_state,
+                "supports_position": supports_position,
+                "trigger": trigger,
+                "target_source": target_source,
+                "force": force,
+                "is_safety": is_safety,
+            }
+            if queue_fields:
+                event.update(queue_fields)
+            self._event_buffer.record(event)

--- a/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
@@ -224,18 +224,32 @@ class CommandQueue:
         """Remaining spacing owed before the next member may transmit."""
         return max(0.0, self._busy_until - monotonic())
 
-    def can_grant_now(self) -> bool:
-        """Whether a slot could be taken this instant with no waiting at all.
+    def projected_wait_seconds(self, *, head_of_line: bool = False) -> float:
+        """Seconds a reservation asking RIGHT NOW would wait before transmitting.
 
-        All three conditions, because any one of them is a wait: nobody holds
-        the slot, nobody is queued for it, and the air owes no spacing.
+        Zero means the slot is free, unqueued and the air owes nothing — the
+        only state in which a command goes out with no delay at all.
+
+        The estimate is the sum of three things a caller cannot see separately:
+        the spacing still owed by the air, one further gap if somebody holds the
+        slot (a holder has yet to transmit and start its own gap), and one gap
+        per reservation ahead of this one in the tiers it cannot jump.
+
+        This exists so a caller can decide whether a wait is AFFORDABLE, which
+        is a different question from whether it is zero. Folding the two — "not
+        free this instant" therefore "stand down" — is what made a reconciliation
+        pass emit at most one frame: the very spacing the pass's own first
+        resend started disqualified every remaining entity on the queue.
+        Spacing owed is bounded by ``gap_seconds`` and is largely the caller's
+        own doing; waiting it out is the entire point of the queue.
         """
-        return (
-            self._owner is None
-            and not self._head_waiters
-            and not self._routine_waiters
-            and self._busy_until <= monotonic()
-        )
+        ahead = len(self._head_waiters)
+        if not head_of_line:
+            ahead += len(self._routine_waiters)
+        wait = self.busy_for_seconds()
+        if self._owner is not None:
+            wait += self.gap_seconds
+        return wait + ahead * self.gap_seconds
 
     # ------------------------------------------------------------------ #
     # The slot
@@ -247,26 +261,21 @@ class CommandQueue:
         *,
         head_of_line: bool,
         budget: float,
-        wait: bool = True,
     ) -> QueueGrant | None:
         """Take the slot and wait out any spacing still owed.
 
         Returns ``None`` when this reservation was superseded by a newer one
-        for the same entity while it waited, or — with ``wait=False`` — when
-        the slot was not free to begin with. Every other outcome is a grant the
+        for the same entity while it waited. Every other outcome is a grant the
         caller must transmit on and then :meth:`release`, including the
         budget-expired one.
 
-        ``wait=False`` is for a caller that cannot afford to suspend at all:
-        the reconciliation resend, whose pass IS the retry loop and which HA
-        re-fires on an interval it re-arms before dispatching. It takes the
-        slot only if :meth:`can_grant_now`, and otherwise stands down having
-        reserved nothing — structurally, so the guarantee survives a later edit
-        to the waiting paths below.
+        ``budget`` is the caller's whole allowance for this one acquisition. A
+        caller that cannot afford to suspend for long — the reconciliation
+        resend, whose pass IS the retry loop and which HA re-fires on an
+        interval it re-arms before dispatching — passes a small one and asks
+        :meth:`resend_stands_down` first, so it only ever enters a wait it can
+        pay for.
         """
-        if not wait and not self.can_grant_now():
-            return None
-
         started = monotonic()
         depth_at_enqueue = self.depth
         budget_expired = False
@@ -419,29 +428,32 @@ class CommandQueue:
         """
         return entity_id in self._pending
 
-    def resend_stands_down(self, entity_id: str) -> bool:
+    def resend_stands_down(self, entity_id: str, *, budget: float) -> bool:
         """Whether a reconciliation resend must yield its whole turn.
 
-        Two independent reasons:
+        Two independent reasons, and the split between them is the point:
 
         * :meth:`defers_to_pending` — a live dispatch for this entity is
-          already waiting and carries the newer decision.
-        * The slot is not free this instant. A resend that queued would hold
-          the reconciliation pass open, per entity, for the whole clearance
-          budget — and HA re-arms the reconciliation interval listener before
-          dispatching each fire as its own background task, so a blocked pass
-          is still running when the next one starts and the two mutate the same
-          per-entity state.
+          already waiting and carries the newer decision. Unbounded from this
+          pass's perspective and never this pass's to wait out.
+        * The turn would cost more than ``budget``, the pass's REMAINING
+          allowance. Spacing owed and reservations ahead are both bounded and
+          largely the pass's own doing, so it waits them out when it can afford
+          to and stands down only when it cannot.
 
-        Exists as a question the PASS can ask before it counts a retry, which
-        is the same reason the clearance gate is asked there: a resend that
-        never goes out must not burn one of the pass's attempts, or repeated
-        stand-downs reach ``gave_up`` and warn "max retries exceeded" about a
-        cover that was never resent. Composed from the same two primitives
-        ``acquire(..., wait=False)`` uses, so the reading taken before the
-        count and the acquisition that follows it cannot disagree.
+        The earlier form asked "is the slot free this instant", which folded the
+        spacing the pass's own previous resend had just started into the
+        stand-down: the first entity to resend disqualified every remaining one,
+        so a pass emitted at most one frame no matter how idle the queue was.
+
+        Advisory, not authoritative. The pass asks it to avoid entering a wait
+        it cannot pay for; whether the resend actually went out is answered by
+        the acquisition itself, so nothing downstream depends on this reading
+        still being true when the wait ends.
         """
-        return self.defers_to_pending(entity_id) or not self.can_grant_now()
+        return (
+            self.defers_to_pending(entity_id) or self.projected_wait_seconds() > budget
+        )
 
     def _enqueue(self, entity_id: str, *, head_of_line: bool) -> _Waiter:
         """Queue a reservation, superseding any this entity already had waiting."""

--- a/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
@@ -76,15 +76,20 @@ def normalize_queue_name(name: Any) -> str:
     return " ".join(str(name).split()).casefold()
 
 
-def _resolved_true(future: asyncio.Future) -> bool:
-    """Whether *future* carries a real ``True`` grant (not a cancellation).
+def _resolution(future: asyncio.Future) -> bool | None:
+    """Return the real outcome a waiter's future carries, or ``None`` if it has none.
 
     ``asyncio.wait_for`` cancels the future it was waiting on when the timeout
     fires, so ``done()`` alone is not enough — the future may be done BECAUSE it
-    was cancelled. It may also have been granted in the very loop iteration the
-    timeout landed in, and that grant is real: the slot is ours.
+    was cancelled. It may also have been resolved in the very loop iteration the
+    timeout landed in, and that resolution is real in BOTH directions: a ``True``
+    means the slot is ours, and a ``False`` means a newer reservation for this
+    entity replaced us. Collapsing the second into a budget-expired grant would
+    put the older decision on the air.
     """
-    return future.done() and not future.cancelled() and future.result() is True
+    if not future.done() or future.cancelled():
+        return None
+    return future.result() is True
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,11 +102,22 @@ class QueueGrant:
     caller is transmitting outside its turn; it is a diagnostic, never a
     refusal. ``depth_at_enqueue`` is how many reservations were already waiting
     when this one asked.
+
+    ``holds_slot`` is the release token, and it is NOT the inverse of
+    ``budget_expired``: a grant that took the slot and then overran its budget
+    waiting out the spacing holds it, while a grant that gave up waiting for
+    the slot entirely does not. It exists because the entity id cannot answer
+    the question — two acquisitions for the SAME entity can be live at once
+    (``apply_position`` re-booking an entity a reconciliation resend is already
+    transmitting), and an entity-keyed release would then let the one that
+    never held the slot free the one that does, mid-transmission.
     """
 
     waited_seconds: float
     budget_expired: bool
     depth_at_enqueue: int
+    entity_id: str = ""
+    holds_slot: bool = True
 
 
 @dataclass(slots=True)
@@ -226,78 +242,139 @@ class CommandQueue:
         depth_at_enqueue = self.depth
         budget_expired = False
         awaited = False
+        holds_slot = False
 
-        if self._owner is not None or self.depth:
-            waiter = self._enqueue(entity_id, head_of_line=head_of_line)
-            awaited = True
-            try:
-                granted = await asyncio.wait_for(waiter.future, budget)
-            except TimeoutError:
-                # ``wait_for`` cancels the future on timeout, but it may already
-                # have been resolved in the same loop iteration — honour that.
-                granted = _resolved_true(waiter.future)
-                if not granted:
-                    self._drop(waiter)
-                    budget_expired = True
-            except asyncio.CancelledError:
-                # A genuine outer cancellation (shutdown, a superseding task
-                # being torn down): leave nothing behind and propagate.
-                self._drop(waiter)
-                raise
-            if not budget_expired and not granted:
-                return None  # superseded by a newer reservation for this entity
-
-        if not budget_expired:
-            self._owner = entity_id
-
-        # Spacing owed by the PREVIOUS transmission, charged against whatever is
-        # left of the budget. Expiring here still yields a grant: the caller
-        # transmits anyway, because withholding is the failure mode.
-        remaining = self._busy_until - monotonic()
-        if remaining > 0:
-            left = budget - (monotonic() - started)
-            if left <= 0:
-                budget_expired = True
-            else:
+        try:
+            if self._owner is not None or self.depth:
+                waiter = self._enqueue(entity_id, head_of_line=head_of_line)
                 awaited = True
-                await asyncio.sleep(min(remaining, left))
-                if remaining > left:
+                try:
+                    granted = await asyncio.wait_for(waiter.future, budget)
+                except TimeoutError:
+                    # ``wait_for`` cancels the future on timeout, but it may
+                    # already have been resolved in the same loop iteration —
+                    # honour that, in BOTH directions. A ``False`` resolved in
+                    # the expiry iteration is a supersede, and a supersede is
+                    # never upgradeable into a grant: transmitting on it would
+                    # put a target a newer decision has already replaced on the
+                    # air, which is the one thing budget expiry must not cost.
+                    resolution = _resolution(waiter.future)
+                    granted = resolution is True
+                    if not granted:
+                        self._drop(waiter)
+                        if resolution is False:
+                            return None
+                        budget_expired = True
+                except BaseException:
+                    # A genuine outer cancellation (shutdown, a superseding task
+                    # being torn down). ``_grant_next`` records the owner and
+                    # resolves the future in one step, so the slot may ALREADY
+                    # be ours even though this coroutine never got to resume —
+                    # claim it here so the unwind below gives it back rather
+                    # than stranding it.
+                    if _resolution(waiter.future) is True:
+                        holds_slot = True
+                    self._drop(waiter)
+                    raise
+                if not budget_expired and not granted:
+                    return None  # superseded by a newer reservation for this entity
+
+            if not budget_expired:
+                self._owner = entity_id
+                holds_slot = True
+
+            # Spacing owed by the PREVIOUS transmission, charged against
+            # whatever is left of the budget. Expiring here still yields a
+            # grant: the caller transmits anyway, because withholding is the
+            # failure mode.
+            remaining = self._busy_until - monotonic()
+            if remaining > 0:
+                left = budget - (monotonic() - started)
+                if left <= 0:
                     budget_expired = True
+                else:
+                    awaited = True
+                    await asyncio.sleep(min(remaining, left))
+                    if remaining > left:
+                        budget_expired = True
+        except BaseException:
+            # Nothing may leave this method holding the slot except a returned
+            # grant. Both awaits above are cancellation points a coordinator
+            # really does fire — the #1138 interlock task is cancelled when a
+            # second external command supersedes it, and unload cancels every
+            # one of them — and a slot stranded that way never comes back on
+            # its own: every other member enqueues, burns its whole budget and
+            # transmits ``budget_expired``, unspaced and simultaneous.
+            if holds_slot:
+                self._hand_off()
+            raise
 
         return QueueGrant(
             waited_seconds=(monotonic() - started) if awaited else 0.0,
             budget_expired=budget_expired,
             depth_at_enqueue=depth_at_enqueue,
+            entity_id=entity_id,
+            holds_slot=holds_slot,
         )
 
-    def release(self, entity_id: str, *, transmitted: bool) -> None:
+    def release(self, grant: QueueGrant, *, transmitted: bool) -> None:
         """Give the slot back, starting the gap when something was transmitted.
 
-        Tolerates a release from an entity that never held the slot — that is
-        exactly what a budget-expired grant is. Such a release still advances
+        Tolerates a release from a grant that never held the slot — that is
+        exactly what a gave-up-waiting grant is. Such a release still advances
         ``busy_until`` (a frame did go out, so the air is busy) but must not
         hand the real holder's slot to the next waiter.
+
+        Keyed on ``grant.holds_slot``, never on the entity id. The entity id
+        cannot answer this: two acquisitions for the SAME entity can be live at
+        once, and ``self._owner != entity_id`` is then vacuously False — the
+        grant that gave up waiting would free the one still on the air, and the
+        next member would key on top of a transmission in progress.
         """
         if transmitted:
             self._busy_until = monotonic() + self.gap_seconds
-        if self._owner is not None and self._owner != entity_id:
+        if not grant.holds_slot:
             return
-        self._owner = None
-        self._grant_next()
+        self._hand_off()
 
     def mark_external_transmit(self) -> None:
-        """Record a frame this queue did not gate (a stop command).
+        """Record a frame this queue did not gate.
 
-        A stop is an interactive, latency-critical command — queueing it would
-        make the user wait out someone else's gap for a button press. It still
-        occupies the air, so the queue is told about it and the NEXT queued
-        member spaces itself accordingly.
+        Two transmissions deliberately run outside a slot, for opposite reasons:
+
+        A **stop** is interactive and latency-critical — queueing it would make
+        the user wait out someone else's gap for a button press.
+
+        A **dual-axis tilt tail** waits on a physical rail before it keys (up to
+        ``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS``), so holding the slot across
+        it would starve every other member, and issue #1115's day/night guard
+        depends on the tail not holding it.
+
+        Both still occupy the air, so both tell the queue and the NEXT queued
+        member spaces itself accordingly instead of assuming the air was free.
         """
         self._busy_until = monotonic() + self.gap_seconds
 
     # ------------------------------------------------------------------ #
     # Waiter bookkeeping — one place, shared by every grant path
     # ------------------------------------------------------------------ #
+
+    def defers_to_pending(self, entity_id: str) -> bool:
+        """Whether a RESEND must stand down for this entity's pending reservation.
+
+        Supersede has a direction. A live dispatch carries the newest decision,
+        so it displaces whatever this entity had waiting — that is the whole
+        point of the one-reservation-per-entity rule. A reconciliation resend
+        re-books a target that was already decided, so displacing a waiting live
+        dispatch would put the OLDER number on the air and drop the newer one,
+        inverting this module's own guarantee that the frame which finally goes
+        out carries the most recent decision.
+
+        Only the WAITING reservation counts. An entity that currently holds the
+        slot is mid-transmit and has no pending reservation, so a resend queues
+        behind it exactly as it did before.
+        """
+        return entity_id in self._pending
 
     def _enqueue(self, entity_id: str, *, head_of_line: bool) -> _Waiter:
         """Queue a reservation, superseding any this entity already had waiting."""
@@ -329,6 +406,16 @@ class CommandQueue:
             except ValueError:
                 continue
             return
+
+    def _hand_off(self) -> None:
+        """Drop ownership and pass the free slot on.
+
+        The one place ownership is given up, shared by the normal release and
+        by the unwind an interrupted :meth:`acquire` performs — mirroring the
+        two would be how one of them ends up leaving the slot held.
+        """
+        self._owner = None
+        self._grant_next()
 
     def _grant_next(self) -> None:
         """Hand the free slot to the next waiter: head tier first, then FIFO."""

--- a/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
@@ -224,20 +224,49 @@ class CommandQueue:
         """Remaining spacing owed before the next member may transmit."""
         return max(0.0, self._busy_until - monotonic())
 
+    def can_grant_now(self) -> bool:
+        """Whether a slot could be taken this instant with no waiting at all.
+
+        All three conditions, because any one of them is a wait: nobody holds
+        the slot, nobody is queued for it, and the air owes no spacing.
+        """
+        return (
+            self._owner is None
+            and not self._head_waiters
+            and not self._routine_waiters
+            and self._busy_until <= monotonic()
+        )
+
     # ------------------------------------------------------------------ #
     # The slot
     # ------------------------------------------------------------------ #
 
     async def acquire(
-        self, entity_id: str, *, head_of_line: bool, budget: float
+        self,
+        entity_id: str,
+        *,
+        head_of_line: bool,
+        budget: float,
+        wait: bool = True,
     ) -> QueueGrant | None:
         """Take the slot and wait out any spacing still owed.
 
-        Returns ``None`` — and only then — when this reservation was superseded
-        by a newer one for the same entity while it waited. Every other outcome
-        is a grant the caller must transmit on and then :meth:`release`,
-        including the budget-expired one.
+        Returns ``None`` when this reservation was superseded by a newer one
+        for the same entity while it waited, or — with ``wait=False`` — when
+        the slot was not free to begin with. Every other outcome is a grant the
+        caller must transmit on and then :meth:`release`, including the
+        budget-expired one.
+
+        ``wait=False`` is for a caller that cannot afford to suspend at all:
+        the reconciliation resend, whose pass IS the retry loop and which HA
+        re-fires on an interval it re-arms before dispatching. It takes the
+        slot only if :meth:`can_grant_now`, and otherwise stands down having
+        reserved nothing — structurally, so the guarantee survives a later edit
+        to the waiting paths below.
         """
+        if not wait and not self.can_grant_now():
+            return None
+
         started = monotonic()
         depth_at_enqueue = self.depth
         budget_expired = False
@@ -283,20 +312,34 @@ class CommandQueue:
                 self._owner = entity_id
                 holds_slot = True
 
-            # Spacing owed by the PREVIOUS transmission, charged against
-            # whatever is left of the budget. Expiring here still yields a
-            # grant: the caller transmits anyway, because withholding is the
-            # failure mode.
-            remaining = self._busy_until - monotonic()
-            if remaining > 0:
+            # Spacing owed by the air, charged against whatever is left of the
+            # budget. Expiring here still yields a grant: the caller transmits
+            # anyway, because withholding is the failure mode.
+            #
+            # RE-READ each time round. ``busy_until`` is not a constant across
+            # this sleep — three transmissions advance it from outside the slot
+            # and every one of them lands, by construction, while the next
+            # member is ALREADY here: ``release`` hands the slot on in the same
+            # call that starts the gap, so a waiter is spacing before the
+            # venetian tail reaches ``mark_air_busy`` (the tail waits out a
+            # physical rail first), before a stop is keyed, and before a
+            # gave-up member transmits out of turn. A sleep sized once from a
+            # single reading cannot see any of them, which would make the
+            # reports inert in exactly the contended case they exist for.
+            #
+            # Bounded regardless: the loop sleeps the REMAINING interval each
+            # pass (never spins) and stops the moment the budget is gone, so no
+            # stream of out-of-turn frames can withhold a command indefinitely.
+            while True:
+                remaining = self._busy_until - monotonic()
+                if remaining <= 0:
+                    break
                 left = budget - (monotonic() - started)
                 if left <= 0:
                     budget_expired = True
-                else:
-                    awaited = True
-                    await asyncio.sleep(min(remaining, left))
-                    if remaining > left:
-                        budget_expired = True
+                    break
+                awaited = True
+                await asyncio.sleep(min(remaining, left))
         except BaseException:
             # Nothing may leave this method holding the slot except a returned
             # grant. Both awaits above are cancellation points a coordinator
@@ -375,6 +418,30 @@ class CommandQueue:
         behind it exactly as it did before.
         """
         return entity_id in self._pending
+
+    def resend_stands_down(self, entity_id: str) -> bool:
+        """Whether a reconciliation resend must yield its whole turn.
+
+        Two independent reasons:
+
+        * :meth:`defers_to_pending` — a live dispatch for this entity is
+          already waiting and carries the newer decision.
+        * The slot is not free this instant. A resend that queued would hold
+          the reconciliation pass open, per entity, for the whole clearance
+          budget — and HA re-arms the reconciliation interval listener before
+          dispatching each fire as its own background task, so a blocked pass
+          is still running when the next one starts and the two mutate the same
+          per-entity state.
+
+        Exists as a question the PASS can ask before it counts a retry, which
+        is the same reason the clearance gate is asked there: a resend that
+        never goes out must not burn one of the pass's attempts, or repeated
+        stand-downs reach ``gave_up`` and warn "max retries exceeded" about a
+        cover that was never resent. Composed from the same two primitives
+        ``acquire(..., wait=False)`` uses, so the reading taken before the
+        count and the acquisition that follows it cannot disagree.
+        """
+        return self.defers_to_pending(entity_id) or not self.can_grant_now()
 
     def _enqueue(self, entity_id: str, *, head_of_line: bool) -> _Waiter:
         """Queue a reservation, superseding any this entity already had waiting."""

--- a/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/queue.py
@@ -1,0 +1,367 @@
+"""Named cover-command dispatch queue (issue #1189).
+
+One-way radio backends (Somfy RTS, RFXtrx) have no acknowledgement: two frames
+keyed at the same moment collide and are simply lost. A reporter running 16 RTS
+covers as 16 independent ACP config entries hits this every time the sun moves
+enough for several facades to re-position at once — nothing in the integration
+arbitrates between entries, because each one owns its own coordinator and its
+own :class:`CoverCommandService`.
+
+This module is that arbiter. A cover names the queue it belongs to; every cover
+naming the same queue transmits one at a time, the queue staying busy for
+``gap_seconds`` after each send. Blank name = no queue = bit-identical to the
+behaviour before this module existed.
+
+Three properties the mechanism carries, each load-bearing:
+
+**Bounded wait.** Every acquisition takes a budget. On expiry the caller gets a
+grant flagged ``budget_expired`` and transmits ANYWAY — a command is never
+withheld indefinitely. An unbounded wait would be issue #756 reintroduced
+outright: a queue wait is a long-blocking dispatch inside the coordinator's
+update cycle, which is precisely the shape #756 was about.
+
+**Head of line, not bypass.** Safety and explicit user commands jump ahead of
+routine waiters but still take their spacing. Bypass would be the wrong answer:
+a storm retraction firing on 16 instances at once is the MOST collision-prone
+moment there is, so safety needs the spacing more than tracking does — it just
+must never wait behind tracking.
+
+**Supersede, don't backlog.** At most one pending reservation per entity; a
+newer acquisition for the same entity cancels the waiting one, which returns
+``None`` so the caller can record a clean skip. This bounds queue depth to the
+entity count and guarantees the frame that finally goes out carries the most
+recent decision rather than a 20-second-stale target — the same last-writer-wins
+doctrine ``coordinator._external_interlock_tasks`` already encodes.
+
+The queue holds no HA references and imports nothing from Home Assistant: it is
+cross-instance manager state, per CODING_GUIDELINES' manager/policy split, and
+nothing in it is cover-type-specific.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+from time import monotonic
+from typing import Any
+
+from ...const import COMMAND_QUEUE_REGISTRY_KEY, DEFAULT_COMMAND_QUEUE_GAP
+
+__all__ = [
+    "CommandQueue",
+    "QueueGrant",
+    "get_command_queue",
+    "normalize_queue_name",
+]
+
+
+def normalize_queue_name(name: Any) -> str:
+    """Fold a queue name to its match key. Empty string means "no queue".
+
+    Free text carries a silent failure class: ``"facade south"`` and
+    ``"Facade South"`` are two queues that both look right, and the symptom —
+    covers that quietly do not serialize — is indistinguishable from the bug
+    this feature exists to fix. So matching folds the two invisible-typo
+    classes: case (``casefold``, not ``lower``, so locale-quirky pairs like
+    ``STRASSE``/``straße`` collapse too) and whitespace (``"Facade  South"`` is
+    the same name typed with an extra space).
+
+    Normalization applies at match and registry time ONLY. Every display
+    surface — the dropdown, the config summary, the queue entry's own title —
+    keeps the user's original casing.
+    """
+    if not name:
+        return ""
+    return " ".join(str(name).split()).casefold()
+
+
+def _resolved_true(future: asyncio.Future) -> bool:
+    """Whether *future* carries a real ``True`` grant (not a cancellation).
+
+    ``asyncio.wait_for`` cancels the future it was waiting on when the timeout
+    fires, so ``done()`` alone is not enough — the future may be done BECAUSE it
+    was cancelled. It may also have been granted in the very loop iteration the
+    timeout landed in, and that grant is real: the slot is ours.
+    """
+    return future.done() and not future.cancelled() and future.result() is True
+
+
+@dataclass(frozen=True, slots=True)
+class QueueGrant:
+    """The outcome of one successful :meth:`CommandQueue.acquire`.
+
+    ``waited_seconds`` is exactly ``0.0`` when the slot was free and unspaced —
+    the "immediate" case the diagnostics report — and the real elapsed wait
+    otherwise. ``budget_expired`` says the bounded-wait ceiling fired and the
+    caller is transmitting outside its turn; it is a diagnostic, never a
+    refusal. ``depth_at_enqueue`` is how many reservations were already waiting
+    when this one asked.
+    """
+
+    waited_seconds: float
+    budget_expired: bool
+    depth_at_enqueue: int
+
+
+@dataclass(slots=True)
+class _Waiter:
+    """One pending reservation. At most one per entity, by construction."""
+
+    entity_id: str
+    future: asyncio.Future
+    head_of_line: bool
+
+
+@dataclass(slots=True)
+class CommandQueue:
+    """Serializes cover commands across every member naming this queue.
+
+    Owns a single logical slot plus a monotonic ``busy_until`` deadline. A
+    member takes the slot, transmits, and releases; the release starts the gap,
+    and the next waiter is granted the slot but does not transmit until the gap
+    has elapsed. The gap therefore applies AFTER a send and never before the
+    first one.
+    """
+
+    name: str
+    #: The registry dict this queue was created in, so the last ``detach`` can
+    #: drop itself. ``None`` for the standalone queues unit tests construct.
+    _registry: dict[str, CommandQueue] | None = None
+
+    _gap_override: float | None = None
+    _busy_until: float = 0.0
+    _owner: str | None = None
+    _attached: int = 0
+    _head_waiters: deque[_Waiter] = field(default_factory=deque)
+    _routine_waiters: deque[_Waiter] = field(default_factory=deque)
+    _pending: dict[str, _Waiter] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------ #
+    # Configuration
+    # ------------------------------------------------------------------ #
+
+    @property
+    def gap_seconds(self) -> float:
+        """Seconds the queue stays busy after a member transmits.
+
+        The default applies whenever no Command Queue config entry owns this
+        name — naming a queue must never require creating one.
+        """
+        if self._gap_override is None:
+            return DEFAULT_COMMAND_QUEUE_GAP
+        return self._gap_override
+
+    @property
+    def gap_source(self) -> str:
+        """Where ``gap_seconds`` came from: ``"entry"`` or ``"default"``.
+
+        The field that actually answers a support question. A queue named by
+        covers but owned by no Command Queue entry reports ``default``, which
+        is the difference between "your configured gap is not being applied"
+        and "you never created the entry that holds it".
+        """
+        return "default" if self._gap_override is None else "entry"
+
+    def set_gap(self, gap: float | None) -> None:
+        """Bind the owning entry's gap, or ``None`` to revert to the default.
+
+        Read live at release time rather than copied into each member, so
+        editing the queue entry takes effect without reloading any member.
+        """
+        self._gap_override = None if gap is None else float(gap)
+
+    # ------------------------------------------------------------------ #
+    # Membership refcount
+    # ------------------------------------------------------------------ #
+
+    @property
+    def attached(self) -> int:
+        """How many config entries currently reference this queue."""
+        return self._attached
+
+    def attach(self) -> None:
+        """Register one more member (a cover entry, or the queue's own entry)."""
+        self._attached += 1
+
+    def detach(self) -> None:
+        """Drop one member; the queue leaves the registry when the last one goes.
+
+        Reloading a single member is attach-after-detach on the SAME object as
+        long as another member (or the queue entry) still holds a reference —
+        which is why the object lives in ``hass.data`` and not on any entry.
+        """
+        self._attached = max(0, self._attached - 1)
+        if self._attached == 0 and self._registry is not None:
+            self._registry.pop(self.name, None)
+
+    # ------------------------------------------------------------------ #
+    # Observation (diagnostics)
+    # ------------------------------------------------------------------ #
+
+    @property
+    def depth(self) -> int:
+        """Reservations waiting for the slot right now (the holder excluded)."""
+        return len(self._head_waiters) + len(self._routine_waiters)
+
+    def busy_for_seconds(self) -> float:
+        """Remaining spacing owed before the next member may transmit."""
+        return max(0.0, self._busy_until - monotonic())
+
+    # ------------------------------------------------------------------ #
+    # The slot
+    # ------------------------------------------------------------------ #
+
+    async def acquire(
+        self, entity_id: str, *, head_of_line: bool, budget: float
+    ) -> QueueGrant | None:
+        """Take the slot and wait out any spacing still owed.
+
+        Returns ``None`` — and only then — when this reservation was superseded
+        by a newer one for the same entity while it waited. Every other outcome
+        is a grant the caller must transmit on and then :meth:`release`,
+        including the budget-expired one.
+        """
+        started = monotonic()
+        depth_at_enqueue = self.depth
+        budget_expired = False
+        awaited = False
+
+        if self._owner is not None or self.depth:
+            waiter = self._enqueue(entity_id, head_of_line=head_of_line)
+            awaited = True
+            try:
+                granted = await asyncio.wait_for(waiter.future, budget)
+            except TimeoutError:
+                # ``wait_for`` cancels the future on timeout, but it may already
+                # have been resolved in the same loop iteration — honour that.
+                granted = _resolved_true(waiter.future)
+                if not granted:
+                    self._drop(waiter)
+                    budget_expired = True
+            except asyncio.CancelledError:
+                # A genuine outer cancellation (shutdown, a superseding task
+                # being torn down): leave nothing behind and propagate.
+                self._drop(waiter)
+                raise
+            if not budget_expired and not granted:
+                return None  # superseded by a newer reservation for this entity
+
+        if not budget_expired:
+            self._owner = entity_id
+
+        # Spacing owed by the PREVIOUS transmission, charged against whatever is
+        # left of the budget. Expiring here still yields a grant: the caller
+        # transmits anyway, because withholding is the failure mode.
+        remaining = self._busy_until - monotonic()
+        if remaining > 0:
+            left = budget - (monotonic() - started)
+            if left <= 0:
+                budget_expired = True
+            else:
+                awaited = True
+                await asyncio.sleep(min(remaining, left))
+                if remaining > left:
+                    budget_expired = True
+
+        return QueueGrant(
+            waited_seconds=(monotonic() - started) if awaited else 0.0,
+            budget_expired=budget_expired,
+            depth_at_enqueue=depth_at_enqueue,
+        )
+
+    def release(self, entity_id: str, *, transmitted: bool) -> None:
+        """Give the slot back, starting the gap when something was transmitted.
+
+        Tolerates a release from an entity that never held the slot — that is
+        exactly what a budget-expired grant is. Such a release still advances
+        ``busy_until`` (a frame did go out, so the air is busy) but must not
+        hand the real holder's slot to the next waiter.
+        """
+        if transmitted:
+            self._busy_until = monotonic() + self.gap_seconds
+        if self._owner is not None and self._owner != entity_id:
+            return
+        self._owner = None
+        self._grant_next()
+
+    def mark_external_transmit(self) -> None:
+        """Record a frame this queue did not gate (a stop command).
+
+        A stop is an interactive, latency-critical command — queueing it would
+        make the user wait out someone else's gap for a button press. It still
+        occupies the air, so the queue is told about it and the NEXT queued
+        member spaces itself accordingly.
+        """
+        self._busy_until = monotonic() + self.gap_seconds
+
+    # ------------------------------------------------------------------ #
+    # Waiter bookkeeping — one place, shared by every grant path
+    # ------------------------------------------------------------------ #
+
+    def _enqueue(self, entity_id: str, *, head_of_line: bool) -> _Waiter:
+        """Queue a reservation, superseding any this entity already had waiting."""
+        previous = self._pending.pop(entity_id, None)
+        if previous is not None:
+            self._remove(previous)
+            if not previous.future.done():
+                previous.future.set_result(False)
+        waiter = _Waiter(
+            entity_id=entity_id,
+            future=asyncio.get_running_loop().create_future(),
+            head_of_line=head_of_line,
+        )
+        self._pending[entity_id] = waiter
+        tier = self._head_waiters if head_of_line else self._routine_waiters
+        tier.append(waiter)
+        return waiter
+
+    def _drop(self, waiter: _Waiter) -> None:
+        """Forget a reservation that gave up (budget expiry, cancellation)."""
+        self._remove(waiter)
+        if self._pending.get(waiter.entity_id) is waiter:
+            del self._pending[waiter.entity_id]
+
+    def _remove(self, waiter: _Waiter) -> None:
+        for tier in (self._head_waiters, self._routine_waiters):
+            try:
+                tier.remove(waiter)
+            except ValueError:
+                continue
+            return
+
+    def _grant_next(self) -> None:
+        """Hand the free slot to the next waiter: head tier first, then FIFO."""
+        if self._owner is not None:
+            return
+        for tier in (self._head_waiters, self._routine_waiters):
+            while tier:
+                waiter = tier.popleft()
+                if self._pending.get(waiter.entity_id) is waiter:
+                    del self._pending[waiter.entity_id]
+                if waiter.future.done():
+                    continue
+                self._owner = waiter.entity_id
+                waiter.future.set_result(True)
+                return
+
+
+def get_command_queue(hass, name: str) -> CommandQueue:
+    """Return the shared queue for a NORMALIZED name, creating it on first ask.
+
+    The single accessor: the config-flow dropdown, the coordinator's attach and
+    the queue entry's own setup all come through here, so two callers can never
+    end up holding different objects for the same name.
+
+    Deliberately not a walk of ``hass.config_entries.async_entries(DOMAIN)`` —
+    that walk is the right way to enumerate names for the dropdown, but runtime
+    serialization needs a shared OBJECT, not an enumeration.
+    """
+    registry: dict[str, CommandQueue] = hass.data.setdefault(
+        COMMAND_QUEUE_REGISTRY_KEY, {}
+    )
+    queue = registry.get(name)
+    if queue is None:
+        queue = CommandQueue(name=name, _registry=registry)
+        registry[name] = queue
+    return queue

--- a/custom_components/adaptive_cover_pro/managers/cover_command/stop.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/stop.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from homeassistant.core import Context, HomeAssistant
 
 from ...cover_types.base import CAP_HAS_STOP, caps_get
+from .queue import CommandQueue
 
 
 class StopTracker:
@@ -38,6 +39,7 @@ class StopTracker:
         *,
         dry_run_fn: Callable[[], bool],
         is_in_transit_fn: Callable[[str], bool] | None = None,
+        queue_fn: Callable[[], CommandQueue | None] | None = None,
     ) -> None:
         """Initialize the StopTracker.
 
@@ -52,11 +54,18 @@ class StopTracker:
                 Defaults to an inline check when omitted (standalone use).
                 ``CoverCommandService`` supplies ``self._is_cover_in_transit``
                 so the transit predicate lives in exactly one place.
+            queue_fn: Optional zero-arg callable returning the entry's
+                :class:`CommandQueue`, or ``None`` when the cover is unqueued
+                (issue #1189). A callable, not a snapshot, for the same reason
+                ``dry_run_fn`` is one — the orchestrator owns the live value.
 
         """
         self._hass = hass
         self._logger = logger
         self._dry_run_fn = dry_run_fn
+        self._queue_fn: Callable[[], CommandQueue | None] = (
+            queue_fn if queue_fn is not None else lambda: None
+        )
         self._is_in_transit_fn: Callable[[str], bool] = (
             is_in_transit_fn
             if is_in_transit_fn is not None
@@ -114,12 +123,23 @@ class StopTracker:
         All ACP-initiated stop_cover calls must go through this helper so that
         the EVENT_CALL_SERVICE listener can identify and ignore them, avoiding
         false manual-override detection.
+
+        A stop deliberately does NOT take a turn in the command queue (issue
+        #1189). Every caller is interactive or urgent — a card button, the
+        My-preset send, an emergency shutdown flush — and making a button press
+        wait out an unrelated cover's gap is a worse outcome than the collision
+        risk of one short frame. It still keys the radio, so the queue is TOLD:
+        the next queued member spaces itself against this transmission instead
+        of assuming the air was free.
         """
         ctx = Context()
         self._acp_stop_contexts.append(ctx.id)
         await self._hass.services.async_call(
             "cover", "stop_cover", {"entity_id": entity_id}, context=ctx
         )
+        queue = self._queue_fn()
+        if queue is not None:
+            queue.mark_external_transmit()
 
     async def try_stop_one(
         self, entity_id: str, caps: dict[str, bool], *, label: str

--- a/custom_components/adaptive_cover_pro/managers/cover_command/stop.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/stop.py
@@ -131,15 +131,21 @@ class StopTracker:
         risk of one short frame. It still keys the radio, so the queue is TOLD:
         the next queued member spaces itself against this transmission instead
         of assuming the air was free.
+
+        Reported BEFORE the await, on the same doctrine the position dispatch
+        states: HA raising — or this task being cancelled mid-call — does not
+        prove the backend never keyed the radio, and claiming the air was free
+        when it may not have been is the one error this feature exists to
+        avoid. The gap is cheap; a collision is not.
         """
         ctx = Context()
         self._acp_stop_contexts.append(ctx.id)
-        await self._hass.services.async_call(
-            "cover", "stop_cover", {"entity_id": entity_id}, context=ctx
-        )
         queue = self._queue_fn()
         if queue is not None:
             queue.mark_external_transmit()
+        await self._hass.services.async_call(
+            "cover", "stop_cover", {"entity_id": entity_id}, context=ctx
+        )
 
     async def try_stop_one(
         self, entity_id: str, caps: dict[str, bool], *, label: str

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -76,11 +76,34 @@ def compute_override_keys(cover_options: dict, profile_options: dict) -> list[st
 
 
 def _building_profile_entries(hass: HomeAssistant) -> list[ConfigEntry]:
-    """Return all Building Profile config entries (controls_cover == False)."""
+    """Return all Building Profile config entries.
+
+    ``controls_cover == False`` alone is no longer the discriminator: the
+    Command Queue entry type shares it (issue #1189), and without the second
+    clause a queue would show up in the profile-link dropdown and be handed to
+    the sensor-propagation listener. Both filters are capability checks, never
+    cover-type strings.
+    """
     return [
         e
         for e in hass.config_entries.async_entries(DOMAIN)
         if not get_policy(e.data.get(CONF_SENSOR_TYPE)).controls_cover
+        and not get_policy(e.data.get(CONF_SENSOR_TYPE)).is_command_queue
+    ]
+
+
+def _command_queue_entries(hass: HomeAssistant) -> list[ConfigEntry]:
+    """Return all Command Queue config entries (issue #1189).
+
+    The counterpart to ``_building_profile_entries``. Used to enumerate the
+    queue names a user has actually created, which is one half of the
+    dropdown's option list — the other half being the names already in use on
+    covers, since naming a queue never required creating one.
+    """
+    return [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if get_policy(e.data.get(CONF_SENSOR_TYPE)).is_command_queue
     ]
 
 

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -68,6 +68,8 @@ from ..const import (
     CONF_END_ENTITY,
     CONF_END_OF_WINDOW_POS,
     CONF_EXTREME_HEAT_POSITION,
+    CONF_COMMAND_QUEUE,
+    CONF_COMMAND_QUEUE_GAP,
     CONF_END_TIME,
     CONF_ENTITIES,
     CONF_FOV_LEFT,
@@ -709,6 +711,11 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_SOLAR_PRIORITY: _range(CONF_SOLAR_PRIORITY),
     # Cover group (issue #790, Phase 2)
     CONF_GROUP_STAGGER_DELAY: _range(CONF_GROUP_STAGGER_DELAY),
+    # Named dispatch queue (issue #1189). The gap is bounded; the name is free
+    # text (any string, or blank for "no queue"), because a cover may join a
+    # queue nobody has created an entry for yet.
+    CONF_COMMAND_QUEUE_GAP: _range(CONF_COMMAND_QUEUE_GAP),
+    CONF_COMMAND_QUEUE: vol.Any(str, None),
 }
 
 # ---------------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -329,5 +329,8 @@
   "axes": {
     "position": "Position",
     "tilt": "Neigung"
+  },
+  "movement": {
+    "queue": "🚦 Befehle serialisiert auf Warteschlange \"{queue}\" ({gap}s Abstand)"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -218,6 +218,9 @@
     "travel_time": "Travel time: {done}/{total} covers",
     "travel_time_manual": "Travel time: {done}/{total} covers ({manual} entered by hand)"
   },
+  "movement": {
+    "queue": "🚦 Commands serialized on queue \"{queue}\" ({gap}s gap)"
+  },
   "my": {
     "entities_enabled": "🎛️ My-preset entities: enabled",
     "entities_disabled": "🎛️ My-preset entities: disabled",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -329,5 +329,8 @@
   "axes": {
     "position": "Position",
     "tilt": "Inclinaison"
+  },
+  "movement": {
+    "queue": "🚦 Commandes sérialisées sur la file d'attente « {queue} » (intervalle {gap}s)"
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -297,7 +297,8 @@
     },
     "abort": {
       "user_cancelled": "Aktion vom Benutzer abgebrochen",
-      "source_not_found": "Die Quellbeschattung existiert nicht mehr."
+      "source_not_found": "Die Quellbeschattung existiert nicht mehr.",
+      "already_configured": "Eine Befehlswarteschlange mit diesem Namen existiert bereits. Beschattungen verweisen auf Warteschlangen nach Name, daher ein Eintrag pro Name — öffnen Sie den bestehenden Eintrag, um den Abstand zu ändern."
     }
   },
   "options": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -45,7 +45,8 @@
           "create_new": "Neue Beschattung erstellen",
           "create_building_profile": "Gebäudeprofil erstellen",
           "duplicate_existing": "Von vorhandener Beschattung duplizieren",
-          "create_group": "Beschattungsgruppe erstellen"
+          "create_group": "Beschattungsgruppe erstellen",
+          "create_command_queue": "Befehlswarteschlange erstellen"
         }
       },
       "create_new": {
@@ -280,6 +281,18 @@
           "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen.",
           "group_area": "Optional: Beschattungen in diesem Bereich treten der Gruppe automatisch bei und die Mitgliedschaft folgt Registrierungsänderungen. Kombiniert mit den obigen Listen."
         }
+      },
+      "create_command_queue": {
+        "title": "Befehlswarteschlange erstellen",
+        "description": "Eine Befehlswarteschlange lässt Beschattungen abwechselnd senden, damit One-Way-Radio-Backends (Somfy RTS, RFXtrx) keine Rahmen durch Kollisionen verlieren. Beschattungen treten bei, indem sie diese Warteschlange auf ihrer Seite \"Bewegung & Zeitplan\" nennen. Das Erstellen dieses Eintrags ist optional - eine benannte Warteschlange serialisiert bereits mit dem Standard-Abstand; hier können Sie diesen Abstand ändern und sehen, wer beigetreten ist. [Weitere Informationen]({learn_more})",
+        "data": {
+          "name": "Name der Warteschlange",
+          "command_queue_gap": "Abstand zwischen Befehlen"
+        },
+        "data_description": {
+          "name": "Beschattungen verweisen auf diese Warteschlange nach Name in ihren Einstellungen \"Bewegung & Zeitplan\". Der Vergleich ignoriert Groß- und Kleinschreibung sowie zusätzliche Leerzeichen.",
+          "command_queue_gap": "Sekunden, die die Warteschlange nach jeder Übertragung einer Beschattung in dieser Warteschlange aktiv bleibt, bevor die nächste Beschattung gehen darf. Standard: 5 Sekunden."
+        }
       }
     },
     "abort": {
@@ -320,7 +333,9 @@
           "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung",
           "group_entities": "🧩 Verfügbar gemachte Entitäten",
           "change_cover_type": "🔁 Beschattungstyp ändern",
-          "calibration": "📐 Kalibrierung"
+          "calibration": "📐 Kalibrierung",
+          "queue_settings": "🚦 Warteschlangen-Einstellungen",
+          "queue_overview": "🚦 Warteschlangen-Übersicht"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -335,7 +350,8 @@
           "end_time": "Endzeit",
           "end_entity": "Entität, die die Endzeit angibt",
           "max_coverage_steps": "Maximale Abdeckungsschritte",
-          "minimize_movements": "Bewegungen minimieren"
+          "minimize_movements": "Bewegungen minimieren",
+          "command_queue": "Befehlswarteschlange"
         },
         "data_description": {
           "delta_position": "Minimale Positionsänderung (%) erforderlich, bevor die Beschattung angepasst wird. Verhindert winzige Anpassungen, wenn die Sonne langsam wandert. Typische Werte: 1-2 % (sehr reaktiv, kann häufig angepasst werden), 5 % (ausgewogen, für die meisten empfohlen), 10 % (weniger häufig, größere Bewegungen). Beispiel: Wenn die Beschattung bei 30 % liegt und die Sonne sich leicht bewegt, passen Sie nur an, wenn die neue Position 35 % oder mehr beträgt (mit 5 % Schwellenwert). Reduziert Motorverschleiß und Geräusche durch ständige winzige Anpassungen.",
@@ -345,7 +361,8 @@
           "end_time": "Beenden Sie die automatische Steuerung nach dieser Zeit (24-Stunden-Format). Verwenden Sie diese Option, um den Datenschutz am Abend aufrechtzuerhalten (auf 18:00 oder 19:00 einstellen), zur Standardeinstellung vor dem Schlafengehen zurückkehren oder leer lassen, um bis Sonnenuntergang fortzufahren. Beispiel: '20:00' bedeutet, dass die automatische Steuerung um 20:00 Uhr endet. Die manuelle Steuerung funktioniert nach dieser Zeit weiterhin.",
           "end_entity": "Entity, die den Endzeitstatus darstellt und die oben festgelegte feste Endzeit außer Kraft setzt. Nützlich zur Automatisierung der Endzeit mit einer Entity (z. B. Sensor, der die Schlafenszeit basierend auf Kalender oder täglicher Routine bereitstellt).",
           "max_coverage_steps": "Die maximale Anzahl der zu berücksichtigenden Schritte (z. B. 5 Schritte = 20% je Schritt). Mehr Schritte bedeuten glattere Bewegungen, aber häufigere Befehle und möglicherweise langsamere Reaktionen. Weniger Schritte reduzieren die Motorverschleiß, aber die Bewegung erscheint weniger flüssig.",
-          "minimize_movements": "Reduzieren Sie die Häufigkeit der Positionsänderung der Beschattung beim Sonnenverfolgen durch Einrasten auf wenige feste Abdeckungsebenen statt kontinuierlicher Sonnenverfolgung. Rundet zu MEHR Abdeckung, damit direkte Sonnenstrahlung niemals durch Rundung eindringt. Tauscht etwas Tageslicht gegen weit weniger Motorbewegungen ein. Standard: aus."
+          "minimize_movements": "Reduzieren Sie die Häufigkeit der Positionsänderung der Beschattung beim Sonnenverfolgen durch Einrasten auf wenige feste Abdeckungsebenen statt kontinuierlicher Sonnenverfolgung. Rundet zu MEHR Abdeckung, damit direkte Sonnenstrahlung niemals durch Rundung eindringt. Tauscht etwas Tageslicht gegen weit weniger Motorbewegungen ein. Standard: aus.",
+          "command_queue": "Serialisieren Sie die Befehle dieser Beschattung gegen andere Beschattungen, die derselben Warteschlange zugewiesen sind. Beschattungen, die eine Warteschlange teilen, senden nie gleichzeitig - nützlich für One-Way-Radio-Backends (Somfy RTS, RFXtrx), bei denen gleichzeitige Befehle kollidieren und verloren gehen. Der Abstand zwischen Befehlen wird im Eintrag \"Befehlswarteschlange\" mit demselben Namen festgelegt oder standardmäßig auf 5 Sekunden eingestellt, falls keine vorhanden ist. Leer lassen für keine Warteschlange (Standard)."
         }
       },
       "cover_entities": {
@@ -1117,6 +1134,20 @@
       "travel_time_manual": {
         "description": "Sekunden für eine vollständige Fahrt von vollständig geschlossen bis vollständig offen. Setzen Sie eine Beschattung auf **0**, um ihre Zeit zu löschen; alles andere muss mindestens {min_seconds} Sekunden betragen.\n\nEine ungefähre Zahl ist wertvoll: Sie beeinflusst nur, wie die Bewegung angezeigt wird, niemals, wohin die Beschattung geschickt wird. Das Timing eines vollständigen Schließens mit einer Stoppuhr ist ausreichend.\n\n{cover_list}",
         "title": "Laufzeit — manuelle Eingabe"
+      },
+      "queue_settings": {
+        "title": "Warteschlangen-Einstellungen",
+        "description": "Wie lange diese Warteschlange nach der Übertragung einer ihrer Beschattungen blockiert bleibt. Jede Beschattung, die diese Warteschlange nennt, übernimmt den neuen Wert bei ihrem nächsten Befehl - kein Neustart erforderlich. [Weitere Informationen]({learn_more})",
+        "data": {
+          "command_queue_gap": "Abstand zwischen Befehlen"
+        },
+        "data_description": {
+          "command_queue_gap": "Sekunden, die die Warteschlange nach jeder Übertragung einer Beschattung in dieser Warteschlange aktiv bleibt, bevor die nächste Beschattung gehen darf. Standard: 5 Sekunden."
+        }
+      },
+      "queue_overview": {
+        "title": "Warteschlangen-Übersicht",
+        "description": "{overview}"
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -45,7 +45,8 @@
           "create_new": "Create new cover",
           "create_building_profile": "Create building profile",
           "duplicate_existing": "Duplicate from existing cover",
-          "create_group": "Create cover group"
+          "create_group": "Create cover group",
+          "create_command_queue": "Create command queue"
         }
       },
       "create_new": {
@@ -280,6 +281,18 @@
           "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped.",
           "group_area": "Optional: covers in this area join the group automatically and membership tracks registry changes. Combined with the lists above."
         }
+      },
+      "create_command_queue": {
+        "title": "Create Command Queue",
+        "description": "A command queue makes covers take turns transmitting, so one-way radio backends (Somfy RTS, RFXtrx) stop losing frames to collisions. Covers join by naming this queue on their Movement & Schedule page. Creating this entry is optional — a named queue already serializes at the default gap; this is where you change that gap and see who joined. [Learn more]({learn_more})",
+        "data": {
+          "name": "Queue name",
+          "command_queue_gap": "Gap between commands"
+        },
+        "data_description": {
+          "name": "Covers reference this queue by name in their Movement & Schedule settings. Matching ignores case and extra spaces.",
+          "command_queue_gap": "Seconds the queue stays busy after any cover on this queue transmits, before the next cover may go. Default: 5 seconds."
+        }
       }
     },
     "abort": {
@@ -321,7 +334,9 @@
           "profile_overrides": "🧹 Local Overrides",
           "group_membership": "👥 Group Members",
           "group_arbitration": "⚖️ Arbitration & Timing",
-          "group_entities": "🧩 Exposed Entities"
+          "group_entities": "🧩 Exposed Entities",
+          "queue_settings": "🚦 Queue Settings",
+          "queue_overview": "🚦 Queue Overview"
         }
       },
       "pipeline_priorities": {
@@ -357,7 +372,8 @@
           "end_time": "End time",
           "end_entity": "Entity indicating ending time",
           "minimize_movements": "Minimize movements",
-          "max_coverage_steps": "Maximum coverage steps"
+          "max_coverage_steps": "Maximum coverage steps",
+          "command_queue": "Command queue"
         },
         "data_description": {
           "delta_position": "Minimum position change (%) required before adjusting the cover. Prevents tiny adjustments as sun moves slowly. Typical values: 1-2% (very responsive, may adjust frequently), 5% (balanced, recommended for most), 10% (less frequent, larger movements). Example: If cover is at 30% and sun moves slightly, only adjust if new position is 35% or more (with 5% threshold). Reduces motor wear and noise from constant tiny adjustments.",
@@ -367,7 +383,8 @@
           "end_time": "Stop automatic control after this time (24-hour format). Use this to keep evening privacy (set to 18:00 or 19:00), return to default before bed, or leave blank to continue until sunset. Example: '20:00' means automatic control stops at 8:00 PM. Manual control still works after this time.",
           "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine).",
           "minimize_movements": "Reduce how often the cover repositions while tracking the sun by snapping to a few fixed coverage levels instead of following the sun continuously. Rounds toward MORE coverage, so direct sun is never let in by the rounding. Trades some natural light for far fewer motor movements. Default: off.",
-          "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the sun acceptance angle and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1."
+          "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the sun acceptance angle and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1.",
+          "command_queue": "Serialize this cover's commands against other covers assigned to the same queue name. Covers sharing a queue never transmit at the same moment — useful for one-way radio backends (Somfy RTS, RFXtrx) where simultaneous commands collide and are lost. The gap between commands is set on the Command Queue entry with the same name, or defaults to 5 seconds if none exists. Leave blank for no queue (default)."
         }
       },
       "change_cover_type": {
@@ -1117,6 +1134,20 @@
           "glare_zone_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
           "glare_zone_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for."
         }
+      },
+      "queue_settings": {
+        "title": "Queue Settings",
+        "description": "How long this queue holds the air after one of its covers transmits. Every cover naming this queue picks the new value up on its next command — no reload needed. [Learn more]({learn_more})",
+        "data": {
+          "command_queue_gap": "Gap between commands"
+        },
+        "data_description": {
+          "command_queue_gap": "Seconds the queue stays busy after any cover on this queue transmits, before the next cover may go. Default: 5 seconds."
+        }
+      },
+      "queue_overview": {
+        "title": "Queue Overview",
+        "description": "{overview}"
       }
     },
     "error": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -297,7 +297,8 @@
     },
     "abort": {
       "user_cancelled": "Action cancelled by user",
-      "source_not_found": "The source cover no longer exists."
+      "source_not_found": "The source cover no longer exists.",
+      "already_configured": "A Command Queue with that name already exists. Covers join a queue by name, so one entry per name — open the existing entry to change its gap."
     }
   },
   "options": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -45,7 +45,8 @@
           "create_new": "Créer un nouveau store",
           "create_building_profile": "Créer un profil de bâtiment",
           "duplicate_existing": "Dupliquer à partir d'un store existant",
-          "create_group": "Créer un groupe de stores"
+          "create_group": "Créer un groupe de stores",
+          "create_command_queue": "Créer une file d'attente de commandes"
         }
       },
       "create_new": {
@@ -280,6 +281,18 @@
           "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré.",
           "group_area": "Optionnel : les stores de cette zone rejoignent le groupe automatiquement et l'adhésion suit les modifications du registre. Combiné avec les listes ci-dessus."
         }
+      },
+      "create_command_queue": {
+        "title": "Créer une file d'attente de commandes",
+        "description": "Une file d'attente de commandes permet aux protections de prendre tour à tour pour transmettre, de sorte que les backends radio unidirectionnels (Somfy RTS, RFXtrx) cessent de perdre des trames en cas de collision. Les protections s'y joignent en nommant cette file d'attente dans leur page Mouvement & Horaire. La création de cette entrée est facultative — une file d'attente nommée sérialise déjà à l'intervalle par défaut ; c'est ici que vous pouvez modifier cet intervalle et voir qui s'y a jointe. [En savoir plus]({learn_more})",
+        "data": {
+          "name": "Nom de la file d'attente",
+          "command_queue_gap": "Intervalle entre les commandes"
+        },
+        "data_description": {
+          "name": "Les protections référencent cette file d'attente par son nom dans leurs paramètres Mouvement & Horaire. La correspondance ignore la casse et les espaces supplémentaires.",
+          "command_queue_gap": "Secondes pendant lesquelles la file d'attente reste occupée après qu'une protection transmette, avant que la protection suivante puisse agir. Par défaut : 5 secondes."
+        }
       }
     },
     "abort": {
@@ -320,7 +333,9 @@
           "group_arbitration": "⚖️ Arbitrage & Synchronisation",
           "group_entities": "🧩 Entités exposées",
           "change_cover_type": "🔁 Modifier le type de store",
-          "calibration": "📐 Étalonnage"
+          "calibration": "📐 Étalonnage",
+          "queue_settings": "🚦 Paramètres de la file d'attente",
+          "queue_overview": "🚦 Aperçu de la file d'attente"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -335,7 +350,8 @@
           "end_time": "Heure de fin",
           "end_entity": "Entité indiquant l'heure de fin",
           "max_coverage_steps": "Étapes de couverture maximale",
-          "minimize_movements": "Minimiser les mouvements"
+          "minimize_movements": "Minimiser les mouvements",
+          "command_queue": "File d'attente de commandes"
         },
         "data_description": {
           "delta_position": "Changement de position minimum (%) requis avant d'ajuster le store. Empêche les minuscules ajustements tandis que le soleil se déplace lentement. Valeurs typiques : 1-2% (très réactif, peut ajuster fréquemment), 5% (équilibré, recommandé pour la plupart), 10% (moins fréquent, mouvements plus importants). Exemple : Si le store est à 30% et le soleil se déplace légèrement, n'ajustez que si la nouvelle position est 35% ou plus (avec un seuil de 5%). Réduit l'usure du moteur et le bruit des minuscules ajustements constants.",
@@ -345,7 +361,8 @@
           "end_time": "Arrêtez le contrôle automatique après cette heure (format 24 heures). Utilisez ceci pour garder l'intimité du soir (réglez sur 18:00 ou 19:00), retournez à la valeur par défaut avant le coucher, ou laissez vide pour continuer jusqu'au coucher du soleil. Exemple : '20:00' signifie que le contrôle automatique s'arrête à 20:00. Le contrôle manuel fonctionne toujours après cette heure.",
           "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité (par ex., un capteur qui fournit l'heure du coucher basée sur le calendrier ou la routine quotidienne).",
           "max_coverage_steps": "Combien de positions distinctes le store peut utiliser sur son chemin vers une couverture complète lorsque 'Minimiser les mouvements' est activé (1-10). 1 = saut direct vers la couverture complète dès que le soleil entre dans l'angle d'ouverture solaire et maintien jusqu'à ce qu'il le quitte (moins de mouvements). Les valeurs supérieures trackent le soleil plus graduellement en ce nombre d'étapes. Par défaut : 1.",
-          "minimize_movements": "Réduisez la fréquence à laquelle le store se repositionne tout en suivant le soleil en accrochant à quelques niveaux de couverture fixes au lieu de suivre le soleil en continu. L'arrondi se fait vers PLUS de couverture, donc le soleil direct n'est jamais laissé entrer par l'arrondi. Échange un peu de lumière naturelle pour beaucoup moins de mouvements moteur. Par défaut : désactivé."
+          "minimize_movements": "Réduisez la fréquence à laquelle le store se repositionne tout en suivant le soleil en accrochant à quelques niveaux de couverture fixes au lieu de suivre le soleil en continu. L'arrondi se fait vers PLUS de couverture, donc le soleil direct n'est jamais laissé entrer par l'arrondi. Échange un peu de lumière naturelle pour beaucoup moins de mouvements moteur. Par défaut : désactivé.",
+          "command_queue": "Sérialiser les commandes de cette protection par rapport aux autres protections assignées au même nom de file d'attente. Les protections partageant une file d'attente ne transmettent jamais au même moment — utile pour les backends radio unidirectionnels (Somfy RTS, RFXtrx) où les commandes simultanées entrent en collision et sont perdues. L'intervalle entre les commandes est défini dans l'entrée File d'attente de commandes portant le même nom, ou par défaut 5 secondes si aucune n'existe. Laissez vide pour aucune file d'attente (par défaut)."
         }
       },
       "cover_entities": {
@@ -1117,6 +1134,20 @@
       "travel_time_manual": {
         "description": "Secondes pour un voyage complet de complètement fermé à complètement ouvert. Mettez un store à **0** pour effacer sa durée ; tout autre valeur doit être d'au moins {min_seconds} secondes.\n\nUne valeur approximative est suffisante : elle n'affecte que la manière dont le mouvement est dessiné, jamais où le store est commandé. Chronométrer une fermeture complète avec un chronomètre est largement suffisant.\n\n{cover_list}",
         "title": "Temps de course — entrée manuelle"
+      },
+      "queue_settings": {
+        "title": "Paramètres de la file d'attente",
+        "description": "Combien de temps cette file d'attente occupera l'air après qu'une de ses protections transmette. Chaque protection nommant cette file d'attente reprendra la nouvelle valeur à sa prochaine commande — aucun rechargement n'est nécessaire. [En savoir plus]({learn_more})",
+        "data": {
+          "command_queue_gap": "Intervalle entre les commandes"
+        },
+        "data_description": {
+          "command_queue_gap": "Secondes pendant lesquelles la file d'attente reste occupée après qu'une protection transmette, avant que la protection suivante puisse agir. Par défaut : 5 secondes."
+        }
+      },
+      "queue_overview": {
+        "title": "Aperçu de la file d'attente",
+        "description": "{overview}"
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -297,7 +297,8 @@
     },
     "abort": {
       "user_cancelled": "Action annulée par l'utilisateur",
-      "source_not_found": "Le store source n'existe plus."
+      "source_not_found": "Le store source n'existe plus.",
+      "already_configured": "Une file d'attente de commandes portant ce nom existe déjà. Les protections s'y joignent en nommant la file d'attente, donc une seule entrée par nom — ouvrez l'entrée existante pour modifier son intervalle."
     }
   },
   "options": {

--- a/tests/test_command_queue.py
+++ b/tests/test_command_queue.py
@@ -25,6 +25,8 @@ from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
+    COMMAND_QUEUE_MAX_WAIT_SECONDS,
+    COMMAND_QUEUE_PASS_BUDGET_FRACTION,
     COMMAND_QUEUE_REGISTRY_KEY,
     CONF_COMMAND_QUEUE,
     CONF_COMMAND_QUEUE_GAP,
@@ -482,6 +484,50 @@ class TestQueueMechanics:
         with pytest.raises(Exception):
             grant.waited_seconds = 1.0  # type: ignore[misc]
         assert not hasattr(grant, "__dict__")
+
+    @pytest.mark.asyncio
+    async def test_projected_wait_counts_spacing_holder_and_queue(self):
+        """The wait a caller would actually take, as a number rather than a flag.
+
+        Zero only when the slot is free, unqueued and the air owes nothing. A
+        holder adds one gap (it has yet to transmit and start its own), each
+        reservation ahead adds another, and spacing already owed adds itself —
+        which is the distinction that matters: spacing is bounded and usually
+        the caller's own doing, so it is affordable, while an unbounded backlog
+        is not.
+        """
+        queue = _queue(gap=1.0)
+        assert queue.projected_wait_seconds() == 0.0
+
+        queue.mark_external_transmit()  # ~1 s of spacing owed, slot still free
+        assert 0.5 < queue.projected_wait_seconds() <= 1.0
+
+        holder = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert holder is not None  # took the slot, waited the spacing out
+        # A holder is one further gap for whoever comes next.
+        assert 0.9 <= queue.projected_wait_seconds() <= 1.1
+
+        waiter = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        assert queue.depth == 1
+        # Holder + one routine reservation ahead.
+        assert 1.9 <= queue.projected_wait_seconds() <= 2.1
+        # A head-of-line asker does not queue behind the routine tier.
+        assert 0.9 <= queue.projected_wait_seconds(head_of_line=True) <= 1.1
+
+        queue.release(holder, transmitted=False)
+        granted = await asyncio.wait_for(waiter, timeout=1.0)
+        assert granted is not None
+        queue.release(granted, transmitted=False)
+
+    def test_resend_stands_down_only_beyond_the_budget(self):
+        """The predicate the pass reads: affordability, not idleness."""
+        queue = _queue(gap=5.0)
+        queue.mark_external_transmit()
+        assert queue.resend_stands_down("cover.a", budget=1.0) is True
+        assert queue.resend_stands_down("cover.a", budget=30.0) is False
 
 
 # ---------------------------------------------------------------------------
@@ -1012,26 +1058,26 @@ class TestOtherWireSites:
 
     @pytest.mark.asyncio
     async def test_reconciliation_resend_takes_a_routine_turn(self):
-        """Routine tier, and never a waiting one.
+        """Routine tier, on the allowance its caller sized.
 
         A retry of a command that already had its chance has no claim on the
-        head of the line ahead of a fresh safety decision — and it asks with
-        ``wait=False``, so it can only ever take a slot that is free already.
+        head of the line ahead of a fresh safety decision. It does WAIT for its
+        turn like any other transmission — what bounds it is the budget handed
+        down, not a refusal to suspend.
         """
         hass = _svc_hass()
         queue = _queue(gap=0.0)
         svc = _svc(hass, command_queue=queue)
-        calls: list[tuple[bool, bool]] = []
+        calls: list[tuple[bool, float]] = []
         real_acquire = CommandQueue.acquire
 
-        async def _tracked(self, entity_id, *, head_of_line, budget, wait=True):
-            calls.append((head_of_line, wait))
+        async def _tracked(self, entity_id, *, head_of_line, budget):
+            calls.append((head_of_line, budget))
             return await real_acquire(
                 self,
                 entity_id,
                 head_of_line=head_of_line,
                 budget=budget,
-                wait=wait,
             )
 
         with (
@@ -1039,89 +1085,98 @@ class TestOtherWireSites:
             patch.object(svc, "_get_current_position", return_value=10),
             patch.object(CommandQueue, "acquire", _tracked),
         ):
-            await svc._execute_command("cover.a", 70)
+            assert await svc._execute_command("cover.a", 70, queue_budget=4.0) is True
 
-        assert calls == [(False, False)]
+        assert calls == [(False, 4.0)]
         hass.services.async_call.assert_awaited_once()
         assert queue._owner is None
         assert queue.busy_for_seconds() == 0.0
 
     @pytest.mark.asyncio
-    async def test_reconciliation_resend_stands_down_rather_than_blocking(self):
-        """A resend takes the slot only if it is free RIGHT NOW.
+    async def test_a_resend_waits_out_spacing_it_can_afford(self):
+        """Spacing owed is not contention — it is the queue doing its job.
 
-        The reconciliation pass IS the retry loop, and HA re-arms its interval
-        listener before dispatching each fire as its own background task — so a
-        pass that blocks per entity for the clearance budget (30 s, against a
-        1-minute interval) is still running when the next one starts, and the
-        two mutate the same ``PerEntityState``. That is the same overlap the
-        ``wait=False`` clearance gate above it exists to prevent, reached by a
-        different road. Standing down costs nothing: the next pass re-asks.
+        Folding "the air is spaced" into the stand-down is what limited a
+        reconciliation pass to a single frame: the gap its OWN first resend
+        started disqualified every remaining cover on the queue. A turn that
+        costs less than the caller's remaining allowance is taken and waited
+        out.
         """
         hass = _svc_hass()
-        queue = _queue(gap=0.0)
+        queue = _queue(gap=_GAP)
         svc = _svc(hass, command_queue=queue)
-        holder = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
-        assert holder is not None
+        queue.mark_external_transmit()  # slot free, but the air is not
+        assert queue._owner is None
+        assert queue.projected_wait_seconds() > 0.0
 
+        loop = asyncio.get_running_loop()
+        started = loop.time()
         with (
             _patch_caps(),
             patch.object(svc, "_get_current_position", return_value=10),
         ):
-            task = asyncio.create_task(svc._execute_command("cover.a", 70))
-            await asyncio.sleep(0)
-            # Returned without ever suspending, and left no reservation behind
-            # for the next pass to trip over.
-            assert task.done()
-            await task
+            assert (
+                await asyncio.wait_for(
+                    svc._execute_command("cover.a", 70, queue_budget=5.0),
+                    timeout=2.0,
+                )
+                is True
+            )
 
-        hass.services.async_call.assert_not_awaited()
-        assert queue.depth == 0
-        queue.release(holder, transmitted=False)
+        hass.services.async_call.assert_awaited_once()
+        assert loop.time() - started >= _GAP
 
     @pytest.mark.asyncio
-    async def test_reconciliation_resend_stands_down_while_the_air_is_spaced(self):
-        """Spacing owed is a wait too — a free slot alone is not enough.
+    async def test_a_resend_stands_down_when_the_turn_outruns_the_allowance(self):
+        """Beyond the allowance the resend yields the whole turn.
 
-        With a configured gap anywhere near the clearance budget, waiting out
-        the spacing blocks the pass for just as long as waiting for the slot.
+        The pass IS the retry loop, and HA re-arms its interval listener before
+        dispatching each fire as its own background task — so a pass that
+        outspends its own interval is still running when the next one starts,
+        and the two mutate the same ``PerEntityState``. Standing down costs
+        nothing: the next pass re-asks.
         """
         hass = _svc_hass()
         queue = _queue(gap=30.0)
         svc = _svc(hass, command_queue=queue)
-        queue.mark_external_transmit()  # slot free, but the air is not
-        assert queue._owner is None
+        queue.mark_external_transmit()  # ~30 s of spacing owed
+        assert queue.projected_wait_seconds() > 5.0
 
         with (
             _patch_caps(),
             patch.object(svc, "_get_current_position", return_value=10),
         ):
-            task = asyncio.create_task(svc._execute_command("cover.a", 70))
+            task = asyncio.create_task(
+                svc._execute_command("cover.a", 70, queue_budget=5.0)
+            )
             await asyncio.sleep(0)
+            # Returned without ever suspending, and left no reservation behind
+            # for the next pass to trip over.
             assert task.done()
-            await task
+            assert await task is False
 
         hass.services.async_call.assert_not_awaited()
+        assert queue.depth == 0
 
     @pytest.mark.asyncio
     async def test_a_stood_down_resend_burns_no_retry(self):
         """Standing down must not cost one of the pass's three attempts.
 
-        The clearance gate directly above is asked before the counter for
-        exactly this reason. A queue stand-down that counted would reach
-        ``gave_up`` after three passes and warn "max retries exceeded" about a
-        cover that was never resent — and with the resend now non-blocking,
-        standing down is the common case on a busy queue, not a corner one.
+        A queue stand-down that counted would reach ``gave_up`` after three
+        passes and warn "max retries exceeded" about a cover that was never
+        resent. The counter is driven by what ``_execute_command`` reports,
+        not by a prediction made before the acquisition — the acquisition
+        suspends, so no earlier reading can promise the frame goes out.
         """
         hass = _svc_hass()
-        queue = _queue(gap=0.0)
+        # A gap wider than the whole pass allowance: every turn on this queue
+        # costs more than one pass can spend.
+        queue = _queue(gap=90.0)
         svc = _svc(hass, command_queue=queue)
         svc.enable_position_matching = True
         svc.set_target("cover.a", 50)
         svc.set_waiting("cover.a", False)
-
-        holder = await queue.acquire("cover.blocker", head_of_line=False, budget=5.0)
-        assert holder is not None
+        queue.mark_external_transmit()
 
         with (
             _patch_caps(),
@@ -1135,7 +1190,6 @@ class TestOtherWireSites:
         hass.services.async_call.assert_not_awaited()
         assert svc.state("cover.a").retry_count == 0
         assert svc.state("cover.a").gave_up is False
-        queue.release(holder, transmitted=False)
 
     @pytest.mark.asyncio
     async def test_a_resend_that_goes_out_still_counts_its_retry(self):
@@ -1233,6 +1287,25 @@ class TestOtherWireSites:
         assert queue.busy_for_seconds() > 0.0
 
     @pytest.mark.asyncio
+    async def test_a_stop_that_raises_still_reports_its_frame(self):
+        """Reported BEFORE the await, on the position dispatch's own doctrine.
+
+        HA raising — or the task being cancelled mid-call — does not prove the
+        backend never keyed the radio, and claiming the air was free when it may
+        not have been is the one error this feature exists to avoid. The gap is
+        cheap; a collision is not.
+        """
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("boom"))
+
+        with pytest.raises(HomeAssistantError):
+            await svc._stop_tracker.call_stop_cover("cover.a")
+
+        assert queue.busy_for_seconds() > 0.0
+
+    @pytest.mark.asyncio
     async def test_stop_on_an_unqueued_cover_is_untouched(self):
         hass = _svc_hass()
         svc = _svc(hass)
@@ -1254,6 +1327,176 @@ class TestOtherWireSites:
         assert queue.busy_for_seconds() == 0.0
         svc.mark_queue_external_transmit()
         assert queue.busy_for_seconds() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Step 5a — the reconciliation pass's own wait allowance
+#
+# The pass sits between two invariants that pull in opposite directions. It must
+# reconcile EVERY cover it owns, or a cover that missed its target sits wrong
+# indefinitely with nothing in the diagnostics to say so. And it must finish
+# before the next pass starts, because HA re-arms the interval listener before
+# dispatching each fire as its own background task, so two overlapping passes
+# mutate one ``PerEntityState``.
+#
+# A per-entity ceiling cannot hold both: N entities each entitled to
+# COMMAND_QUEUE_MAX_WAIT_SECONDS is N x 30 s against a 60 s interval. A
+# per-entity refusal to wait at all cannot either: the gap the pass's own first
+# resend starts then disqualifies every remaining cover, and the pass emits one
+# frame. One allowance for the whole pass is what satisfies both.
+# ---------------------------------------------------------------------------
+
+
+def _reconcile_svc(hass, queue, covers, *, target=50):
+    """Build a service with *covers* recorded off target and eligible to resend."""
+    svc = _svc(hass, command_queue=queue)
+    svc.enable_position_matching = True
+    for entity_id in covers:
+        svc.set_target(entity_id, target)
+        svc.set_waiting(entity_id, False)
+    return svc
+
+
+def _sent_entities(hass) -> list[str]:
+    return [
+        call.args[2]["entity_id"] for call in hass.services.async_call.await_args_list
+    ]
+
+
+@pytest.mark.unit
+class TestReconciliationPassAllowance:
+    """One pass reconciles every cover it can afford, and no more."""
+
+    @pytest.mark.asyncio
+    async def test_one_pass_resends_every_off_target_cover_on_an_idle_queue(self):
+        """Five covers, one entry, an idle queue — five frames, spaced.
+
+        The regression this locks: ``resend_stands_down`` used to ask "is the
+        slot free THIS INSTANT", and ``can_grant_now`` counts the spacing owed.
+        The first cover's own resend started that spacing, so covers two
+        through five stood down — every pass, forever, on a queue nobody else
+        was using.
+        """
+        hass = _svc_hass()
+        queue = _queue(gap=_GAP)
+        covers = [f"cover.c{i}" for i in range(1, 6)]
+        svc = _reconcile_svc(hass, queue, covers)
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(svc, "_is_cover_in_transit", return_value=False),
+        ):
+            await asyncio.wait_for(
+                svc.run_reconciliation_pass(dt.datetime.now(dt.UTC)), timeout=5.0
+            )
+        elapsed = loop.time() - started
+
+        assert _sent_entities(hass) == covers
+        assert [svc.state(c).retry_count for c in covers] == [1] * len(covers)
+        # Spaced, not simultaneous: four gaps between five frames.
+        assert elapsed >= _GAP * (len(covers) - 1)
+
+    @pytest.mark.asyncio
+    async def test_the_pass_stops_spending_when_its_allowance_runs_out(self):
+        """The allowance is what bounds the pass, and it is a TOTAL.
+
+        Covers past the allowance stand down having booked nothing and burned
+        no attempt, and the pass ends inside its own budget rather than
+        N x the per-command ceiling.
+        """
+        hass = _svc_hass()
+        gap = 0.15
+        budget = 0.375  # room for two waits (0.15 + 0.15), not for a third
+        queue = _queue(gap=gap)
+        covers = [f"cover.c{i}" for i in range(1, 7)]
+        svc = _reconcile_svc(hass, queue, covers)
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(svc, "_is_cover_in_transit", return_value=False),
+            patch.object(svc, "_reconciliation_queue_budget", return_value=budget),
+        ):
+            await asyncio.wait_for(
+                svc.run_reconciliation_pass(dt.datetime.now(dt.UTC)), timeout=5.0
+            )
+        elapsed = loop.time() - started
+
+        sent = _sent_entities(hass)
+        # More than the single frame the old stand-down allowed, and fewer than
+        # all six — the allowance genuinely cut in.
+        assert 1 < len(sent) < len(covers)
+        assert sent == covers[: len(sent)]
+        for entity_id in sent:
+            assert svc.state(entity_id).retry_count == 1
+        for entity_id in covers[len(sent) :]:
+            assert svc.state(entity_id).retry_count == 0
+            assert svc.state(entity_id).gave_up is False
+        # The pass spent its allowance, not a per-entity multiple of it.
+        assert elapsed < budget + gap
+
+    @pytest.mark.asyncio
+    async def test_the_allowance_cannot_reach_the_next_pass(self):
+        """The overlap bound, stated on the shipped derivation.
+
+        Half the pass's own interval, so the other half is slack for the
+        transmissions themselves and for scheduler jitter — and never more than
+        the per-command ceiling for any single entity, so a slow interval does
+        not license a single cover to sit in the queue for minutes.
+        """
+        svc = _svc(_svc_hass(), command_queue=_queue())
+        interval_seconds = svc._check_interval_minutes * 60.0
+        allowance = svc._reconciliation_queue_budget()
+
+        assert allowance == interval_seconds * COMMAND_QUEUE_PASS_BUDGET_FRACTION
+        assert allowance < interval_seconds
+        # A single entity is capped twice over: by what the pass has left, and
+        # by the per-command bounded-wait invariant.
+        deadline = time.monotonic() + 10_000.0
+        assert svc._resend_wait_allowance(deadline) == COMMAND_QUEUE_MAX_WAIT_SECONDS
+        assert svc._resend_wait_allowance(time.monotonic() - 1.0) == 0.0
+
+    @pytest.mark.asyncio
+    async def test_a_re_armed_cover_does_not_starve_the_others(self):
+        """The starvation case: sun tracking re-arming the first cover.
+
+        ``apply_position`` resets ``retry_count``/``gave_up``, so a re-targeted
+        cover re-enters every pass at the front of the dispatch order. With the
+        stand-down keyed on "slot free this instant", that cover's own resend
+        spaced the air and the covers behind it were never resent once — a cover
+        stuck off target with no retry, no warning and no diagnostic, on a
+        default configuration.
+        """
+        hass = _svc_hass()
+        queue = _queue(gap=_GAP)
+        covers = ["cover.c1", "cover.c2", "cover.c3"]
+        svc = _reconcile_svc(hass, queue, covers)
+        resent: dict[str, int] = dict.fromkeys(covers, 0)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(svc, "_is_cover_in_transit", return_value=False),
+        ):
+            for cycle in range(3):
+                # Sun tracking re-targets the first cover between passes.
+                await svc.apply_position("cover.c1", 50 + cycle, "solar", _ctx())
+                hass.services.async_call.reset_mock()
+                for entity_id in covers:
+                    svc.set_waiting(entity_id, False)
+                await asyncio.wait_for(
+                    svc.run_reconciliation_pass(dt.datetime.now(dt.UTC)), timeout=5.0
+                )
+                for entity_id in _sent_entities(hass):
+                    resent[entity_id] += 1
+
+        assert resent["cover.c2"] > 0, "cover.c2 was never resent"
+        assert resent["cover.c3"] > 0, "cover.c3 was never resent"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_command_queue.py
+++ b/tests/test_command_queue.py
@@ -15,6 +15,7 @@ Test classes mirror the implementation steps:
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -165,9 +166,10 @@ class TestQueueMechanics:
         order: list[tuple[str, float]] = []
 
         async def run(entity: str) -> None:
-            assert await queue.acquire(entity, head_of_line=False, budget=_BUDGET)
+            grant = await queue.acquire(entity, head_of_line=False, budget=_BUDGET)
+            assert grant is not None
             order.append((entity, loop.time()))
-            queue.release(entity, transmitted=True)
+            queue.release(grant, transmitted=True)
 
         await run("cover.a")
         await run("cover.b")
@@ -186,7 +188,7 @@ class TestQueueMechanics:
         await asyncio.sleep(0)
         assert not task.done()
 
-        queue.release("cover.a", transmitted=True)
+        queue.release(first, transmitted=True)
         second = await task
         assert second is not None
         assert second.waited_seconds > 0.0
@@ -195,12 +197,13 @@ class TestQueueMechanics:
     @pytest.mark.asyncio
     async def test_release_untransmitted_grants_next_with_no_spacing(self):
         queue = _queue(gap=10.0)
-        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
         task = asyncio.create_task(
             queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
         )
         await asyncio.sleep(0)
-        queue.release("cover.a", transmitted=False)
+        queue.release(first, transmitted=False)
         second = await asyncio.wait_for(task, timeout=1.0)
         assert second is not None
         assert second.budget_expired is False
@@ -208,13 +211,15 @@ class TestQueueMechanics:
     @pytest.mark.asyncio
     async def test_head_of_line_jumps_ahead_of_routine_waiters(self):
         queue = _queue()
-        assert await queue.acquire("cover.h", head_of_line=False, budget=_BUDGET)
+        holder = await queue.acquire("cover.h", head_of_line=False, budget=_BUDGET)
+        assert holder is not None
         granted: list[str] = []
 
         async def run(entity: str, *, head: bool) -> None:
-            assert await queue.acquire(entity, head_of_line=head, budget=_BUDGET)
+            grant = await queue.acquire(entity, head_of_line=head, budget=_BUDGET)
+            assert grant is not None
             granted.append(entity)
-            queue.release(entity, transmitted=False)
+            queue.release(grant, transmitted=False)
 
         routine_1 = asyncio.create_task(run("cover.r1", head=False))
         await asyncio.sleep(0)
@@ -223,7 +228,7 @@ class TestQueueMechanics:
         safety = asyncio.create_task(run("cover.s", head=True))
         await asyncio.sleep(0)
 
-        queue.release("cover.h", transmitted=False)
+        queue.release(holder, transmitted=False)
         await asyncio.wait_for(
             asyncio.gather(routine_1, routine_2, safety), timeout=2.0
         )
@@ -235,8 +240,9 @@ class TestQueueMechanics:
         """Head-of-line is not bypass — a safety command still waits the gap."""
         queue = _queue()
         loop = asyncio.get_running_loop()
-        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
-        queue.release("cover.a", transmitted=True)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        queue.release(first, transmitted=True)
         started = loop.time()
         safety = await queue.acquire("cover.s", head_of_line=True, budget=_BUDGET)
         assert safety is not None
@@ -245,7 +251,8 @@ class TestQueueMechanics:
     @pytest.mark.asyncio
     async def test_waiting_reservation_is_superseded_by_a_newer_one(self):
         queue = _queue()
-        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        holder = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert holder is not None
 
         stale = asyncio.create_task(
             queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
@@ -258,7 +265,7 @@ class TestQueueMechanics:
 
         assert await asyncio.wait_for(stale, timeout=1.0) is None
 
-        queue.release("cover.a", transmitted=False)
+        queue.release(holder, transmitted=False)
         assert await asyncio.wait_for(fresh, timeout=1.0) is not None
 
     @pytest.mark.asyncio
@@ -272,7 +279,7 @@ class TestQueueMechanics:
         await asyncio.sleep(0)
         # The holder keeps its slot; the newcomer merely queues behind it.
         assert not waiting.done()
-        queue.release("cover.a", transmitted=False)
+        queue.release(holder, transmitted=False)
         assert await asyncio.wait_for(waiting, timeout=1.0) is not None
 
     @pytest.mark.asyncio
@@ -287,14 +294,15 @@ class TestQueueMechanics:
 
         # A budget-expired grant's release must still advance busy_until, and
         # must not hand the stuck holder's slot to anyone else.
-        queue.release("cover.b", transmitted=True)
+        queue.release(grant, transmitted=True)
         assert queue.busy_for_seconds() > 0.0
 
     @pytest.mark.asyncio
     async def test_budget_expiry_during_spacing_still_returns_a_grant(self):
         queue = _queue(gap=10.0)
-        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
-        queue.release("cover.a", transmitted=True)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        queue.release(first, transmitted=True)
         grant = await queue.acquire("cover.b", head_of_line=False, budget=0.02)
         assert grant is not None
         assert grant.budget_expired is True
@@ -316,23 +324,207 @@ class TestQueueMechanics:
     @pytest.mark.asyncio
     async def test_depth_reports_waiting_reservations(self):
         queue = _queue()
-        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
         assert queue.depth == 0
         task = asyncio.create_task(
             queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
         )
         await asyncio.sleep(0)
         assert queue.depth == 1
-        queue.release("cover.a", transmitted=False)
-        assert await asyncio.wait_for(task, timeout=1.0)
+        queue.release(first, transmitted=False)
+        second = await asyncio.wait_for(task, timeout=1.0)
+        assert second is not None
         assert queue.depth == 0
-        queue.release("cover.b", transmitted=False)
+        queue.release(second, transmitted=False)
+
+    @pytest.mark.asyncio
+    async def test_expired_grant_never_frees_the_same_entitys_live_slot(self):
+        """Two grants, one entity: only the one that HOLDS the slot may free it.
+
+        Same-entity concurrency is routine — ``apply_position`` can re-book an
+        entity a reconciliation resend is already transmitting, and at a
+        configured gap above the 30 s budget every wait ends this way. Keying
+        the release on the entity id makes the identity check vacuous: the
+        grant that gave up waiting frees the one that is still on the air, and
+        the next member keys on top of it.
+        """
+        queue = _queue()
+        holder = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert holder is not None
+        assert holder.holds_slot is True
+
+        # A second dispatch for the SAME entity gives up waiting.
+        expired = await queue.acquire("cover.a", head_of_line=False, budget=0.02)
+        assert expired is not None
+        assert expired.budget_expired is True
+        assert expired.holds_slot is False
+
+        waiter = asyncio.create_task(
+            queue.acquire("cover.c", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+
+        queue.release(expired, transmitted=True)
+        await asyncio.sleep(0)
+        # cover.a is still mid-transmit, so the slot is still cover.a's.
+        assert queue._owner == "cover.a"
+        assert not waiter.done()
+
+        queue.release(holder, transmitted=False)
+        assert await asyncio.wait_for(waiter, timeout=1.0) is not None
 
     def test_grant_is_a_frozen_slotted_dataclass(self):
         grant = QueueGrant(waited_seconds=0.0, budget_expired=False, depth_at_enqueue=0)
         with pytest.raises(Exception):
             grant.waited_seconds = 1.0  # type: ignore[misc]
         assert not hasattr(grant, "__dict__")
+
+
+# ---------------------------------------------------------------------------
+# Step 2b — unwinding an interrupted acquisition
+#
+# A dispatch task really does get torn down mid-acquire: the #1138 external
+# interlock cancels the prior task for a follower when a second external
+# command lands, and unload cancels every one of them. A slot stranded by that
+# teardown never comes back on its own — every other member then enqueues,
+# burns the whole 30 s budget and transmits ``budget_expired``, unspaced and
+# simultaneous, which is the exact collision this feature exists to prevent.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestInterruptedAcquire:
+    """Cancellation must never leave the slot held."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_the_spacing_sleep_releases_the_slot(self):
+        queue = _queue(gap=0.2)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        queue.release(first, transmitted=True)  # spacing now owed
+
+        task = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        # cover.b took the slot and is sleeping out the previous send's gap.
+        assert queue._owner == "cover.b"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert queue._owner is None
+        # Granted on the remaining spacing, not after the whole budget — the
+        # tell that the slot was really free rather than stranded.
+        grant = await queue.acquire("cover.c", head_of_line=False, budget=0.5)
+        assert grant is not None
+        assert grant.budget_expired is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_after_the_grant_lands_releases_the_slot(self):
+        """``_grant_next`` records the owner and resolves the future together.
+
+        Between those two and the waiting task actually resuming there is a
+        whole scheduler turn, and a cancellation delivered in it used to clean
+        the tiers while leaving ownership behind.
+        """
+        queue = _queue(gap=0.0)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        task = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+
+        queue.release(first, transmitted=False)
+        assert queue._owner == "cover.b"  # granted, but cover.b has not resumed
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert queue._owner is None
+        grant = await queue.acquire("cover.c", head_of_line=False, budget=0.5)
+        assert grant is not None
+        assert grant.budget_expired is False
+
+    @pytest.mark.asyncio
+    async def test_supersede_landing_with_the_budget_expiry_is_not_a_grant(self):
+        """A ``False`` resolved in the expiry iteration is a skip, not a grant.
+
+        The two events can land in one scheduler batch: the supersede resolves
+        the future first, then the deadline callback finds it already done and
+        falls back to ``_must_cancel``, so the wait raises ``TimeoutError`` over
+        a future that says "superseded". Reading only "was it granted" turns
+        that into a budget-expired GRANT, and the caller transmits a target a
+        newer decision has already replaced.
+        """
+        queue = _queue(gap=0.0)
+        loop = asyncio.get_running_loop()
+        holder = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert holder is not None
+
+        task = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=0.05)
+        )
+        await asyncio.sleep(0)
+        # Block the loop past the deadline so the supersede and the deadline
+        # handle are picked up in the SAME batch, supersede first.
+        time.sleep(0.06)
+        loop.call_soon(lambda: queue._enqueue("cover.b", head_of_line=False))
+
+        assert await asyncio.wait_for(task, timeout=1.0) is None
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_dispatch_hands_the_slot_back(self):
+        """The same teardown, seen from ``apply_position``."""
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        gate = asyncio.Event()
+
+        async def _blocked(*_a, **_kw):
+            await gate.wait()
+
+        hass.services.async_call = AsyncMock(side_effect=_blocked)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            task = asyncio.create_task(
+                svc.apply_position("cover.a", 70, "solar", _ctx())
+            )
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert queue._owner == "cover.a"
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert queue._owner is None
+
+    @pytest.mark.asyncio
+    async def test_an_error_before_the_send_hands_the_slot_back(self):
+        """Nothing between the grant and the send may strand the slot."""
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(
+                svc, "_prepare_service_call", side_effect=RuntimeError("boom")
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert queue._owner is None
+        # Nothing went out, so nobody owes the air anything.
+        assert queue.busy_for_seconds() == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -467,7 +659,7 @@ class TestDispatchGate:
             assert svc.get_target("cover.a") is None
             svc._grace_mgr.start_command_grace_period.assert_not_called()
 
-            queue.release("cover.blocker", transmitted=False)
+            queue.release(blocker, transmitted=False)
             assert await asyncio.wait_for(fresh, timeout=2.0) == (
                 "sent",
                 "set_cover_position",
@@ -660,7 +852,8 @@ class TestOrderingAndGraceWindow:
 
         # Hold the queue so the dispatch below has to wait out a real gap.
         held = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
-        queue.release("cover.other", transmitted=True)
+        assert held is not None
+        queue.release(held, transmitted=True)
         started = loop.time()
 
         with (
@@ -699,7 +892,7 @@ class TestOrderingAndGraceWindow:
             )
             assert second is not None
             assert second.budget_expired is False
-            queue.release("cover.b", transmitted=False)
+            queue.release(second, transmitted=False)
             await asyncio.wait_for(first, timeout=2.0)
 
         assert "after_position_command" in log
@@ -755,10 +948,60 @@ class TestOtherWireSites:
             task = asyncio.create_task(svc._execute_command("cover.a", 70))
             await asyncio.sleep(0)
             hass.services.async_call.assert_not_awaited()
-            queue.release("cover.other", transmitted=False)
+            queue.release(holder, transmitted=False)
             await asyncio.wait_for(task, timeout=2.0)
 
         hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_resend_yields_to_a_waiting_live_dispatch(self):
+        """Supersede has a DIRECTION: a resend never displaces a live decision.
+
+        Both seams acquire under the same one-reservation-per-entity rule, so a
+        resend enqueuing behind a WAITING ``apply_position`` for the same entity
+        used to cancel it. The fresh dispatch then returned
+        ``superseded_in_queue`` having booked nothing, and what went on the air
+        was the previously booked target — the module's own guarantee that the
+        frame that finally goes out carries the most recent decision, inverted.
+        """
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        # Somebody else holds the slot so the live dispatch has to wait.
+        blocker = await queue.acquire("cover.blocker", head_of_line=False, budget=5.0)
+        assert blocker is not None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            live = asyncio.create_task(
+                svc.apply_position("cover.a", 70, "solar", _ctx())
+            )
+            await asyncio.sleep(0)
+            assert queue.depth == 1
+
+            # The reconciliation pass re-books the OLD target behind it.
+            resend = asyncio.create_task(svc._execute_command("cover.a", 40))
+            await asyncio.sleep(0)
+
+            # It stood down at once instead of taking the live reservation's
+            # place — no reservation of its own, and the live one untouched.
+            assert resend.done()
+            assert not live.done()
+            assert queue.depth == 1
+            hass.services.async_call.assert_not_awaited()
+
+            queue.release(blocker, transmitted=False)
+            assert await asyncio.wait_for(live, timeout=2.0) == (
+                "sent",
+                "set_cover_position",
+            )
+            await asyncio.wait_for(resend, timeout=1.0)
+
+        # One frame, carrying the FRESH target.
+        assert hass.services.async_call.await_count == 1
+        assert hass.services.async_call.await_args[0][2]["position"] == 70
 
     @pytest.mark.asyncio
     async def test_stop_transmits_immediately_and_reports_the_air_as_busy(self):
@@ -790,6 +1033,114 @@ class TestOtherWireSites:
         svc = _svc(hass)
         await svc._stop_tracker.call_stop_cover("cover.a")
         hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mark_queue_external_transmit_is_a_noop_when_unqueued(self):
+        hass = _svc_hass()
+        svc = _svc(hass)
+        svc.mark_queue_external_transmit()  # must not raise
+        assert COMMAND_QUEUE_REGISTRY_KEY not in hass.data
+
+    @pytest.mark.asyncio
+    async def test_mark_queue_external_transmit_advances_the_spacing(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        assert queue.busy_for_seconds() == 0.0
+        svc.mark_queue_external_transmit()
+        assert queue.busy_for_seconds() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Step 5b — the venetian tail's own frame
+#
+# The settle+tilt tail runs OUTSIDE the slot on purpose (holding it across a
+# settle capped at 60 s would starve the queue, and #1115's day/night guard
+# depends on the tail not holding it). That makes the tilt frame a transmission
+# the queue never gated, exactly like a stop — so, exactly like a stop, it has
+# to tell the queue, or the next member keys on top of it.
+# ---------------------------------------------------------------------------
+
+
+def _tilt_sequencer(queue, *, position: int = 70):
+    """Build a ``DualAxisSequencer`` wired to *queue*, settling instantly."""
+    from custom_components.adaptive_cover_pro.cover_types.venetian.sequencer import (
+        DualAxisSequencer,
+    )
+
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass, DualAxisSequencer(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=lambda _eid: position,
+        set_commanded_position=lambda *_a: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        post_settle_hold_seconds=0,
+        mark_air_busy=None if queue is None else queue.mark_external_transmit,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("neutralize_venetian_delays")
+class TestVenetianTailReportsItsFrame:
+    """The tail transmits outside the slot, so it reports the air as busy."""
+
+    @pytest.mark.asyncio
+    async def test_the_tail_reports_its_tilt_frame_to_the_queue(self):
+        queue = _queue()
+        hass, seq = _tilt_sequencer(queue)
+        assert queue.busy_for_seconds() == 0.0
+
+        await seq.run_sequence(
+            "cover.a", position_target=70, tilt_target=40, reason="solar"
+        )
+
+        hass.services.async_call.assert_awaited()
+        assert queue.busy_for_seconds() > 0.0
+
+    @pytest.mark.asyncio
+    async def test_a_deduped_tail_reports_nothing(self):
+        """No frame, no spacing — the tail only owes the air what it used."""
+        queue = _queue()
+        _hass_obj, seq = _tilt_sequencer(queue)
+        seq._tilt_targets["cover.a"] = 40
+        seq._tilt_targets_verified.add("cover.a")
+
+        await seq.run_sequence(
+            "cover.a", position_target=70, tilt_target=40, reason="solar"
+        )
+
+        assert queue.busy_for_seconds() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_an_unwired_sequencer_is_untouched(self):
+        _hass_obj, seq = _tilt_sequencer(None)
+        await seq.run_sequence(
+            "cover.a", position_target=70, tilt_target=40, reason="solar"
+        )
+
+    def test_the_policy_wires_the_queue_reporter_onto_its_sequencer(self):
+        """``attach`` is where the tail meets the command service."""
+        from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
+            VenetianPolicy,
+        )
+
+        svc = _svc(_svc_hass(), command_queue=_queue())
+        policy = VenetianPolicy()
+        policy.attach(
+            hass=MagicMock(),
+            logger=MagicMock(),
+            grace_mgr=MagicMock(),
+            get_current_position=lambda _eid: 0,
+            set_commanded_position=lambda *_a: None,
+            position_tolerance=5,
+            is_dry_run=lambda: False,
+            mark_air_busy=svc.mark_queue_external_transmit,
+        )
+        assert policy.sequencer._mark_air_busy == svc.mark_queue_external_transmit
 
 
 # ---------------------------------------------------------------------------
@@ -1133,7 +1484,7 @@ class TestCrossEntrySerialization:
             await asyncio.sleep(0)
             safety = asyncio.create_task(_dispatch(b, "cover.b", 0, is_safety=True))
             await asyncio.sleep(0)
-            queue.release("cover.z", transmitted=True)
+            queue.release(holder, transmitted=True)
             released_at = loop.time()
             await asyncio.wait_for(asyncio.gather(routine, safety), timeout=5.0)
 
@@ -1189,6 +1540,57 @@ class TestCommandQueueConfigFlow:
         assert entry.data[CONF_SENSOR_TYPE] == CoverType.COMMAND_QUEUE
         assert entry.data["name"] == "Facade South"
         assert entry.options[CONF_COMMAND_QUEUE_GAP] == 7.5
+
+    async def test_a_second_queue_with_the_same_name_is_refused(self, hass):
+        """The NAME is the identity here — two entries owning it corrupt the gap.
+
+        Unlike a Building Profile, which links by ``entry_id``, a Command Queue
+        entry binds itself to the shared queue by normalized name. Two entries
+        on one name both ``attach()`` and both ``set_gap()``, so the bound gap
+        is whichever loaded last — and unloading or deleting EITHER runs
+        ``set_gap(None)``, silently reverting the queue to the default while
+        the surviving entry's UI still shows its configured value.
+        """
+        await _add_queue_entry(hass, name="Facade South", gap=7.5)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_command_queue"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            # Normalized-equal, not byte-equal: the invisible-typo classes the
+            # matcher folds everywhere else must fold here too.
+            {"name": "  facade   SOUTH ", CONF_COMMAND_QUEUE_GAP: 2.0},
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == "already_configured"
+
+        queue_entries = [
+            entry
+            for entry in hass.config_entries.async_entries(DOMAIN)
+            if entry.data.get(CONF_SENSOR_TYPE) == CoverType.COMMAND_QUEUE
+        ]
+        assert len(queue_entries) == 1
+        assert queue_entries[0].options[CONF_COMMAND_QUEUE_GAP] == 7.5
+
+    async def test_a_distinct_queue_name_still_creates(self, hass):
+        await _add_queue_entry(hass, name="Facade South", gap=7.5)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_command_queue"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Facade North", CONF_COMMAND_QUEUE_GAP: 2.0},
+        )
+        assert result["type"] == "create_entry"
+        assert result["result"].data["name"] == "Facade North"
 
     async def test_create_step_defaults_the_gap_to_the_constant(self, hass):
         from custom_components.adaptive_cover_pro.config_flow import (
@@ -1409,8 +1811,8 @@ class TestQueueDiagnostics:
         queue = _queue()
         svc = _svc(hass, command_queue=queue)
         held = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
-        queue.release("cover.other", transmitted=True)
         assert held is not None
+        queue.release(held, transmitted=True)
 
         with (
             _patch_caps(),

--- a/tests/test_command_queue.py
+++ b/tests/test_command_queue.py
@@ -1,0 +1,1489 @@
+"""Issue #1189 — named cover-command dispatch queue.
+
+Covers sharing a queue name never transmit at the same moment: the queue holds
+the slot for a configurable gap after every send, so one-way radio backends
+(Somfy RTS, RFXtrx) stop losing colliding frames.
+
+Test classes mirror the implementation steps:
+
+* ``TestNormalization`` / ``TestRegistry`` — the pure name folding and the
+  ``hass.data`` registry with attach/detach refcounting.
+* ``TestQueueMechanics`` — the ``CommandQueue`` state machine (serialization,
+  head-of-line, supersede, bounded budget) with no HA involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    COMMAND_QUEUE_REGISTRY_KEY,
+    CONF_COMMAND_QUEUE,
+    CONF_COMMAND_QUEUE_GAP,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DEFAULT_COMMAND_QUEUE_GAP,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+from custom_components.adaptive_cover_pro.cover_types import (
+    POLICY_REGISTRY,
+    get_policy,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
+    ServiceCallPlan,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command.queue import (
+    CommandQueue,
+    QueueGrant,
+    get_command_queue,
+    normalize_queue_name,
+)
+
+# A gap short enough to keep the suite fast but long enough to be observable.
+_GAP = 0.05
+# Generous budget — the bounded-wait tests set their own tiny one.
+_BUDGET = 5.0
+
+
+def _hass() -> SimpleNamespace:
+    """Minimal hass stand-in: the queue registry only ever touches ``.data``."""
+    return SimpleNamespace(data={})
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNormalization:
+    """``normalize_queue_name`` folds the invisible-typo classes."""
+
+    def test_folds_case(self):
+        assert normalize_queue_name("Facade South") == normalize_queue_name(
+            "facade south"
+        )
+        assert normalize_queue_name("FACADE SOUTH") == "facade south"
+
+    def test_collapses_internal_whitespace(self):
+        assert normalize_queue_name("Facade  South") == normalize_queue_name(
+            "Facade South"
+        )
+        assert normalize_queue_name("Facade\tSouth") == "facade south"
+
+    def test_strips_surrounding_whitespace(self):
+        assert normalize_queue_name("  Facade South  ") == "facade south"
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t\n", None])
+    def test_blank_is_empty(self, blank):
+        assert normalize_queue_name(blank) == ""
+
+    def test_casefold_not_lower(self):
+        """Casefold, so locale-quirky pairs still collapse (German sharp s)."""
+        assert normalize_queue_name("STRASSE") == normalize_queue_name("straße")
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRegistry:
+    """``get_command_queue`` is the single shared-object accessor."""
+
+    def test_same_object_for_normalized_equal_names(self):
+        hass = _hass()
+        a = get_command_queue(hass, normalize_queue_name("Facade South"))
+        b = get_command_queue(hass, normalize_queue_name("  facade   south "))
+        assert a is b
+
+    def test_distinct_objects_for_distinct_names(self):
+        hass = _hass()
+        a = get_command_queue(hass, normalize_queue_name("Facade South"))
+        b = get_command_queue(hass, normalize_queue_name("Facade North"))
+        assert a is not b
+
+    def test_refcount_keeps_queue_until_last_detach(self):
+        hass = _hass()
+        queue = get_command_queue(hass, "facade south")
+        queue.attach()
+        queue.attach()
+        queue.detach()
+        assert hass.data[COMMAND_QUEUE_REGISTRY_KEY].get("facade south") is queue
+        queue.detach()
+        assert "facade south" not in hass.data[COMMAND_QUEUE_REGISTRY_KEY]
+
+    def test_default_gap_is_the_constant(self):
+        hass = _hass()
+        queue = get_command_queue(hass, "facade south")
+        assert queue.gap_seconds == DEFAULT_COMMAND_QUEUE_GAP
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — queue mechanics (pure asyncio, no HA)
+# ---------------------------------------------------------------------------
+
+
+def _queue(gap: float = _GAP) -> CommandQueue:
+    q = CommandQueue("facade south")
+    q.set_gap(gap)
+    return q
+
+
+@pytest.mark.unit
+class TestQueueMechanics:
+    """The ``CommandQueue`` state machine."""
+
+    @pytest.mark.asyncio
+    async def test_first_send_is_immediate(self):
+        """The gap applies AFTER a send, never before the first one."""
+        queue = _queue()
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        grant = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert isinstance(grant, QueueGrant)
+        assert grant.waited_seconds == 0.0
+        assert grant.budget_expired is False
+        assert grant.depth_at_enqueue == 0
+        assert loop.time() - started < _GAP
+
+    @pytest.mark.asyncio
+    async def test_two_acquires_serialize_with_the_gap(self):
+        queue = _queue()
+        loop = asyncio.get_running_loop()
+        order: list[tuple[str, float]] = []
+
+        async def run(entity: str) -> None:
+            assert await queue.acquire(entity, head_of_line=False, budget=_BUDGET)
+            order.append((entity, loop.time()))
+            queue.release(entity, transmitted=True)
+
+        await run("cover.a")
+        await run("cover.b")
+        assert [e for e, _ in order] == ["cover.a", "cover.b"]
+        assert order[1][1] - order[0][1] >= _GAP
+
+    @pytest.mark.asyncio
+    async def test_second_waiter_blocks_until_the_holder_releases(self):
+        queue = _queue()
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+
+        task = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        queue.release("cover.a", transmitted=True)
+        second = await task
+        assert second is not None
+        assert second.waited_seconds > 0.0
+        assert second.depth_at_enqueue == 0
+
+    @pytest.mark.asyncio
+    async def test_release_untransmitted_grants_next_with_no_spacing(self):
+        queue = _queue(gap=10.0)
+        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        task = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        queue.release("cover.a", transmitted=False)
+        second = await asyncio.wait_for(task, timeout=1.0)
+        assert second is not None
+        assert second.budget_expired is False
+
+    @pytest.mark.asyncio
+    async def test_head_of_line_jumps_ahead_of_routine_waiters(self):
+        queue = _queue()
+        assert await queue.acquire("cover.h", head_of_line=False, budget=_BUDGET)
+        granted: list[str] = []
+
+        async def run(entity: str, *, head: bool) -> None:
+            assert await queue.acquire(entity, head_of_line=head, budget=_BUDGET)
+            granted.append(entity)
+            queue.release(entity, transmitted=False)
+
+        routine_1 = asyncio.create_task(run("cover.r1", head=False))
+        await asyncio.sleep(0)
+        routine_2 = asyncio.create_task(run("cover.r2", head=False))
+        await asyncio.sleep(0)
+        safety = asyncio.create_task(run("cover.s", head=True))
+        await asyncio.sleep(0)
+
+        queue.release("cover.h", transmitted=False)
+        await asyncio.wait_for(
+            asyncio.gather(routine_1, routine_2, safety), timeout=2.0
+        )
+        # Safety first, then FIFO within the routine tier.
+        assert granted == ["cover.s", "cover.r1", "cover.r2"]
+
+    @pytest.mark.asyncio
+    async def test_safety_still_takes_its_spacing(self):
+        """Head-of-line is not bypass — a safety command still waits the gap."""
+        queue = _queue()
+        loop = asyncio.get_running_loop()
+        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        queue.release("cover.a", transmitted=True)
+        started = loop.time()
+        safety = await queue.acquire("cover.s", head_of_line=True, budget=_BUDGET)
+        assert safety is not None
+        assert loop.time() - started >= _GAP
+
+    @pytest.mark.asyncio
+    async def test_waiting_reservation_is_superseded_by_a_newer_one(self):
+        queue = _queue()
+        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+
+        stale = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        fresh = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+
+        assert await asyncio.wait_for(stale, timeout=1.0) is None
+
+        queue.release("cover.a", transmitted=False)
+        assert await asyncio.wait_for(fresh, timeout=1.0) is not None
+
+    @pytest.mark.asyncio
+    async def test_current_holder_is_never_superseded(self):
+        queue = _queue()
+        holder = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert holder is not None
+        waiting = asyncio.create_task(
+            queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        # The holder keeps its slot; the newcomer merely queues behind it.
+        assert not waiting.done()
+        queue.release("cover.a", transmitted=False)
+        assert await asyncio.wait_for(waiting, timeout=1.0) is not None
+
+    @pytest.mark.asyncio
+    async def test_budget_expiry_transmits_anyway_and_still_spaces(self):
+        queue = _queue(gap=10.0)
+        holder = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert holder is not None
+
+        grant = await queue.acquire("cover.b", head_of_line=False, budget=0.02)
+        assert grant is not None
+        assert grant.budget_expired is True
+
+        # A budget-expired grant's release must still advance busy_until, and
+        # must not hand the stuck holder's slot to anyone else.
+        queue.release("cover.b", transmitted=True)
+        assert queue.busy_for_seconds() > 0.0
+
+    @pytest.mark.asyncio
+    async def test_budget_expiry_during_spacing_still_returns_a_grant(self):
+        queue = _queue(gap=10.0)
+        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        queue.release("cover.a", transmitted=True)
+        grant = await queue.acquire("cover.b", head_of_line=False, budget=0.02)
+        assert grant is not None
+        assert grant.budget_expired is True
+
+    @pytest.mark.asyncio
+    async def test_set_gap_none_restores_the_default(self):
+        queue = _queue(gap=1.5)
+        assert queue.gap_seconds == 1.5
+        queue.set_gap(None)
+        assert queue.gap_seconds == DEFAULT_COMMAND_QUEUE_GAP
+
+    @pytest.mark.asyncio
+    async def test_mark_external_transmit_advances_busy_until(self):
+        queue = _queue(gap=1.5)
+        assert queue.busy_for_seconds() == 0.0
+        queue.mark_external_transmit()
+        assert queue.busy_for_seconds() > 0.0
+
+    @pytest.mark.asyncio
+    async def test_depth_reports_waiting_reservations(self):
+        queue = _queue()
+        assert await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert queue.depth == 0
+        task = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)
+        assert queue.depth == 1
+        queue.release("cover.a", transmitted=False)
+        assert await asyncio.wait_for(task, timeout=1.0)
+        assert queue.depth == 0
+        queue.release("cover.b", transmitted=False)
+
+    def test_grant_is_a_frozen_slotted_dataclass(self):
+        grant = QueueGrant(waited_seconds=0.0, budget_expired=False, depth_at_enqueue=0)
+        with pytest.raises(Exception):
+            grant.waited_seconds = 1.0  # type: ignore[misc]
+        assert not hasattr(grant, "__dict__")
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — the gate inside apply_position
+# ---------------------------------------------------------------------------
+
+
+_CAPS = {
+    "has_set_position": True,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+
+
+def _svc_hass() -> MagicMock:
+    h = MagicMock()
+    h.data = {}
+    h.services.async_call = AsyncMock()
+    return h
+
+
+def _svc(hass, *, command_queue=None) -> CoverCommandService:
+    s = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        command_queue=command_queue,
+    )
+    s._enabled = True
+    return s
+
+
+def _ctx(*, is_safety=False, user_command=False, policy=None):
+    return PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=1,
+        time_threshold=0,
+        special_positions=[0, 100],
+        force=True,
+        is_safety=is_safety,
+        user_command=user_command,
+        policy=policy,
+    )
+
+
+def _patch_caps(caps=None):
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command"
+        ".check_cover_features",
+        return_value=dict(caps or _CAPS),
+    )
+
+
+@pytest.mark.unit
+class TestDispatchGate:
+    """``apply_position``'s queue gate — placement, staleness, release."""
+
+    @pytest.mark.asyncio
+    async def test_unqueued_cover_dispatch_is_untouched(self):
+        """No queue configured → not one queue call, not one registry key."""
+        hass = _svc_hass()
+        svc = _svc(hass)
+
+        async def _explode(*_a, **_kw):
+            raise AssertionError("the queue must not be consulted when unqueued")
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(CommandQueue, "acquire", _explode),
+        ):
+            outcome, _ = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert outcome == "sent"
+        assert COMMAND_QUEUE_REGISTRY_KEY not in hass.data
+
+    @pytest.mark.asyncio
+    async def test_queued_second_cover_waits_out_the_gap(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        loop = asyncio.get_running_loop()
+        stamps: list[float] = []
+        hass.services.async_call = AsyncMock(
+            side_effect=lambda *a, **kw: stamps.append(loop.time())
+        )
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx())
+            await svc.apply_position("cover.b", 70, "solar", _ctx())
+
+        assert len(stamps) == 2
+        assert stamps[1] - stamps[0] >= _GAP
+
+    @pytest.mark.asyncio
+    async def test_superseded_reservation_skips_and_books_nothing(self):
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        # Somebody else holds the slot so both attempts have to wait.
+        blocker = await queue.acquire("cover.blocker", head_of_line=False, budget=5.0)
+        assert blocker is not None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            stale = asyncio.create_task(
+                svc.apply_position("cover.a", 70, "solar", _ctx())
+            )
+            await asyncio.sleep(0)
+            fresh = asyncio.create_task(
+                svc.apply_position("cover.a", 40, "solar", _ctx())
+            )
+            await asyncio.sleep(0)
+
+            assert await asyncio.wait_for(stale, timeout=2.0) == (
+                "skipped",
+                "superseded_in_queue",
+            )
+            # Nothing booked by the superseded attempt.
+            assert svc.state("cover.a").sent_at is None
+            assert svc.get_target("cover.a") is None
+            svc._grace_mgr.start_command_grace_period.assert_not_called()
+
+            queue.release("cover.blocker", transmitted=False)
+            assert await asyncio.wait_for(fresh, timeout=2.0) == (
+                "sent",
+                "set_cover_position",
+            )
+
+    @pytest.mark.asyncio
+    async def test_entity_gone_during_the_wait_is_a_clean_skip(self):
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(svc, "is_entity_unavailable", side_effect=[False, True]),
+        ):
+            outcome, detail = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert (outcome, detail) == ("skipped", "cover_unavailable")
+        hass.services.async_call.assert_not_awaited()
+        assert svc.state("cover.a").sent_at is None
+        assert svc.get_target("cover.a") is None
+        svc._grace_mgr.start_command_grace_period.assert_not_called()
+        # The slot went back untransmitted — no gap owed, no owner left behind.
+        assert queue.busy_for_seconds() == 0.0
+        assert queue._owner is None
+
+    @pytest.mark.asyncio
+    async def test_plan_is_recomputed_after_the_queue_wait(self):
+        """Capabilities can change across the wait — the stale plan must not ship."""
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        before = ServiceCallPlan(
+            service="set_cover_position",
+            service_data={"entity_id": "cover.a", "position": 70},
+            supports_position=True,
+            routed_target=70,
+        )
+        after = ServiceCallPlan(
+            service="open_cover",
+            service_data={"entity_id": "cover.a"},
+            supports_position=False,
+            routed_target=100,
+        )
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch(
+                "custom_components.adaptive_cover_pro.managers.cover_command"
+                ".route_service_call",
+                side_effect=[before, after],
+            ) as routed,
+        ):
+            outcome, detail = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert routed.call_count == 2
+        assert (outcome, detail) == ("sent", "open_cover")
+
+    @pytest.mark.asyncio
+    async def test_dry_run_never_touches_the_queue(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        svc._dry_run = True
+
+        async def _explode(*_a, **_kw):
+            raise AssertionError("a dry run must not consult the queue")
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(CommandQueue, "acquire", _explode),
+        ):
+            outcome, detail = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert (outcome, detail) == ("skipped", "dry_run")
+        assert queue._owner is None
+
+    @pytest.mark.asyncio
+    async def test_slot_is_released_even_when_the_service_call_raises(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("boom"))
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            outcome, detail = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert (outcome, detail) == ("skipped", "service_call_failed")
+        assert queue._owner is None
+
+    @pytest.mark.asyncio
+    async def test_no_capable_service_releases_untransmitted(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        caps = dict(_CAPS)
+        caps.update(has_set_position=False, has_open=False, has_close=False)
+
+        with (
+            _patch_caps(caps),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            outcome, detail = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert (outcome, detail) == ("skipped", "no_capable_service")
+        assert queue._owner is None
+        assert queue.busy_for_seconds() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — ordering + grace-window regression spine
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPolicy:
+    """A policy stub that records the order of the dispatch-path hooks."""
+
+    def __init__(self, log: list[str], *, tail: float = 0.0) -> None:
+        self._log = log
+        self._tail = tail
+
+    def capture_dispatch_token(self, _entity_id):
+        self._log.append("capture_dispatch_token")
+        return "token"
+
+    async def await_dispatch_clearance(self, _entity_id, **_kw):
+        self._log.append("await_dispatch_clearance")
+        return True
+
+    async def before_position_command(self, *_a, **_kw):
+        return None
+
+    async def after_position_command(self, *_a, **_kw):
+        self._log.append("after_position_command")
+        if self._tail:
+            await asyncio.sleep(self._tail)
+
+    async def maybe_update_tilt_only(self, *_a, **_kw):
+        return None
+
+
+@pytest.mark.unit
+class TestOrderingAndGraceWindow:
+    """The placement is load-bearing in both directions (#1115, #1139, #853)."""
+
+    @pytest.mark.asyncio
+    async def test_queue_acquire_runs_after_dispatch_clearance(self):
+        """Before the clearance gate the Model C middle rail would deadlock."""
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        log: list[str] = []
+        policy = _RecordingPolicy(log)
+
+        real_acquire = CommandQueue.acquire
+
+        async def _tracked(self, *a, **kw):
+            log.append("queue_acquire")
+            return await real_acquire(self, *a, **kw)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(CommandQueue, "acquire", _tracked),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx(policy=policy))
+
+        assert log[:3] == [
+            "capture_dispatch_token",
+            "await_dispatch_clearance",
+            "queue_acquire",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_command_grace_period_starts_after_queue_wait(self):
+        """#1139: a 20 s wait must not burn the 5 s grace window before the send."""
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        loop = asyncio.get_running_loop()
+        grace_at: list[float] = []
+        svc._grace_mgr.start_command_grace_period = MagicMock(
+            side_effect=lambda _e: grace_at.append(loop.time())
+        )
+
+        # Hold the queue so the dispatch below has to wait out a real gap.
+        held = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
+        queue.release("cover.other", transmitted=True)
+        started = loop.time()
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        assert held is not None
+        assert grace_at, "the grace window must be started by a real dispatch"
+        assert grace_at[0] - started >= _GAP
+        # sent_at is booked at transmit time too, not at decision time (#853).
+        assert svc.state("cover.a").sent_at is not None
+
+    @pytest.mark.asyncio
+    async def test_venetian_tail_runs_outside_the_queue_slot(self):
+        """The settle+tilt tail must not starve the queue for its whole duration."""
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        log: list[str] = []
+        policy = _RecordingPolicy(log, tail=0.2)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            first = asyncio.create_task(
+                svc.apply_position("cover.a", 70, "solar", _ctx(policy=policy))
+            )
+            await asyncio.sleep(0.05)
+            # The tail is still running; a second cover must not be blocked by it.
+            second = await asyncio.wait_for(
+                queue.acquire("cover.b", head_of_line=False, budget=0.05),
+                timeout=0.5,
+            )
+            assert second is not None
+            assert second.budget_expired is False
+            queue.release("cover.b", transmitted=False)
+            await asyncio.wait_for(first, timeout=2.0)
+
+        assert "after_position_command" in log
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — the other wire sites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOtherWireSites:
+    """Reconciliation queues like any dispatch; a stop reports without queueing."""
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_resend_takes_a_routine_turn(self):
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        calls: list[bool] = []
+        real_acquire = CommandQueue.acquire
+
+        async def _tracked(self, entity_id, *, head_of_line, budget):
+            calls.append(head_of_line)
+            return await real_acquire(
+                self, entity_id, head_of_line=head_of_line, budget=budget
+            )
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch.object(CommandQueue, "acquire", _tracked),
+        ):
+            await svc._execute_command("cover.a", 70)
+
+        assert calls == [False]
+        hass.services.async_call.assert_awaited_once()
+        assert queue._owner is None
+        assert queue.busy_for_seconds() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_resend_waits_behind_a_holder(self):
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        holder = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
+        assert holder is not None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            task = asyncio.create_task(svc._execute_command("cover.a", 70))
+            await asyncio.sleep(0)
+            hass.services.async_call.assert_not_awaited()
+            queue.release("cover.other", transmitted=False)
+            await asyncio.wait_for(task, timeout=2.0)
+
+        hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_transmits_immediately_and_reports_the_air_as_busy(self):
+        """Stops skip the queue but still report the air as busy.
+
+        A button press must not wait out someone else's gap — but it does
+        key the radio, so the queue is told.
+        """
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        marked: list[str] = []
+        real_mark = CommandQueue.mark_external_transmit
+
+        def _tracked(self):
+            marked.append(self.name)
+            real_mark(self)
+
+        with patch.object(CommandQueue, "mark_external_transmit", _tracked):
+            await svc._stop_tracker.call_stop_cover("cover.a")
+
+        hass.services.async_call.assert_awaited_once()
+        assert marked == [queue.name]
+        assert queue.busy_for_seconds() > 0.0
+
+    @pytest.mark.asyncio
+    async def test_stop_on_an_unqueued_cover_is_untouched(self):
+        hass = _svc_hass()
+        svc = _svc(hass)
+        await svc._stop_tracker.call_stop_cover("cover.a")
+        hass.services.async_call.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — the Command Queue entry type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEntryType:
+    """A virtual entry type, discriminated by capability and never by string."""
+
+    def test_cover_type_member_and_display_name(self):
+        assert CoverType.COMMAND_QUEUE == "cover_command_queue"
+        assert CoverType.COMMAND_QUEUE.display_name == "Command Queue"
+
+    def test_policy_capabilities(self):
+        policy = get_policy(CoverType.COMMAND_QUEUE)
+        assert policy.controls_cover is False
+        assert policy.is_command_queue is True
+        assert policy.axes == ()
+
+    def test_every_other_policy_is_not_a_command_queue(self):
+        for cover_type in POLICY_REGISTRY:
+            if cover_type == CoverType.COMMAND_QUEUE:
+                continue
+            assert get_policy(cover_type).is_command_queue is False
+
+    def test_entry_filters_exclude_and_include_the_right_entries(self):
+        from custom_components.adaptive_cover_pro.profile_link import (
+            _building_profile_entries,
+            _command_queue_entries,
+            _cover_entries,
+        )
+
+        entries = [
+            SimpleNamespace(
+                entry_id="cover", data={CONF_SENSOR_TYPE: CoverType.BLIND}, options={}
+            ),
+            SimpleNamespace(
+                entry_id="profile",
+                data={CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+                options={},
+            ),
+            SimpleNamespace(
+                entry_id="queue",
+                data={CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+                options={},
+            ),
+        ]
+        hass = MagicMock()
+        hass.config_entries.async_entries.return_value = entries
+
+        assert [e.entry_id for e in _cover_entries(hass)] == ["cover"]
+        assert [e.entry_id for e in _building_profile_entries(hass)] == ["profile"]
+        assert [e.entry_id for e in _command_queue_entries(hass)] == ["queue"]
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — queue-entry lifecycle (real config entries)
+# ---------------------------------------------------------------------------
+
+
+async def _add_queue_entry(hass, *, name="Facade South", gap=2.5, entry_id="queue_1"):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": name, CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+        options={CONF_COMMAND_QUEUE_GAP: gap},
+        entry_id=entry_id,
+        title=f"Command Queue {name}",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def _add_cover_entry(hass, *, entry_id, queue_name, entity="cover.test_blind"):
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    options = dict(VERTICAL_OPTIONS)
+    options[CONF_ENTITIES] = [entity]
+    if queue_name is not None:
+        options[CONF_COMMAND_QUEUE] = queue_name
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=options,
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _registry(hass) -> dict:
+    return hass.data.get(COMMAND_QUEUE_REGISTRY_KEY, {})
+
+
+@pytest.mark.integration
+class TestQueueEntryLifecycle:
+    """The queue entry owns the gap; the covers own the membership."""
+
+    async def test_queue_entry_binds_its_gap(self, hass):
+        await _add_queue_entry(hass, gap=2.5)
+        queue = _registry(hass)["facade south"]
+        assert queue.gap_seconds == 2.5
+        assert queue.attached == 1
+
+    async def test_a_name_with_no_entry_still_serializes_at_the_default(self, hass):
+        await _add_cover_entry(hass, entry_id="cov_a", queue_name="Unowned Queue")
+        queue = _registry(hass)["unowned queue"]
+        assert queue.gap_seconds == DEFAULT_COMMAND_QUEUE_GAP
+        assert queue.attached == 1
+
+    async def test_cover_joins_the_queue_by_normalized_name(self, hass):
+        await _add_queue_entry(hass, name="Facade South", gap=2.5)
+        await _add_cover_entry(hass, entry_id="cov_a", queue_name="  FACADE   south ")
+        assert list(_registry(hass)) == ["facade south"]
+        queue = _registry(hass)["facade south"]
+        assert queue.attached == 2
+        assert queue.gap_seconds == 2.5
+
+    async def test_options_update_propagates_without_reloading_members(self, hass):
+        entry = await _add_queue_entry(hass, gap=2.5)
+        cover = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South"
+        )
+        queue = _registry(hass)["facade south"]
+        coordinator_before = cover.runtime_data
+
+        hass.config_entries.async_update_entry(
+            entry, options={CONF_COMMAND_QUEUE_GAP: 7.5}
+        )
+        await hass.async_block_till_done()
+
+        assert queue.gap_seconds == 7.5
+        # Same live object, same live coordinator — nothing was torn down.
+        assert _registry(hass)["facade south"] is queue
+        assert cover.runtime_data is coordinator_before
+
+    async def test_unloading_the_entry_reverts_the_gap_but_keeps_members(self, hass):
+        entry = await _add_queue_entry(hass, gap=2.5)
+        await _add_cover_entry(hass, entry_id="cov_a", queue_name="Facade South")
+        queue = _registry(hass)["facade south"]
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert _registry(hass)["facade south"] is queue
+        assert queue.gap_seconds == DEFAULT_COMMAND_QUEUE_GAP
+        assert queue.attached == 1
+
+    async def test_member_reload_keeps_the_same_queue_object(self, hass):
+        await _add_queue_entry(hass, gap=2.5)
+        cover = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South"
+        )
+        queue = _registry(hass)["facade south"]
+
+        from tests.ha_helpers import _patch_coordinator_refresh
+
+        with _patch_coordinator_refresh():
+            await hass.config_entries.async_reload(cover.entry_id)
+            await hass.async_block_till_done()
+
+        assert _registry(hass)["facade south"] is queue
+        assert queue.attached == 2
+
+    async def test_registry_key_drops_when_the_last_member_leaves(self, hass):
+        entry = await _add_queue_entry(hass, gap=2.5)
+        cover = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South"
+        )
+
+        await hass.config_entries.async_unload(cover.entry_id)
+        await hass.async_block_till_done()
+        assert "facade south" in _registry(hass)
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+        assert "facade south" not in _registry(hass)
+
+    async def test_removing_the_queue_entry_leaves_cover_options_untouched(self, hass):
+        entry = await _add_queue_entry(hass, gap=2.5)
+        cover = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South"
+        )
+
+        await hass.config_entries.async_remove(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Dangling names are deliberate and functional: the cover keeps its
+        # assignment and reverts to the default gap.
+        assert cover.options[CONF_COMMAND_QUEUE] == "Facade South"
+
+    async def test_no_crosstalk_with_building_profiles(self, hass):
+        """A queue entry must never reach the profile propagation listener."""
+        from custom_components.adaptive_cover_pro import _async_profile_propagate
+
+        entry = await _add_queue_entry(hass, gap=2.5)
+        cover = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South"
+        )
+        before = dict(cover.options)
+
+        await _async_profile_propagate(hass, entry)
+        await hass.async_block_till_done()
+
+        assert dict(cover.options) == before
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — two live entries serialize
+# ---------------------------------------------------------------------------
+
+
+def _seed_cover_state(hass, entity_id: str, position: int = 10) -> None:
+    """Seed a position-capable cover: OPEN|CLOSE|SET_POSITION|STOP."""
+    hass.states.async_set(
+        entity_id,
+        "open",
+        {"current_position": position, "supported_features": 15},
+    )
+
+
+def _timed_cover_calls(order: list[tuple[str, float]]):
+    """Patch ``ServiceRegistry.async_call`` to stamp every cover command.
+
+    Patched on the CLASS: ``ServiceRegistry`` uses slots, so the instance
+    attribute is read-only. One helper rather than three copies — the three
+    tests below differ in what they assert about the order, not in how they
+    observe it.
+    """
+    from homeassistant.core import ServiceRegistry
+
+    original = ServiceRegistry.async_call
+    loop = asyncio.get_running_loop()
+
+    async def _timed(self, domain, service, service_data=None, *args, **kwargs):
+        if domain == "cover":
+            entity = (service_data or {}).get("entity_id")
+            order.append((entity, loop.time()))
+        return await original(self, domain, service, service_data, *args, **kwargs)
+
+    return patch.object(ServiceRegistry, "async_call", _timed)
+
+
+async def _dispatch(entry, entity_id: str, position: int, *, is_safety=False):
+    svc = entry.runtime_data._cmd_svc
+    return await svc.apply_position(
+        entity_id,
+        position,
+        "solar",
+        PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=1,
+            time_threshold=0,
+            special_positions=[0, 100],
+            force=True,
+            is_safety=is_safety,
+        ),
+    )
+
+
+@pytest.mark.integration
+class TestCrossEntrySerialization:
+    """The whole point: two independent config entries take turns."""
+
+    async def test_entries_sharing_a_name_serialize_across_casing(self, hass):
+        _seed_cover_state(hass, "cover.a")
+        _seed_cover_state(hass, "cover.b")
+        await _add_queue_entry(hass, name="Facade South", gap=_GAP)
+        a = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South", entity="cover.a"
+        )
+        b = await _add_cover_entry(
+            hass, entry_id="cov_b", queue_name="  facade   SOUTH ", entity="cover.b"
+        )
+        assert list(_registry(hass)) == ["facade south"]
+
+        order: list[tuple[str, float]] = []
+        with _timed_cover_calls(order):
+            await asyncio.gather(
+                _dispatch(a, "cover.a", 70),
+                _dispatch(b, "cover.b", 70),
+            )
+
+        assert {eid for eid, _ in order} == {"cover.a", "cover.b"}
+        assert order[1][1] - order[0][1] >= _GAP
+
+    async def test_different_names_do_not_influence_each_other(self, hass):
+        _seed_cover_state(hass, "cover.a")
+        _seed_cover_state(hass, "cover.b")
+        a = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="North", entity="cover.a"
+        )
+        b = await _add_cover_entry(
+            hass, entry_id="cov_b", queue_name="South", entity="cover.b"
+        )
+        assert sorted(_registry(hass)) == ["north", "south"]
+
+        order: list[tuple[str, float]] = []
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        with _timed_cover_calls(order):
+            await asyncio.gather(
+                _dispatch(a, "cover.a", 70),
+                _dispatch(b, "cover.b", 70),
+            )
+
+        assert {eid for eid, _ in order} == {"cover.a", "cover.b"}
+        # Both go out promptly — well inside one default gap.
+        assert max(ts for _, ts in order) - started < DEFAULT_COMMAND_QUEUE_GAP
+
+    async def test_safety_goes_first_but_still_waits_its_spacing(self, hass):
+        _seed_cover_state(hass, "cover.a")
+        _seed_cover_state(hass, "cover.b")
+        await _add_queue_entry(hass, name="Facade South", gap=_GAP)
+        a = await _add_cover_entry(
+            hass, entry_id="cov_a", queue_name="Facade South", entity="cover.a"
+        )
+        b = await _add_cover_entry(
+            hass, entry_id="cov_b", queue_name="Facade South", entity="cover.b"
+        )
+        queue = _registry(hass)["facade south"]
+
+        # A third member is mid-transmission, so both dispatches must queue.
+        holder = await queue.acquire("cover.z", head_of_line=False, budget=5.0)
+        assert holder is not None
+
+        loop = asyncio.get_running_loop()
+        order: list[tuple[str, float]] = []
+
+        with _timed_cover_calls(order):
+            routine = asyncio.create_task(_dispatch(a, "cover.a", 70))
+            await asyncio.sleep(0)
+            safety = asyncio.create_task(_dispatch(b, "cover.b", 0, is_safety=True))
+            await asyncio.sleep(0)
+            queue.release("cover.z", transmitted=True)
+            released_at = loop.time()
+            await asyncio.wait_for(asyncio.gather(routine, safety), timeout=5.0)
+
+        assert [eid for eid, _ in order] == ["cover.b", "cover.a"]
+        # Head of line, NOT bypass: the safety command still took its spacing.
+        assert order[0][1] - released_at >= _GAP
+
+
+# ---------------------------------------------------------------------------
+# Step 9 — config flow: create + options
+# ---------------------------------------------------------------------------
+
+
+def _schema_keys(schema) -> set[str]:
+    return {str(marker.schema) for marker in schema.schema}
+
+
+def _selector_for(schema, key):
+    for marker, sel in schema.schema.items():
+        if str(marker.schema) == key:
+            return sel
+    raise AssertionError(f"{key} not in schema")
+
+
+@pytest.mark.integration
+class TestCommandQueueConfigFlow:
+    """Creating a queue, editing it, and assigning covers to it."""
+
+    async def test_create_menu_offers_the_queue(self, hass):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        assert result["type"] == "menu"
+        assert "create_command_queue" in result["menu_options"]
+
+    async def test_create_step_round_trips_name_and_gap(self, hass):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_command_queue"}
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "create_command_queue"
+        assert _schema_keys(result["data_schema"]) == {"name", CONF_COMMAND_QUEUE_GAP}
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"name": "Facade South", CONF_COMMAND_QUEUE_GAP: 7.5},
+        )
+        assert result["type"] == "create_entry"
+        entry = result["result"]
+        assert entry.data[CONF_SENSOR_TYPE] == CoverType.COMMAND_QUEUE
+        assert entry.data["name"] == "Facade South"
+        assert entry.options[CONF_COMMAND_QUEUE_GAP] == 7.5
+
+    async def test_create_step_defaults_the_gap_to_the_constant(self, hass):
+        from custom_components.adaptive_cover_pro.config_flow import (
+            COMMAND_QUEUE_CREATE_SCHEMA,
+        )
+
+        validated = COMMAND_QUEUE_CREATE_SCHEMA({"name": "Q"})
+        assert validated[CONF_COMMAND_QUEUE_GAP] == DEFAULT_COMMAND_QUEUE_GAP
+
+    async def test_queue_options_menu(self, hass):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "Facade South", CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+            options={CONF_COMMAND_QUEUE_GAP: 2.5},
+            entry_id="queue_1",
+            title="Command Queue Facade South",
+        )
+        entry.add_to_hass(hass)
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+
+        result = await flow.async_step_init()
+        assert result["type"] == "menu"
+        assert result["menu_options"] == [
+            "queue_settings",
+            "queue_overview",
+            "done",
+        ]
+
+    async def test_queue_settings_round_trips_the_gap(self, hass):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "Facade South", CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+            options={CONF_COMMAND_QUEUE_GAP: 2.5},
+            entry_id="queue_1",
+            title="Command Queue Facade South",
+        )
+        entry.add_to_hass(hass)
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+
+        result = await flow.async_step_queue_settings()
+        assert result["type"] == "form"
+        assert _schema_keys(result["data_schema"]) == {CONF_COMMAND_QUEUE_GAP}
+
+        await flow.async_step_queue_settings({CONF_COMMAND_QUEUE_GAP: 9.0})
+        assert flow.options[CONF_COMMAND_QUEUE_GAP] == 9.0
+
+    async def test_queue_gap_range_is_single_sourced(self):
+        from custom_components.adaptive_cover_pro.const import OPTION_RANGES
+
+        assert OPTION_RANGES[CONF_COMMAND_QUEUE_GAP] == (0.0, 60.0)
+
+    async def test_queue_overview_lists_matching_covers_only(self, hass):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "Facade South", CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+            options={CONF_COMMAND_QUEUE_GAP: 2.5},
+            entry_id="queue_1",
+            title="Command Queue Facade South",
+        )
+        entry.add_to_hass(hass)
+        for entry_id, title, queue_name in (
+            ("cov_a", "Kitchen", "  FACADE   south "),
+            ("cov_b", "Study", "Facade North"),
+            ("cov_c", "Hall", None),
+        ):
+            options = {} if queue_name is None else {CONF_COMMAND_QUEUE: queue_name}
+            member = MockConfigEntry(
+                domain=DOMAIN,
+                data={"name": title, CONF_SENSOR_TYPE: CoverType.BLIND},
+                options=options,
+                entry_id=entry_id,
+                title=title,
+            )
+            member.add_to_hass(hass)
+
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+        result = await flow.async_step_queue_overview()
+        overview = result["description_placeholders"]["overview"]
+        assert "Kitchen" in overview
+        assert "Study" not in overview
+        assert "Hall" not in overview
+
+    async def test_automation_step_dropdown_lists_the_deduped_union(self, hass):
+        queue_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "Roof Terrace", CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+            options={},
+            entry_id="queue_1",
+            title="Command Queue Roof Terrace",
+        )
+        queue_entry.add_to_hass(hass)
+        first = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "A", CONF_SENSOR_TYPE: CoverType.BLIND},
+            options={CONF_COMMAND_QUEUE: "Facade South"},
+            entry_id="cov_a",
+            title="A",
+        )
+        first.add_to_hass(hass)
+        second = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "B", CONF_SENSOR_TYPE: CoverType.BLIND},
+            options={CONF_COMMAND_QUEUE: "facade  south"},
+            entry_id="cov_b",
+            title="B",
+        )
+        second.add_to_hass(hass)
+
+        flow = OptionsFlowHandler(first)
+        flow.hass = hass
+        flow.handler = first.entry_id
+        result = await flow.async_step_automation()
+        selector_obj = _selector_for(result["data_schema"], CONF_COMMAND_QUEUE)
+        labels = [o["label"] for o in selector_obj.config["options"]]
+        # Deduped by normalized name, displayed in first-seen original casing.
+        assert labels == ["Facade South", "Roof Terrace"]
+        assert selector_obj.config["custom_value"] is True
+
+    async def test_free_text_is_stored_exactly_as_typed(self, hass):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "A", CONF_SENSOR_TYPE: CoverType.BLIND},
+            options={},
+            entry_id="cov_a",
+            title="A",
+        )
+        entry.add_to_hass(hass)
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+        flow.handler = entry.entry_id
+
+        await flow.async_step_automation({CONF_COMMAND_QUEUE: "Facade South"})
+        assert flow.options[CONF_COMMAND_QUEUE] == "Facade South"
+
+    async def test_blank_submission_pops_the_key(self, hass):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "A", CONF_SENSOR_TYPE: CoverType.BLIND},
+            options={CONF_COMMAND_QUEUE: "Facade South"},
+            entry_id="cov_a",
+            title="A",
+        )
+        entry.add_to_hass(hass)
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+        flow.handler = entry.entry_id
+
+        await flow.async_step_automation({CONF_COMMAND_QUEUE: ""})
+        assert CONF_COMMAND_QUEUE not in flow.options
+
+    async def test_absent_submission_also_pops_the_key(self, hass):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "A", CONF_SENSOR_TYPE: CoverType.BLIND},
+            options={CONF_COMMAND_QUEUE: "Facade South"},
+            entry_id="cov_a",
+            title="A",
+        )
+        entry.add_to_hass(hass)
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+        flow.handler = entry.entry_id
+
+        await flow.async_step_automation({})
+        assert CONF_COMMAND_QUEUE not in flow.options
+
+    def test_queue_is_in_the_automation_sync_category(self):
+        from custom_components.adaptive_cover_pro.config_flow import SYNC_CATEGORIES
+
+        assert CONF_COMMAND_QUEUE in SYNC_CATEGORIES["automation"]
+
+
+# ---------------------------------------------------------------------------
+# Step 12 — diagnostics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestQueueDiagnostics:
+    """Why a cover moved 8 seconds late must be answerable from the data."""
+
+    @pytest.mark.asyncio
+    async def test_unqueued_dispatch_records_no_queue_fields(self):
+        hass = _svc_hass()
+        svc = _svc(hass)
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        action = svc.last_cover_action
+        assert "queue_name" not in action
+
+    @pytest.mark.asyncio
+    async def test_immediate_dispatch_records_the_immediate_outcome(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        action = svc.last_cover_action
+        assert action["queue_name"] == "facade south"
+        assert action["queue_outcome"] == "immediate"
+        assert action["queue_wait_seconds"] == 0.0
+        assert action["queue_depth_at_enqueue"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_waited_dispatch_records_the_wait(self):
+        hass = _svc_hass()
+        queue = _queue()
+        svc = _svc(hass, command_queue=queue)
+        held = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
+        queue.release("cover.other", transmitted=True)
+        assert held is not None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        action = svc.last_cover_action
+        assert action["queue_outcome"] == "waited"
+        # Strictly positive, not ">= the gap": this field measures THIS
+        # dispatch's own wait, and the gap started ticking at the previous
+        # transmit — so the remaining spacing it actually sleeps is always a
+        # little less than the full gap.
+        assert action["queue_wait_seconds"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_a_budget_expired_dispatch_says_so(self):
+        hass = _svc_hass()
+        queue = _queue(gap=10.0)
+        svc = _svc(hass, command_queue=queue)
+        holder = await queue.acquire("cover.other", head_of_line=False, budget=5.0)
+        assert holder is not None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+            patch(
+                "custom_components.adaptive_cover_pro.managers.cover_command"
+                ".COMMAND_QUEUE_MAX_WAIT_SECONDS",
+                0.02,
+            ),
+        ):
+            outcome, _ = await svc.apply_position("cover.a", 70, "solar", _ctx())
+
+        # Transmitted anyway — the bounded-wait invariant.
+        assert outcome == "sent"
+        assert svc.last_cover_action["queue_outcome"] == "budget_expired"
+
+    def test_entry_diagnostics_carry_the_queue_block(self):
+        from custom_components.adaptive_cover_pro.diagnostics.builder import (
+            DiagnosticsBuilder,
+        )
+
+        hass = _hass()
+        queue = get_command_queue(hass, "facade south")
+        queue.attach()
+        queue.attach()
+        queue.set_gap(7.5)
+
+        block = DiagnosticsBuilder.build_command_queue_block(queue)
+        assert block == {
+            "name": "facade south",
+            "gap_seconds": 7.5,
+            "gap_source": "entry",
+            "attached_members": 2,
+            "current_depth": 0,
+        }
+
+    def test_entry_diagnostics_report_a_defaulted_gap_as_such(self):
+        from custom_components.adaptive_cover_pro.diagnostics.builder import (
+            DiagnosticsBuilder,
+        )
+
+        hass = _hass()
+        queue = get_command_queue(hass, "facade south")
+        queue.attach()
+        block = DiagnosticsBuilder.build_command_queue_block(queue)
+        assert block["gap_source"] == "default"
+        assert block["gap_seconds"] == DEFAULT_COMMAND_QUEUE_GAP
+
+    def test_entry_diagnostics_omit_the_block_when_unqueued(self):
+        from custom_components.adaptive_cover_pro.diagnostics.builder import (
+            DiagnosticsBuilder,
+        )
+
+        assert DiagnosticsBuilder.build_command_queue_block(None) is None

--- a/tests/test_command_queue.py
+++ b/tests/test_command_queue.py
@@ -15,6 +15,7 @@ Test classes mirror the implementation steps:
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -320,6 +321,108 @@ class TestQueueMechanics:
         assert queue.busy_for_seconds() == 0.0
         queue.mark_external_transmit()
         assert queue.busy_for_seconds() > 0.0
+
+    @pytest.mark.asyncio
+    async def test_a_frame_reported_mid_wait_pushes_the_grant_out(self):
+        """A report must reach a waiter that is ALREADY inside its spacing sleep.
+
+        This is the only case that matters. ``release`` hands the slot on
+        immediately, so the next member is always spacing by the time the
+        venetian tail reaches ``mark_air_busy`` — the tail first waits out a
+        physical rail. A spacing sleep computed once, from a single reading of
+        ``busy_until``, cannot observe an advance that lands during it, which
+        made the report inert in exactly the contended case it exists for: the
+        waiter keyed while ``busy_for_seconds()`` still said the air was busy.
+        """
+        queue = _queue(gap=0.2)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        queue.release(first, transmitted=True)  # air busy for 0.2 s
+
+        waiter = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0.1)  # cover.b is now inside its spacing sleep
+
+        reported = time.monotonic()
+        queue.mark_external_transmit()  # the tail's own frame
+
+        grant = await asyncio.wait_for(waiter, timeout=_BUDGET)
+        assert grant is not None
+        assert grant.budget_expired is False
+        # A full gap separates the reported frame from this grant...
+        assert time.monotonic() - reported >= 0.19
+        # ...and the queue itself agrees the air was free when it let go.
+        assert queue.busy_for_seconds() == 0.0
+        queue.release(grant, transmitted=False)
+
+    @pytest.mark.asyncio
+    async def test_a_gave_up_members_frame_also_pushes_a_waiter_out(self):
+        """The same re-read covers the other out-of-turn reporter.
+
+        A member whose budget expired transmits anyway and releases
+        ``transmitted=True`` without ever holding the slot. That frame lands
+        while the real next member is already spacing, exactly as the tail's
+        does.
+        """
+        queue = _queue(gap=0.2)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        queue.release(first, transmitted=True)
+
+        waiter = asyncio.create_task(
+            queue.acquire("cover.b", head_of_line=False, budget=_BUDGET)
+        )
+        await asyncio.sleep(0)  # cover.b takes the slot and starts spacing
+
+        expired = await queue.acquire("cover.c", head_of_line=False, budget=0.1)
+        assert expired is not None
+        assert expired.budget_expired is True
+        assert expired.holds_slot is False
+        keyed = time.monotonic()
+        queue.release(expired, transmitted=True)
+
+        grant = await asyncio.wait_for(waiter, timeout=_BUDGET)
+        assert grant is not None
+        assert time.monotonic() - keyed >= 0.19
+        assert queue.busy_for_seconds() == 0.0
+        queue.release(grant, transmitted=False)
+
+    @pytest.mark.asyncio
+    async def test_repeated_reports_still_cannot_outlast_the_budget(self):
+        """Re-reading ``busy_until`` must not unbound the wait.
+
+        Every sleep is charged against the same budget, so a stream of
+        out-of-turn frames delays a waiter up to the ceiling and no further:
+        on expiry it is granted anyway, flagged ``budget_expired``, and
+        transmits. No command is ever withheld indefinitely.
+        """
+        queue = _queue(gap=0.1)
+        first = await queue.acquire("cover.a", head_of_line=False, budget=_BUDGET)
+        assert first is not None
+        queue.release(first, transmitted=True)
+
+        async def _keep_keying() -> None:
+            while True:
+                await asyncio.sleep(0.02)
+                queue.mark_external_transmit()
+
+        noise = asyncio.create_task(_keep_keying())
+        started = time.monotonic()
+        try:
+            grant = await asyncio.wait_for(
+                queue.acquire("cover.b", head_of_line=False, budget=0.3),
+                timeout=_BUDGET,
+            )
+        finally:
+            noise.cancel()
+        elapsed = time.monotonic() - started
+
+        assert grant is not None
+        assert grant.budget_expired is True
+        assert elapsed >= 0.3
+        assert elapsed < 2.0
+        queue.release(grant, transmitted=True)
 
     @pytest.mark.asyncio
     async def test_depth_reports_waiting_reservations(self):
@@ -909,16 +1012,26 @@ class TestOtherWireSites:
 
     @pytest.mark.asyncio
     async def test_reconciliation_resend_takes_a_routine_turn(self):
+        """Routine tier, and never a waiting one.
+
+        A retry of a command that already had its chance has no claim on the
+        head of the line ahead of a fresh safety decision — and it asks with
+        ``wait=False``, so it can only ever take a slot that is free already.
+        """
         hass = _svc_hass()
         queue = _queue(gap=0.0)
         svc = _svc(hass, command_queue=queue)
-        calls: list[bool] = []
+        calls: list[tuple[bool, bool]] = []
         real_acquire = CommandQueue.acquire
 
-        async def _tracked(self, entity_id, *, head_of_line, budget):
-            calls.append(head_of_line)
+        async def _tracked(self, entity_id, *, head_of_line, budget, wait=True):
+            calls.append((head_of_line, wait))
             return await real_acquire(
-                self, entity_id, head_of_line=head_of_line, budget=budget
+                self,
+                entity_id,
+                head_of_line=head_of_line,
+                budget=budget,
+                wait=wait,
             )
 
         with (
@@ -928,13 +1041,23 @@ class TestOtherWireSites:
         ):
             await svc._execute_command("cover.a", 70)
 
-        assert calls == [False]
+        assert calls == [(False, False)]
         hass.services.async_call.assert_awaited_once()
         assert queue._owner is None
         assert queue.busy_for_seconds() == 0.0
 
     @pytest.mark.asyncio
-    async def test_reconciliation_resend_waits_behind_a_holder(self):
+    async def test_reconciliation_resend_stands_down_rather_than_blocking(self):
+        """A resend takes the slot only if it is free RIGHT NOW.
+
+        The reconciliation pass IS the retry loop, and HA re-arms its interval
+        listener before dispatching each fire as its own background task — so a
+        pass that blocks per entity for the clearance budget (30 s, against a
+        1-minute interval) is still running when the next one starts, and the
+        two mutate the same ``PerEntityState``. That is the same overlap the
+        ``wait=False`` clearance gate above it exists to prevent, reached by a
+        different road. Standing down costs nothing: the next pass re-asks.
+        """
         hass = _svc_hass()
         queue = _queue(gap=0.0)
         svc = _svc(hass, command_queue=queue)
@@ -947,11 +1070,93 @@ class TestOtherWireSites:
         ):
             task = asyncio.create_task(svc._execute_command("cover.a", 70))
             await asyncio.sleep(0)
-            hass.services.async_call.assert_not_awaited()
-            queue.release(holder, transmitted=False)
-            await asyncio.wait_for(task, timeout=2.0)
+            # Returned without ever suspending, and left no reservation behind
+            # for the next pass to trip over.
+            assert task.done()
+            await task
+
+        hass.services.async_call.assert_not_awaited()
+        assert queue.depth == 0
+        queue.release(holder, transmitted=False)
+
+    @pytest.mark.asyncio
+    async def test_reconciliation_resend_stands_down_while_the_air_is_spaced(self):
+        """Spacing owed is a wait too — a free slot alone is not enough.
+
+        With a configured gap anywhere near the clearance budget, waiting out
+        the spacing blocks the pass for just as long as waiting for the slot.
+        """
+        hass = _svc_hass()
+        queue = _queue(gap=30.0)
+        svc = _svc(hass, command_queue=queue)
+        queue.mark_external_transmit()  # slot free, but the air is not
+        assert queue._owner is None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            task = asyncio.create_task(svc._execute_command("cover.a", 70))
+            await asyncio.sleep(0)
+            assert task.done()
+            await task
+
+        hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_stood_down_resend_burns_no_retry(self):
+        """Standing down must not cost one of the pass's three attempts.
+
+        The clearance gate directly above is asked before the counter for
+        exactly this reason. A queue stand-down that counted would reach
+        ``gave_up`` after three passes and warn "max retries exceeded" about a
+        cover that was never resent — and with the resend now non-blocking,
+        standing down is the common case on a busy queue, not a corner one.
+        """
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        svc.enable_position_matching = True
+        svc.set_target("cover.a", 50)
+        svc.set_waiting("cover.a", False)
+
+        holder = await queue.acquire("cover.blocker", head_of_line=False, budget=5.0)
+        assert holder is not None
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            for _ in range(svc._max_retries + 2):
+                await asyncio.wait_for(
+                    svc.run_reconciliation_pass(dt.datetime.now(dt.UTC)), timeout=1.0
+                )
+
+        hass.services.async_call.assert_not_awaited()
+        assert svc.state("cover.a").retry_count == 0
+        assert svc.state("cover.a").gave_up is False
+        queue.release(holder, transmitted=False)
+
+    @pytest.mark.asyncio
+    async def test_a_resend_that_goes_out_still_counts_its_retry(self):
+        """The counter is untouched for a resend that actually transmits."""
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+        svc.enable_position_matching = True
+        svc.set_target("cover.a", 50)
+        svc.set_waiting("cover.a", False)
+
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=10),
+        ):
+            await asyncio.wait_for(
+                svc.run_reconciliation_pass(dt.datetime.now(dt.UTC)), timeout=1.0
+            )
 
         hass.services.async_call.assert_awaited_once()
+        assert svc.state("cover.a").retry_count == 1
 
     @pytest.mark.asyncio
     async def test_reconciliation_resend_yields_to_a_waiting_live_dispatch(self):

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -253,7 +253,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -289,7 +289,7 @@ async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -302,7 +302,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -329,7 +329,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -366,7 +366,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -408,7 +408,7 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
@@ -431,7 +431,7 @@ async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
@@ -444,7 +444,7 @@ async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -457,7 +457,7 @@ async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
@@ -466,7 +466,7 @@ async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> 
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 # ---------------------------------------------------------------------------
@@ -488,7 +488,7 @@ async def test_migrate_v3_6_sets_weather_enabled_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=5)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -501,7 +501,7 @@ async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is False
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
@@ -514,7 +514,7 @@ async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> None:
@@ -523,7 +523,7 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 # ---------------------------------------------------------------------------
@@ -544,7 +544,7 @@ async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     # Additive/no-op: no outside_temp_source key seeded, options untouched.
     assert "outside_temp_source" not in entry.options
     # Cascades on through v3.13 too, which seeds default_percentage (#1126).
@@ -561,9 +561,9 @@ async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options == first
 
 
@@ -579,7 +579,7 @@ async def test_migrate_v3_6_to_3_7_preserves_explicit_source(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options["outside_temp_source"] == "max_of_live_and_forecast"
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 # ---------------------------------------------------------------------------
@@ -610,7 +610,7 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     # No dead key seeded by the v3.4→v3.5 block.
     assert "show_weather_retraction" not in entry.options
     assert entry.options == {
@@ -650,7 +650,7 @@ async def test_migrate_v3_7_to_v3_8_converts_blind_spots(hass: HomeAssistant) ->
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     opts = entry.options
     # Slot 1 converted (new_left = 45-10 = 35, new_right = 30-45 = -15).
     assert opts["blind_spot_left_gamma"] == 35
@@ -683,9 +683,9 @@ async def test_migrate_v3_7_to_v3_8_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options == first
 
 
@@ -721,7 +721,7 @@ async def test_migrate_v3_7_to_v3_8_no_blind_spot_is_noop(hass: HomeAssistant) -
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options == {**before, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -748,7 +748,7 @@ async def test_migrate_v3_7_to_v3_8_tolerates_none_fov_left(
         minor_version=7,
     )
     assert await async_migrate_entry(hass, entry) is True  # no TypeError
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options["blind_spot_left_gamma"] == 80  # 90 - 10
     assert entry.options["blind_spot_right_gamma"] == -60  # 30 - 90
 
@@ -797,14 +797,14 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 16 (the v3.15 → v3.16 no-op block that
-    advances entries past the additive sun-tracking-gate options, per issue
-    #1167).
+    Currently the highest target is 17 (the v3.16 → v3.17 no-op block that
+    advances entries past the additive command-queue options, per issue
+    #1189).
     Raise this assertion whenever a new minor migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 16
+    assert ConfigFlowHandler.MINOR_VERSION == 17
 
 
 # ---------------------------------------------------------------------------
@@ -860,7 +860,7 @@ async def test_migrate_v3_8_to_v3_9_is_additive_noop(hass: HomeAssistant) -> Non
     entry = _make_entry(hass, dict(options), version=3, minor_version=8)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -889,7 +889,7 @@ async def test_migrate_v3_9_to_v3_10_additive_noop_without_legacy_margin(
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=9)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -913,7 +913,7 @@ async def test_migrate_v3_9_to_v3_10_copies_legacy_safety_margin(
         minor_version=9,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     # New neutral key seeded from the legacy value.
     assert entry.options[CONF_TILT_SAFETY_MARGIN] == 0.5
     # Legacy key retained unchanged (additive / rollback-safe).
@@ -952,7 +952,7 @@ async def test_migrate_v3_10_is_idempotent(hass: HomeAssistant) -> None:
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -977,7 +977,7 @@ async def test_migrate_v3_10_to_v3_11_seeds_shade_mode_for_awning(
         minor_version=10,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options[CONF_AWNING_SHADE_MODE] == AWNING_SHADE_MODE_WINDOW
 
 
@@ -990,7 +990,7 @@ async def test_migrate_v3_10_to_v3_11_skips_non_awning(
     options = {"azimuth": 180, "custom_position_sensors_1": ["binary_sensor.door"]}
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert CONF_AWNING_SHADE_MODE not in entry.options
     # Cascades on through v3.13, which seeds this blind's default position (#1126).
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
@@ -1065,7 +1065,7 @@ async def test_migrate_v3_11_to_v3_12_repairs_malformed_time(
     """
     entry = _make_entry(hass, {time_key: stored}, version=3, minor_version=11)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options[time_key] == expected
 
 
@@ -1174,7 +1174,7 @@ async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_blind(
         sensor_type=CoverType.BLIND,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options[CONF_DEFAULT_HEIGHT] == 100
 
 
@@ -1197,7 +1197,7 @@ async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_awning(
         sensor_type=CoverType.AWNING,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options[CONF_DEFAULT_HEIGHT] == 0
 
 
@@ -1298,7 +1298,7 @@ async def test_migrate_v3_13_unknown_sensor_type_does_not_abort_cascade(
         sensor_type=bad_sensor_type,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     # The v3.11 → v3.12 sibling repair still landed — proof the cascade
     # continued past the bad sensor_type instead of aborting.
     assert entry.options["end_time"] == "00:00:00"
@@ -1453,7 +1453,7 @@ async def test_migrate_v3_13_advances_to_14_without_seeding(
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert "day_night_concurrent_rail_travel" not in entry.options
     assert entry.options == before
 
@@ -1468,9 +1468,9 @@ async def test_migrate_v3_13_to_v3_14_is_idempotent(hass: HomeAssistant) -> None
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options == first
 
 
@@ -1486,7 +1486,7 @@ async def test_migrate_v3_13_to_v3_14_preserves_an_explicit_choice(
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options["day_night_concurrent_rail_travel"] is False
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 # ---------------------------------------------------------------------------
@@ -1511,7 +1511,7 @@ async def test_migrate_v3_14_advances_to_15_without_seeding(
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert "day_night_external_command_interlock" not in entry.options
     assert entry.options == before
 
@@ -1526,9 +1526,9 @@ async def test_migrate_v3_14_to_v3_15_is_idempotent(hass: HomeAssistant) -> None
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options == first
 
 
@@ -1544,7 +1544,7 @@ async def test_migrate_v3_14_to_v3_15_preserves_an_explicit_choice(
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options["day_night_external_command_interlock"] is False
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
 
 
 # ---------------------------------------------------------------------------
@@ -1571,7 +1571,7 @@ async def test_migrate_v3_15_advances_to_16_without_seeding(
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert "sun_tracking_gate_sensors" not in entry.options
     assert "sun_tracking_gate_template" not in entry.options
     assert "sun_tracking_gate_template_mode" not in entry.options
@@ -1588,9 +1588,9 @@ async def test_migrate_v3_15_to_v3_16_is_idempotent(hass: HomeAssistant) -> None
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
     assert entry.options == first
 
 
@@ -1615,4 +1615,65 @@ async def test_migrate_v3_15_to_v3_16_preserves_a_configured_gate(
         == "{{ is_state('climate.up', 'cool') }}"
     )
     assert entry.options["sun_tracking_gate_template_mode"] == "and"
-    assert entry.minor_version == 16
+    assert entry.minor_version == 17
+
+
+# ---------------------------------------------------------------------------
+# v3.16 → v3.17 — additive named command-queue options (issue #1189).
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v3_16_advances_to_17_without_seeding(
+    hass: HomeAssistant,
+) -> None:
+    """A minor-16 entry reaches minor 17 with its options untouched.
+
+    ``command_queue`` is deliberately NOT seeded: an absent key already reads as
+    "no queue", which is exactly the dispatch behaviour every existing install
+    has today. Seeding anything here would enrol every cover in a queue nobody
+    asked for and start spacing commands that were never colliding.
+    """
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180, CONF_DEFAULT_HEIGHT: 60},
+        version=3,
+        minor_version=16,
+    )
+    before = dict(entry.options)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 17
+    assert "command_queue" not in entry.options
+    assert "command_queue_gap" not in entry.options
+    assert entry.options == before
+
+
+async def test_migrate_v3_16_to_v3_17_is_idempotent(hass: HomeAssistant) -> None:
+    """Re-running the migration on an already-advanced entry is stable."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=16,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    first = dict(entry.options)
+    assert entry.minor_version == 17
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 17
+    assert entry.options == first
+
+
+async def test_migrate_v3_16_to_v3_17_preserves_an_assigned_queue(
+    hass: HomeAssistant,
+) -> None:
+    """An entry that already names a queue keeps it verbatim, casing included."""
+    entry = _make_entry(
+        hass,
+        {"command_queue": "Facade South"},
+        version=3,
+        minor_version=16,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.options["command_queue"] == "Facade South"
+    assert entry.minor_version == 17

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -4213,3 +4213,50 @@ def test_both_gates_render_through_the_one_shared_helper():
 
     src = inspect.getsource(cf._build_config_summary)
     assert src.count("_render_condition_gate_summary(") == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #1189 — named command queue
+# ---------------------------------------------------------------------------
+
+
+def test_summary_omits_the_queue_line_when_unassigned():
+    """The overwhelmingly common cover says nothing about queues."""
+    summary = _build_config_summary(_minimal_vertical(), CoverType.BLIND)
+    assert "queue" not in summary.lower()
+
+
+def test_summary_shows_the_queue_and_the_default_gap():
+    from custom_components.adaptive_cover_pro.const import CONF_COMMAND_QUEUE
+
+    cfg = _minimal_vertical()
+    cfg[CONF_COMMAND_QUEUE] = "Facade South"
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert 'Commands serialized on queue "Facade South" (5.0s gap)' in summary
+
+
+def test_summary_resolves_the_gap_from_the_owning_entry(hass):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_COMMAND_QUEUE,
+        CONF_COMMAND_QUEUE_GAP,
+        CONF_SENSOR_TYPE,
+        DOMAIN,
+    )
+
+    queue_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Facade South", CONF_SENSOR_TYPE: CoverType.COMMAND_QUEUE},
+        options={CONF_COMMAND_QUEUE_GAP: 12.0},
+        entry_id="queue_1",
+        title="Command Queue Facade South",
+    )
+    queue_entry.add_to_hass(hass)
+
+    cfg = _minimal_vertical()
+    # Different casing on purpose: the summary must resolve the way the runtime
+    # does, by normalized name.
+    cfg[CONF_COMMAND_QUEUE] = "  facade   SOUTH "
+    summary = _build_config_summary(cfg, CoverType.BLIND, hass)
+    assert 'Commands serialized on queue "facade   SOUTH" (12.0s gap)' in summary

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -417,11 +417,12 @@ def test_controls_cover_default_true() -> None:
     """``controls_cover`` defaults True; only virtual entry types opt out.
 
     The base default is ``True`` so adding the discriminator didn't require
-    touching every policy. ``cover_building_profile`` is the one shipped
-    virtual entry type that registers no platforms and has no axes, so it is
-    the sole policy allowed to report ``False``. Pinning both directions
-    keeps the cover-contract suites and cover-only menus exercising every
-    real cover type and guards against a real cover accidentally opting out.
+    touching every policy. ``cover_building_profile`` and
+    ``cover_command_queue`` are the shipped virtual entry types that register no
+    platforms and have no axes, so they are the only policies allowed to report
+    ``False``. Pinning both directions keeps the cover-contract suites and
+    cover-only menus exercising every real cover type and guards against a real
+    cover accidentally opting out.
     """
     from custom_components.adaptive_cover_pro.cover_types.base import CoverTypePolicy
 
@@ -429,7 +430,7 @@ def test_controls_cover_default_true() -> None:
 
     from custom_components.adaptive_cover_pro.cover_types import POLICY_REGISTRY
 
-    expected_non_cover = {"cover_building_profile"}
+    expected_non_cover = {"cover_building_profile", "cover_command_queue"}
     for cover_type, policy_cls in POLICY_REGISTRY.items():
         if cover_type in expected_non_cover:
             assert (

--- a/tests/test_skip_reason_guard.py
+++ b/tests/test_skip_reason_guard.py
@@ -43,6 +43,7 @@ _EXPECTED_SKIP_CODES: frozenset[str] = frozenset(
         "cover_unavailable",
         "policy_deferred",
         "calibration_in_progress",
+        "superseded_in_queue",
     }
 )
 


### PR DESCRIPTION
## Summary

Covers on one-way radio backends (Somfy RTS, RFXtrx) lose frames when independent config entries transmit at the same moment. The only spacing that existed was the Cover Group stagger, which is group-scoped and only fires on group-triggered fan-out, so routine per-entry solar tracking was unthrottled and entries sharing sun geometry collided freely.

Covers now opt into a named command queue on Movement & Schedule. Covers sharing a queue never transmit inside each other's spacing window. The gap belongs to the queue rather than the member and is configured on a new Command Queue config entry; a queue name with no matching entry still works at the 5 s default, so naming a queue never requires creating one. Unassigned covers hit one early-out and behave exactly as before.

The gate sits between the physical-clearance gate and the booking call, which is load-bearing: placing it earlier deadlocks Model C dual-rail sequencing (#1115), and placing it after booking would burn the 5 s command grace window against backend waits measured up to 33 s (#1139). A bounded 30 s wait budget keeps the queue from reintroducing #756. Safety-priority dispatch is head-of-line but still takes its spacing, since a storm retraction across many covers is the most collision-prone moment there is.

Three commits of audit fixes follow the feature commit. Four adversarial audit passes ran, each probing the real queue rather than reading it; the last was clean. They caught a cancelled acquire that stranded the slot permanently, a budget-expired grant that could steal the live holder's slot, an air-busy report that went unobserved by anyone already waiting, and a reconciliation pass that emitted at most one frame per cycle.

Config entry migration is additive: MINOR_VERSION 16 to 17, VERSION stays 3 for rollback safety.

## Testing
- ✅ 12614 tests passing

## Related Issues
Refs #1189