### PR TITLE
fix: picker offers the current cover type; DE/FR label parity

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3993,6 +3993,26 @@ def _eligible_cover_types(
     return eligible, blocked
 
 
+def _offered_cover_types(current_type: str | None, eligible: list[str]) -> list[str]:
+    """Build the picker's list: the alternatives plus the type it already is (#1200).
+
+    ``eligible`` answers "what can this instance switch TO", which is the
+    question the abort and the blocked-types explanation are both asking — so
+    the current type is rightly absent from it. The dropdown asks a different
+    question: what the field's value is allowed to be, and it opens on the
+    value the instance already has. Without the current type in the option set
+    that pre-selection is impossible and the frontend highlights whichever
+    alternative happens to sort first.
+
+    Deliberately never consults capabilities: a venetian entry bound to a
+    position-only cover would otherwise be rendered as blocked and
+    pre-selected at the same time.
+    """
+    if current_type not in SENSOR_TYPE_MENU:
+        return eligible
+    return [t for t in SENSOR_TYPE_MENU if t == current_type or t in eligible]
+
+
 def _blocked_types_text(
     blocked: list[str],
     known: Mapping[str, Mapping[str, bool] | None],
@@ -5333,6 +5353,12 @@ class OptionsFlowHandler(OptionsFlow):
         the covers already bound here, and explains the ones it filtered out
         instead of hiding them. The dropdown reuses the ``selector.mode`` label
         bundle the create flow already ships, so no per-type string is added.
+
+        The type the instance already is is offered too, and is what the field
+        opens on (issue #1200). It is not a switch target — picking it returns
+        to the menu — but a required select with no suggested value opens on
+        an arbitrary alternative, which reads as a claim about what this
+        instance currently is.
         """
         known = bound_cover_capabilities(self.hass, self.options)
         eligible, blocked = _eligible_cover_types(self.sensor_type, known)
@@ -5340,22 +5366,34 @@ class OptionsFlowHandler(OptionsFlow):
             return self.async_abort(reason="no_eligible_cover_types")  # type: ignore[return-value]
 
         if user_input is not None:
-            self._pending_cover_type = user_input[CONF_SENSOR_TYPE]
+            new_type = user_input[CONF_SENSOR_TYPE]
+            # Compared against the type the FLOW is on, never the stored one.
+            # Mid-dialog A → B, the flow is on B and picking A is the revert —
+            # which still has ``_apply_pending_cover_type``'s unwind to run.
+            # Keying on the stored type would strand a pending switch the user
+            # believed they had just cancelled.
+            if new_type == self.sensor_type:
+                return await self.async_step_init()
+            self._pending_cover_type = new_type
             return await self.async_step_change_cover_type_confirm()
 
         labels = await _load_summary_labels(
             self.hass, _resolve_summary_language(self.hass, self.context)
         )
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_SENSOR_TYPE): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=_offered_cover_types(self.sensor_type, eligible),
+                        translation_key="mode",
+                    )
+                )
+            }
+        )
         return self.async_show_form(  # type: ignore[return-value]
             step_id="change_cover_type",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_SENSOR_TYPE): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=eligible, translation_key="mode"
-                        )
-                    )
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                schema, {CONF_SENSOR_TYPE: self.sensor_type}
             ),
             description_placeholders={
                 "current_type": get_policy(self.sensor_type).display_label(labels),
@@ -5371,6 +5409,10 @@ class OptionsFlowHandler(OptionsFlow):
 
         Same one-extra-click shape as ``async_step_sync_confirm``. Unticking the
         box returns to the menu with nothing changed.
+
+        Renders under a second step id when the pick cancels a pending switch
+        rather than making one — see
+        ``async_step_change_cover_type_revert_confirm``.
         """
         new_type = self._pending_cover_type
         if new_type is None:
@@ -5417,14 +5459,27 @@ class OptionsFlowHandler(OptionsFlow):
         _, capability_notes = check_cover_capabilities(
             self.options, new_type, self.hass, prospective=True
         )
+        # A pick that lands back on the stored type cancels the pending switch
+        # instead of making one, and the wording above degenerates there: the
+        # net change against stored state is nothing, so both ends name the
+        # same cover type. Same screen, same handler, second step id — which is
+        # the only handle the frontend has for choosing another description.
+        reverting = new_type == stored_type and self._cover_type_changed
         return self.async_show_form(  # type: ignore[return-value]
-            step_id="change_cover_type_confirm",
+            step_id=(
+                "change_cover_type_revert_confirm"
+                if reverting
+                else "change_cover_type_confirm"
+            ),
             data_schema=vol.Schema(
                 {vol.Required("confirm", default=False): selector.BooleanSelector()}
             ),
             description_placeholders={
                 "from_type": get_policy(stored_type).display_label(labels),
                 "to_type": get_policy(new_type).display_label(labels),
+                # The switch a revert cancels — the only placeholder on this
+                # screen read from in-memory rather than stored state.
+                "pending_type": get_policy(self.sensor_type).display_label(labels),
                 "stranded_options": "\n".join(f"- `{k}`" for k in stranded) or "—",
                 "capability_notes": "\n".join(f"- {n}" for n in capability_notes)
                 or "—",
@@ -5434,6 +5489,18 @@ class OptionsFlowHandler(OptionsFlow):
                 or "—",
             },
         )
+
+    async def async_step_change_cover_type_revert_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm cancelling a pending, unsaved cover-type switch (issue #1200).
+
+        Deliberately no logic of its own: cancelling a pending switch IS a
+        switch — back to the stored type — and runs the same unwind every other
+        pick runs. The step exists only because a step's description is chosen
+        by its id, so revert-specific copy needs an id of its own.
+        """
+        return await self.async_step_change_cover_type_confirm(user_input)
 
     # ---- Pending cover-type switch (issue #1132) ------------------------- #
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4007,6 +4007,12 @@ def _offered_cover_types(current_type: str | None, eligible: list[str]) -> list[
     Deliberately never consults capabilities: a venetian entry bound to a
     position-only cover would otherwise be rendered as blocked and
     pre-selected at the same time.
+
+    That guarantee covers ``current_type`` — the type the FLOW is on — which is
+    the stored type only while no switch is pending. Mid-dialog venetian →
+    blind, ``current_type`` is blind and the stored venetian is back among the
+    blocked types like any other unsatisfiable one, so a revert to it is not
+    offered here.
     """
     if current_type not in SENSOR_TYPE_MENU:
         return eligible
@@ -5464,6 +5470,16 @@ class OptionsFlowHandler(OptionsFlow):
         # net change against stored state is nothing, so both ends name the
         # same cover type. Same screen, same handler, second step id — which is
         # the only handle the frontend has for choosing another description.
+        #
+        # ``_cover_type_changed`` is redundant today: the picker returns to the
+        # menu when the pick equals ``self.sensor_type``, so reaching here with
+        # ``new_type == stored_type`` already implies the flow moved off it. It
+        # stays because it is the revert copy's own precondition rather than a
+        # restatement of that early return — the screen asserts an unsaved
+        # switch exists and names it via ``pending_type``. Drop the conjunct and
+        # relaxing the early return would silently point a "you have a pending
+        # switch to X" screen at an entry with no pending switch, where X is the
+        # type it already is.
         reverting = new_type == stored_type and self._cover_type_changed
         return self.async_show_form(  # type: ignore[return-value]
             step_id=(

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -230,9 +230,9 @@
   "cover_types": {
     "blind": "Vertikale Jalousie",
     "awning": "Horizontale Markise",
-    "tilt": "Jalousie / Neigung",
-    "oscillating_awning": "Schwenkmarkise",
-    "venetian": "Jalousie (Zwei-Achsen)",
+    "tilt": "Jalousie (nur Neigung)",
+    "oscillating_awning": "Fallarmmarkise",
+    "venetian": "Jalousie (zweiachsig)",
     "roof_window": "Dachfenster",
     "sliding_curtain": "Schiebevorhang",
     "louvered_roof": "Lamellendach",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -230,8 +230,8 @@
   "cover_types": {
     "blind": "Store vertical",
     "awning": "Store banne horizontal",
-    "tilt": "Store vénitien / inclinaison",
-    "oscillating_awning": "Store oscillant",
+    "tilt": "Store vénitien (inclinaison seule)",
+    "oscillating_awning": "Store à projection",
     "venetian": "Store vénitien (deux axes)",
     "roof_window": "Fenêtre de toit",
     "sliding_curtain": "Rideau coulissant",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -151,7 +151,7 @@
           "min_tilt": "Untergrenze für die minimale Neigungswinkel der Lamellen (0–100). Höhere Werte verhindern, dass Lamellen vollständig schließen – nützlich für Jalousien, die bei 0% das gesamte Licht blockieren. Standard: 0 (keine Untergrenze). Beispiel: Stellen Sie 10 ein, wenn Ihre Jalousien bei 0% vollständig dunkel werden und Sie immer etwas Licht durchlassen möchten.",
           "venetian_post_settle_hold": "Wie lange (in Sekunden) nach dem Anhalten des Antriebs gewartet wird, bevor der Neigungsbefehl gesendet wird. Standardmäßig 2,0 s, was für die meisten Aktoren geeignet ist. Erhöhen Sie den Wert auf 4–6 s für KNX FGR223 oder andere Firmware, die kurz nach dem Anhalten des Antriebs eine Neigung-zu-Offen-Bewegung erneut auslöst — ohne die zusätzliche Wartezeit konkurriert der Neigungsbefehl mit dieser Auslösung und verliert. Bereich 0,0–10,0 s.",
           "venetian_backrotate_publish_lag": "Wie lange (in Sekunden) die Integration eine verspätete Statusmeldung der Position von Ihrem Aktor toleriert, bevor sie als echte Benutzerberührung behandelt wird. Standard 45 s eignet sich für Somfy IO über Tahoma. Erhöhen Sie auf 60–120 s, wenn Ihre Hardware (langsamer KNX-Bus, Fibaro/Shelly-Neuveröffentlichung) die aktuelle_Position lange nach dem physischen Stopp der Beschattung meldet – Symptom sind fehlerhafte 'manual_override_set'-Ereignisse, die etwa 30–90 s nach einem befohlenen Bewegungsbefehl ausgelöst werden. Verringern Sie nur, wenn Sie einen ungewöhnlich schnellen Aktor haben und eine straffere Erkennungsfehlertoleranz möchten. Bereich 15–180 s.",
-          "arm_length": "Länge des Schwenkarmes einer Gelenkarmmarkise, vom Wandpivot bis zur Stoffkante. In der für Home Assistant konfigurierten Einheit dargestellt. Wird zusammen mit dem Schwenkwinkel verwendet, um zu berechnen, wie weit der Stoff bei jeder Öffnungsposition reicht. Beispiel: 0,8 m / 31 in.",
+          "arm_length": "Länge des Schwenkarmes einer Fallarmmarkise, vom Wandpivot bis zur Stoffkante. In der für Home Assistant konfigurierten Einheit dargestellt. Wird zusammen mit dem Schwenkwinkel verwendet, um zu berechnen, wie weit der Stoff bei jeder Öffnungsposition reicht. Beispiel: 0,8 m / 31 in.",
           "awning_min_angle": "Armwinkel, wenn die Markise vollständig geschlossen/eingezogen ist (0–180°). Normalerweise 0° = Arm vertikal an der Wand. Definiert den Anfang des Schwenkbereichs.",
           "awning_max_angle": "Armwinkel, wenn die Markise vollständig offen ist (0–180°). Der Arm schwenkt linear vom geschlossenen Winkel zu diesem Wert über 0–100% Öffnung. Beispiel: ein Schwenkbereich von 175° ≈ 1,75° pro 1%.",
           "awning_housing_offset": "Vertikaler Versatz des Armpivots über die Oberkante des Fensters (0–1 m). Zusammen mit Fensterhöhe und Armlänge zur Lokalisierung des Pivots verwendet. Setzen Sie auf 0, wenn das Gehäuse bündig mit der Fensteroberkante sitzt.",
@@ -458,7 +458,7 @@
           "min_tilt": "Untergrenze für die minimale Neigungswinkel der Lamellen (0–100). Höhere Werte verhindern, dass Lamellen vollständig schließen – nützlich für Jalousien, die bei 0% das gesamte Licht blockieren. Standard: 0 (keine Untergrenze). Beispiel: Stellen Sie 10 ein, wenn Ihre Jalousien bei 0% vollständig dunkel werden und Sie immer etwas Licht durchlassen möchten.",
           "venetian_post_settle_hold": "Wie lange (in Sekunden) nach dem Anhalten des Antriebs gewartet wird, bevor der Neigungsbefehl gesendet wird. Standardmäßig 2,0 s, was für die meisten Aktoren geeignet ist. Erhöhen Sie den Wert auf 4–6 s für KNX FGR223 oder andere Firmware, die kurz nach dem Anhalten des Antriebs eine Neigung-zu-Offen-Bewegung erneut auslöst — ohne die zusätzliche Wartezeit konkurriert der Neigungsbefehl mit dieser Auslösung und verliert. Bereich 0,0–10,0 s.",
           "venetian_backrotate_publish_lag": "Wie lange (in Sekunden) die Integration eine verspätete Statusmeldung der Position von Ihrem Aktor toleriert, bevor sie als echte Benutzerberührung behandelt wird. Standard 45 s eignet sich für Somfy IO über Tahoma. Erhöhen Sie auf 60–120 s, wenn Ihre Hardware (langsamer KNX-Bus, Fibaro/Shelly-Neuveröffentlichung) die aktuelle_Position lange nach dem physischen Stopp der Beschattung meldet – Symptom sind fehlerhafte 'manual_override_set'-Ereignisse, die etwa 30–90 s nach einem befohlenen Bewegungsbefehl ausgelöst werden. Verringern Sie nur, wenn Sie einen ungewöhnlich schnellen Aktor haben und eine straffere Erkennungsfehlertoleranz möchten. Bereich 15–180 s.",
-          "arm_length": "Länge des Schwenkarmes einer Gelenkarmmarkise, vom Wandpivot bis zur Stoffkante. In der für Home Assistant konfigurierten Einheit dargestellt. Wird zusammen mit dem Schwenkwinkel verwendet, um zu berechnen, wie weit der Stoff bei jeder Öffnungsposition reicht. Beispiel: 0,8 m / 31 in.",
+          "arm_length": "Länge des Schwenkarmes einer Fallarmmarkise, vom Wandpivot bis zur Stoffkante. In der für Home Assistant konfigurierten Einheit dargestellt. Wird zusammen mit dem Schwenkwinkel verwendet, um zu berechnen, wie weit der Stoff bei jeder Öffnungsposition reicht. Beispiel: 0,8 m / 31 in.",
           "awning_min_angle": "Armwinkel, wenn die Markise vollständig geschlossen/eingezogen ist (0–180°). Normalerweise 0° = Arm vertikal an der Wand. Definiert den Anfang des Schwenkbereichs.",
           "awning_max_angle": "Armwinkel, wenn die Markise vollständig offen ist (0–180°). Der Arm schwenkt linear vom geschlossenen Winkel zu diesem Wert über 0–100% Öffnung. Beispiel: ein Schwenkbereich von 175° ≈ 1,75° pro 1%.",
           "awning_housing_offset": "Vertikaler Versatz des Armpivots über die Oberkante des Fensters (0–1 m). Zusammen mit Fensterhöhe und Armlänge zur Lokalisierung des Pivots verwendet. Setzen Sie auf 0, wenn das Gehäuse bündig mit der Fensteroberkante sitzt.",
@@ -1368,14 +1368,14 @@
       "options": {
         "cover_blind": "Vertikale Jalousie",
         "cover_awning": "Horizontale Markise",
-        "cover_tilt": "Dreh-Jalousie",
-        "cover_venetian": "Jalousette (zweiachsig)",
-        "cover_oscillating_awning": "Gelenkarmmarkise (drop-arm)",
+        "cover_tilt": "Jalousie (nur Neigung)",
+        "cover_venetian": "Jalousie (zweiachsig)",
+        "cover_oscillating_awning": "Fallarmmarkise",
         "cover_roof_window": "Dachfenster",
         "cover_sliding_curtain": "Schiebevorhang (horizontal)",
         "cover_louvered_roof": "Lamellendach",
         "cover_day_night_shade": "Tag/Nacht-Rollo (Doppelstoff)",
-        "cover_dual_panel": "Doppelpaneel (transparent + Verdunkelung)"
+        "cover_dual_panel": "Doppelpaneel-Beschattung (transparent + Verdunkelung)"
       }
     },
     "tilt_mode": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1097,12 +1097,12 @@
       },
       "change_cover_type": {
         "data": {
-          "sensor_type": "Neuer Beschattungstyp"
+          "sensor_type": "Beschattungstyp"
         },
         "data_description": {
-          "sensor_type": "Der Beschattungstyp, zu dem diese Instanz wechselt. Sie bestätigen im nächsten Bildschirm und geben dann die Geometrie des neuen Typs ein."
+          "sensor_type": "Startet mit dem Typ, den diese Instanz derzeit hat. Wählen Sie einen anderen, um zu wechseln – Sie bestätigen im nächsten Bildschirm und geben dann die Geometrie des neuen Typs ein. Wenn Sie ihn unverändert lassen, ändert sich nichts."
         },
-        "description": "Diese Instanz ist derzeit vom Typ **{current_type}**. Wählen Sie den Beschattungstyp aus, zu dem sie werden soll – jede Entität behält ihre aktuelle Entitäts-ID, damit Ihre Dashboards und Automatisierungen weiterhin funktionieren.\n\nEs werden nur Typen aufgelistet, die Ihre gebundenen Beschattungen tatsächlich steuern können. Hier nicht angeboten:\n\n{blocked_types}\n\n[Mehr erfahren]({learn_more})",
+        "description": "Diese Instanz ist derzeit vom Typ **{current_type}**. Wählen Sie den Beschattungstyp aus, zu dem sie werden soll – jede Entität behält ihre aktuelle Entitäts-ID, damit Ihre Dashboards und Automatisierungen weiterhin funktionieren.\n\nAbgesehen vom aktuellen Typ werden nur Typen aufgelistet, die Ihre gebundenen Beschattungen tatsächlich steuern können. Hier nicht angeboten:\n\n{blocked_types}\n\n[Mehr erfahren]({learn_more})",
         "title": "Beschattungstyp ändern"
       },
       "change_cover_type_confirm": {
@@ -1111,6 +1111,13 @@
         },
         "description": "Wechsel von **{from_type}** zu **{to_type}**.\n\nEinstellungen, die nur der alte Typ verwendet, bleiben gespeichert und werden nicht gelöscht, sodass ein Zurückwechsel sie intakt vorfindet. Nach dem Wechsel derzeit inaktiv:\n\n{stranded_options}\n\nFunktionseigenschaften für den neuen Typ:\n\n{capability_notes}\n\nPositionspolarität:\n\n{position_polarity}\n\nJede Entität behält ihre Entitäts-ID. Typspezifische Entitäten, die der neue Typ nicht bereitstellt, bleiben in der Entitätsregistrierung als nicht verfügbar und werden wiederhergestellt, wenn Sie zurückwechseln. Füllen Sie nach der Bestätigung die Geometrie des neuen Typs aus und beenden Sie mit Speichern und schließen, um die Änderung anzuwenden.",
         "title": "Beschattungstyp ändern – Bestätigung"
+      },
+      "change_cover_type_revert_confirm": {
+        "title": "Beschattungstyp ändern – Ausstehenden Wechsel abbrechen",
+        "description": "In diesem Dialog wartet ein ungespeicherter Wechsel zu **{pending_type}** darauf, angewendet zu werden. Wenn Sie dies bestätigen, wird er verworfen: Diese Instanz bleibt **{from_type}**, und die Einstellungen, die der ausstehende Wechsel geändert hat, werden auf ihren Zustand beim Öffnen des Dialogs zurückgesetzt.\n\nSo oder so wurde bisher nichts geschrieben, daher ist keine Entität betroffen und es wird nichts neu geladen. Überprüfen Sie nach der Bestätigung die Geometrie und beenden Sie mit Speichern und schließen.",
+        "data": {
+          "confirm": "Ausstehende Beschattungstypänderung abbrechen"
+        }
       },
       "calibration": {
         "description": "Messen Sie, wie diese Beschattung tatsächlich funktioniert, und speichern Sie die Messergebnisse.\n\n**Positionskalibrierung** ordnet die von Adaptive Cover Pro berechnete Position der Zahl zu, die Ihre Beschattung erreichen muss. **Laufzeit** speichert, wie lange ein vollständiges Öffnen oder Schließen dauert, sodass Dashboards die Bewegung der Beschattung anzeigen können, statt sie zu springen.",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1368,7 +1368,7 @@
       "options": {
         "cover_blind": "Vertical blind",
         "cover_awning": "Horizontal awning",
-        "cover_tilt": "Tilted blind",
+        "cover_tilt": "Venetian / tilt blind (tilt-only)",
         "cover_venetian": "Venetian blind (dual-axis)",
         "cover_oscillating_awning": "Oscillating awning (drop-arm)",
         "cover_roof_window": "Roof window",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -390,12 +390,12 @@
       },
       "change_cover_type": {
         "title": "Change Cover Type",
-        "description": "This instance is currently of type **{current_type}**. Pick the cover type it should become — every entity keeps its current entity ID, so your dashboards and automations keep working.\n\nOnly types your bound covers can actually drive are listed. Not offered here:\n\n{blocked_types}\n\n[Learn more]({learn_more})",
+        "description": "This instance is currently of type **{current_type}**. Pick the cover type it should become — every entity keeps its current entity ID, so your dashboards and automations keep working.\n\nApart from the type it already is, only types your bound covers can actually drive are listed. Not offered here:\n\n{blocked_types}\n\n[Learn more]({learn_more})",
         "data": {
-          "sensor_type": "New Cover Type"
+          "sensor_type": "Cover Type"
         },
         "data_description": {
-          "sensor_type": "The cover type this instance will switch to. You confirm on the next screen, then fill in the new type's geometry."
+          "sensor_type": "Starts on the type this instance is now. Pick a different one to switch — you confirm on the next screen, then fill in the new type's geometry. Leaving it as it is changes nothing."
         }
       },
       "change_cover_type_confirm": {
@@ -403,6 +403,13 @@
         "description": "Switching from **{from_type}** to **{to_type}**.\n\nSettings only the old type uses stay stored and are not deleted, so switching back finds them intact. Currently inert after the switch:\n\n{stranded_options}\n\nCapability notes for the new type:\n\n{capability_notes}\n\nPosition polarity:\n\n{position_polarity}\n\nEvery entity keeps its entity ID. Type-specific entities the new type does not provide stay in the entity registry as unavailable, and return if you switch back. After confirming, fill in the new type's geometry and finish with Save & Close to apply the change.",
         "data": {
           "confirm": "Confirm cover type change"
+        }
+      },
+      "change_cover_type_revert_confirm": {
+        "title": "Change Cover Type — Cancel Pending Switch",
+        "description": "This dialog has an unsaved switch to **{pending_type}** waiting to be applied. Confirming cancels it: this instance stays **{from_type}**, and the settings the pending switch changed go back to what they were when you opened the dialog.\n\nNothing has been written yet either way, so no entity is affected and no reload happens. After confirming, review the geometry and finish with Save & Close.",
+        "data": {
+          "confirm": "Cancel the pending cover type change"
         }
       },
       "cover_entities": {
@@ -1360,7 +1367,7 @@
     "mode": {
       "options": {
         "cover_blind": "Vertical blind",
-        "cover_awning": "Horizontal blind",
+        "cover_awning": "Horizontal awning",
         "cover_tilt": "Tilted blind",
         "cover_venetian": "Venetian blind (dual-axis)",
         "cover_oscillating_awning": "Oscillating awning (drop-arm)",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -151,7 +151,7 @@
           "min_tilt": "Limite inférieure de l'angle d'inclinaison des lamelles (0–100 %). Les valeurs plus élevées empêchent les lamelles de se fermer complètement — utile pour les stores qui bloquent toute la lumière à 0 %. Défaut : 0 (pas de limite). Exemple : réglez à 10 si vos stores deviennent complètement opaques à 0 % et vous voulez toujours un peu de lumière.",
           "venetian_post_settle_hold": "Durée d'attente (en secondes) après l'arrêt du mécanisme avant l'envoi de la commande d'inclinaison. La valeur par défaut de 2,0 s convient à la plupart des actionneurs. Augmentez à 4–6 s pour le KNX FGR223 ou tout autre firmware qui réenclenche une inclinaison-vers-ouvert peu après l'arrêt du mécanisme — sans ce délai supplémentaire, la commande d'inclinaison entre en conflit avec ce réenclenchement et perd. Plage : 0,0–10,0 s.",
           "venetian_backrotate_publish_lag": "Durée (en secondes) pendant laquelle l'intégration tolère une publication tardive de l'état de position de votre actionneur avant de la traiter comme un geste utilisateur réel. 45 s par défaut convient à Somfy IO via Tahoma. Augmentez à 60–120 s si votre matériel (bus KNX lent, Fibaro/Shelly republish) publie la position actuelle après l'arrêt physique du store – le symptôme est des événements « manual_override_set » parasites déclenchés ~30–90 s après un mouvement commandé. Diminuez uniquement si vous avez un actionneur inhabituellement rapide et souhaitez une détection de faux contact plus stricte. Plage 15–180 s.",
-          "arm_length": "Longueur du bras articulé d'un store banne à bras articulés, du pivot mural au bord du tissu. Affichée dans l'unité configurée pour Home Assistant. Utilisée avec l'angle de balayage du bras pour calculer la distance d'extension du tissu à chaque pourcentage d'ouverture. Exemple : 0,8 m / 31 po.",
+          "arm_length": "Longueur du bras pivotant d'un store à projection, du pivot mural au bord du tissu. Affichée dans l'unité configurée pour Home Assistant. Utilisée avec l'angle de balayage du bras pour calculer la distance d'extension du tissu à chaque pourcentage d'ouverture. Exemple : 0,8 m / 31 po.",
           "awning_min_angle": "Angle du bras lorsque le store banne est complètement fermé/rétracté (0–180°). En règle générale, 0° = bras vertical contre le mur. Définit le début de l'arc de balayage.",
           "awning_max_angle": "Angle du bras lorsque le store banne est complètement ouvert (0–180°). Le bras pivote linéairement de l'angle fermé à cette valeur sur 0–100% d'ouverture. Exemple : un balayage total de 175° ≈ 1,75° par 1%.",
           "awning_housing_offset": "Décalage vertical du pivot du bras au-dessus du haut de la fenêtre (0–1 m). Combiné avec la hauteur de la fenêtre et la longueur du bras pour localiser le pivot. Définir à 0 lorsque le boîtier s'aligne avec le haut de la fenêtre.",
@@ -458,7 +458,7 @@
           "min_tilt": "Limite inférieure de l'angle d'inclinaison des lamelles (0–100 %). Les valeurs plus élevées empêchent les lamelles de se fermer complètement — utile pour les stores qui bloquent toute la lumière à 0 %. Défaut : 0 (pas de limite). Exemple : réglez à 10 si vos stores deviennent complètement opaques à 0 % et vous voulez toujours un peu de lumière.",
           "venetian_post_settle_hold": "Durée d'attente (en secondes) après l'arrêt du mécanisme avant l'envoi de la commande d'inclinaison. La valeur par défaut de 2,0 s convient à la plupart des actionneurs. Augmentez à 4–6 s pour le KNX FGR223 ou tout autre firmware qui réenclenche une inclinaison-vers-ouvert peu après l'arrêt du mécanisme — sans ce délai supplémentaire, la commande d'inclinaison entre en conflit avec ce réenclenchement et perd. Plage : 0,0–10,0 s.",
           "venetian_backrotate_publish_lag": "Durée (en secondes) pendant laquelle l'intégration tolère une publication tardive de l'état de position de votre actionneur avant de la traiter comme un geste utilisateur réel. 45 s par défaut convient à Somfy IO via Tahoma. Augmentez à 60–120 s si votre matériel (bus KNX lent, Fibaro/Shelly republish) publie la position actuelle après l'arrêt physique du store – le symptôme est des événements « manual_override_set » parasites déclenchés ~30–90 s après un mouvement commandé. Diminuez uniquement si vous avez un actionneur inhabituellement rapide et souhaitez une détection de faux contact plus stricte. Plage 15–180 s.",
-          "arm_length": "Longueur du bras articulé d'un store banne à bras articulés, du pivot mural au bord du tissu. Affichée dans l'unité configurée pour Home Assistant. Utilisée avec l'angle de balayage du bras pour calculer la distance d'extension du tissu à chaque pourcentage d'ouverture. Exemple : 0,8 m / 31 po.",
+          "arm_length": "Longueur du bras pivotant d'un store à projection, du pivot mural au bord du tissu. Affichée dans l'unité configurée pour Home Assistant. Utilisée avec l'angle de balayage du bras pour calculer la distance d'extension du tissu à chaque pourcentage d'ouverture. Exemple : 0,8 m / 31 po.",
           "awning_min_angle": "Angle du bras lorsque le store banne est complètement fermé/rétracté (0–180°). En règle générale, 0° = bras vertical contre le mur. Définit le début de l'arc de balayage.",
           "awning_max_angle": "Angle du bras lorsque le store banne est complètement ouvert (0–180°). Le bras pivote linéairement de l'angle fermé à cette valeur sur 0–100% d'ouverture. Exemple : un balayage total de 175° ≈ 1,75° par 1%.",
           "awning_housing_offset": "Décalage vertical du pivot du bras au-dessus du haut de la fenêtre (0–1 m). Combiné avec la hauteur de la fenêtre et la longueur du bras pour localiser le pivot. Définir à 0 lorsque le boîtier s'aligne avec le haut de la fenêtre.",
@@ -1368,14 +1368,14 @@
       "options": {
         "cover_blind": "Store vertical",
         "cover_awning": "Store banne horizontal",
-        "cover_tilt": "Store à inclinaison",
-        "cover_venetian": "Store vénitien (double axe)",
-        "cover_oscillating_awning": "Store banne à bras articulé",
+        "cover_tilt": "Store vénitien (inclinaison seule)",
+        "cover_venetian": "Store vénitien (deux axes)",
+        "cover_oscillating_awning": "Store à projection (bras oscillant)",
         "cover_roof_window": "Fenêtre de toit",
         "cover_sliding_curtain": "Rideau coulissant (horizontal)",
         "cover_louvered_roof": "Toit à lames",
         "cover_day_night_shade": "Store jour/nuit (double tissu)",
-        "cover_dual_panel": "Double panneau (voile + occultant)"
+        "cover_dual_panel": "Store à double panneau (voile + occultant)"
       }
     },
     "tilt_mode": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1097,12 +1097,12 @@
       },
       "change_cover_type": {
         "data": {
-          "sensor_type": "Nouveau type de store"
+          "sensor_type": "Type de store"
         },
         "data_description": {
-          "sensor_type": "Le type de store vers lequel cette instance basculera. Vous confirmerez sur l'écran suivant, puis remplirez la géométrie du nouveau type."
+          "sensor_type": "Démarre sur le type que cette instance a actuellement. Choisissez-en un autre pour basculer — vous confirmerez sur l'écran suivant, puis remplirez la géométrie du nouveau type. Le laisser tel quel ne change rien."
         },
-        "description": "Cette instance est actuellement de type **{current_type}**. Choisissez le type de store qu'elle devrait devenir — chaque entité conserve son ID d'entité actuel, donc vos tableaux de bord et automations continuent de fonctionner.\n\nSeuls les types que vos protections peuvent réellement gérer sont énumérés. Non proposés ici :\n\n{blocked_types}\n\n[En savoir plus]({learn_more})",
+        "description": "Cette instance est actuellement de type **{current_type}**. Choisissez le type de store qu'elle devrait devenir — chaque entité conserve son ID d'entité actuel, donc vos tableaux de bord et automations continuent de fonctionner.\n\nHormis le type qu'elle est déjà, seuls les types que vos protections peuvent réellement gérer sont énumérés. Non proposés ici :\n\n{blocked_types}\n\n[En savoir plus]({learn_more})",
         "title": "Modifier le type de store"
       },
       "change_cover_type_confirm": {
@@ -1111,6 +1111,13 @@
         },
         "description": "Basculement de **{from_type}** vers **{to_type}**.\n\nLes paramètres que seul l'ancien type utilise restent stockés et ne sont pas supprimés, ainsi revenir en arrière les retrouve intacts. Actuellement inactifs après le basculement :\n\n{stranded_options}\n\nNotes de capacité pour le nouveau type :\n\n{capability_notes}\n\nPolarité des positions :\n\n{position_polarity}\n\nChaque entité conserve son ID d'entité. Les entités spécifiques au type que le nouveau type ne fournit pas restent dans le registre des entités comme indisponibles et reviennent si vous revenez à l'ancien type. Après confirmation, remplissez la géométrie du nouveau type et terminez avec Enregistrer et fermer pour appliquer la modification.",
         "title": "Modifier le type de store — Confirmer"
+      },
+      "change_cover_type_revert_confirm": {
+        "title": "Modifier le type de store — Annuler le basculement en attente",
+        "description": "Un basculement non enregistré vers **{pending_type}** attend d'être appliqué dans cette boîte de dialogue. Le confirmer l'annule : cette instance reste **{from_type}**, et les paramètres modifiés par le basculement en attente reviennent à ce qu'ils étaient à l'ouverture de la boîte de dialogue.\n\nDans un cas comme dans l'autre, rien n'a encore été écrit : aucune entité n'est affectée et aucun rechargement ne se produit. Après confirmation, vérifiez la géométrie et terminez avec Enregistrer et fermer.",
+        "data": {
+          "confirm": "Annuler le changement de type de store en attente"
+        }
       },
       "calibration": {
         "description": "Mesurez le comportement réel de ce store et enregistrez les mesures.\n\n**L'étalonnage de position** mappe la position calculée par Adaptive Cover Pro sur le nombre que votre store doit atteindre. **Le temps de course** enregistre la durée d'une ouverture ou fermeture complète, afin que les cartes de tableau de bord puissent animer le mouvement au lieu de sauter.",

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -270,8 +270,52 @@ async def test_picker_offers_capability_compatible_types_only(
     assert CoverType.TILT not in offered
     assert CoverType.VENETIAN not in offered
     assert CoverType.LOUVERED_ROOF not in offered
-    # Never offer the type it already is.
-    assert CoverType.BLIND not in offered
+    # Always offer the type it already is, pre-selected (#1200).
+    assert CoverType.BLIND in offered
+
+
+@pytest.mark.integration
+async def test_picker_preselects_the_current_type(hass: HomeAssistant) -> None:
+    """The dropdown opens on the type this instance already is (#1200).
+
+    With the current type filtered out and no suggested value, the frontend
+    highlighted whichever type happened to sort first among the alternatives —
+    reading as "this instance is a Horizontal awning" on a vertical blind.
+    """
+    entry = await _setup_entry(hass, entry_id="preselect_current")
+
+    result = await _open_picker(hass, entry)
+
+    marker = next(m for m in result["data_schema"].schema if str(m) == CONF_SENSOR_TYPE)
+    assert (marker.description or {}).get("suggested_value") == CoverType.BLIND
+
+
+@pytest.mark.integration
+async def test_picker_offers_the_current_type_even_when_it_is_no_longer_satisfiable(
+    hass: HomeAssistant,
+) -> None:
+    """The type it already is is offered whatever the bound covers can do (#1200).
+
+    A venetian entry whose covers are position-only fails venetian's own entity
+    filter, so the eligibility split calls it blocked. Offering it anyway is
+    what makes the pre-selection honest — and it must not simultaneously be
+    listed as a type the covers rule out, which would tell the user the value
+    the field is sitting on is unavailable.
+    """
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    entry = await _setup_entry(
+        hass, cover_type=CoverType.VENETIAN, entry_id="offer_unsatisfiable_current"
+    )
+
+    result = await _open_picker(hass, entry)
+
+    offered = _type_selector(result).config["options"]
+    assert CoverType.VENETIAN in offered
+    assert (
+        get_policy(CoverType.VENETIAN).display_label()
+        not in result["description_placeholders"]["blocked_types"]
+    )
 
 
 @pytest.mark.integration
@@ -440,6 +484,27 @@ async def test_confirm_step_shown_after_pick(hass: HomeAssistant) -> None:
     assert placeholders["to_type"] == get_policy(CoverType.AWNING).display_label()
     # Nothing is written until the user confirms.
     assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+
+
+@pytest.mark.integration
+async def test_picking_the_current_type_returns_to_the_menu(
+    hass: HomeAssistant,
+) -> None:
+    """Leaving the field on the type it already is changes nothing (#1200).
+
+    The current type is in the dropdown so the field can open on it. Submitting
+    it is "never mind", not a switch — there is nothing to confirm, nothing to
+    strand, and no geometry to re-collect.
+    """
+    entry = await _setup_entry(hass, entry_id="pick_current_noop")
+    options_before = dict(entry.options)
+
+    result = await _pick(hass, entry, CoverType.BLIND)
+
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert dict(entry.options) == options_before
 
 
 @pytest.mark.integration
@@ -2079,6 +2144,78 @@ async def test_round_trip_switch_reloads_nothing(hass: HomeAssistant) -> None:
     assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
     assert dict(entry.options) == options_before
     assert _reloads(reload, entry) == 0
+
+
+async def _revert_pending_switch(hass: HomeAssistant, entry: MockConfigEntry) -> dict:
+    """Switch to awning without saving, then pick the stored type back."""
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    async def _straight_back_to_menu(self, user_input=None):
+        return await self.async_step_init()
+
+    with patch.object(
+        OptionsFlowHandler, "async_step_geometry", _straight_back_to_menu
+    ):
+        menu = await hass.config_entries.options.async_init(entry.entry_id)
+        menu = await _switch_to(hass, menu["flow_id"], CoverType.AWNING, geometry=False)
+        picker = await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "change_cover_type"}
+        )
+        return await hass.config_entries.options.async_configure(
+            picker["flow_id"], {CONF_SENSOR_TYPE: CoverType.BLIND}
+        )
+
+
+@pytest.mark.integration
+async def test_reverting_a_pending_switch_still_shows_the_confirm_screen(
+    hass: HomeAssistant,
+) -> None:
+    """Picking the stored type back mid-dialog is a switch, not a no-op (#1200).
+
+    The picker's no-op shortcut compares against ``self.sensor_type`` — the
+    type the FLOW is on — and never against the stored one. After a pending
+    blind → awning the flow is on awning, so picking blind is the revert, and
+    it has real work to do: ``_apply_pending_cover_type`` unwinds the polarity
+    re-seed and the incoming type's keys. Short-circuiting to the menu here
+    would leave the user's cancelled switch pending and applied at Save.
+    """
+    entry = await _setup_entry(hass, entry_id="revert_pending_confirm")
+
+    result = await _revert_pending_switch(hass, entry)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "change_cover_type_revert_confirm"
+
+
+@pytest.mark.integration
+async def test_reverting_a_pending_switch_reads_as_a_cancellation(
+    hass: HomeAssistant,
+) -> None:
+    """A revert gets its own copy instead of "switching from X to X" (#1200).
+
+    The confirm screen states the net change against STORED state on purpose,
+    and a revert has no net change — so the shared wording degenerates into
+    naming the same cover type twice. The revert gets a second step id, which
+    is the only handle the frontend has for choosing a different description,
+    and a ``pending_type`` placeholder naming the switch being cancelled.
+    ``from_type``/``to_type`` keep their stored-state meaning untouched.
+    """
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    entry = await _setup_entry(hass, entry_id="revert_pending_copy")
+
+    result = await _revert_pending_switch(hass, entry)
+
+    placeholders = result["description_placeholders"]
+    assert placeholders["pending_type"] == get_policy(CoverType.AWNING).display_label()
+    assert placeholders["from_type"] == get_policy(CoverType.BLIND).display_label()
+
+    step = _en_json()["options"]["step"]["change_cover_type_revert_confirm"]
+    assert step["description"].strip()
+    assert step["title"].strip()
+    assert step["data"]["confirm"].strip()
+    assert "{pending_type}" in step["description"]
+    assert "Switching from" not in step["description"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -296,11 +296,12 @@ async def test_picker_offers_the_current_type_even_when_it_is_no_longer_satisfia
 ) -> None:
     """The type it already is is offered whatever the bound covers can do (#1200).
 
-    A venetian entry whose covers are position-only fails venetian's own entity
-    filter, so the eligibility split calls it blocked. Offering it anyway is
-    what makes the pre-selection honest — and it must not simultaneously be
-    listed as a type the covers rule out, which would tell the user the value
-    the field is sitting on is unavailable.
+    A venetian entry whose covers are position-only would fail venetian's own
+    entity filter, and every other type that fails it is dropped from the
+    dropdown. ``_offered_cover_types`` puts the current type back without
+    asking about capabilities, which is what makes the pre-selection honest.
+
+    The two halves below do not carry equal weight — see their comments.
     """
     from custom_components.adaptive_cover_pro.cover_types import get_policy
 
@@ -311,7 +312,16 @@ async def test_picker_offers_the_current_type_even_when_it_is_no_longer_satisfia
     result = await _open_picker(hass, entry)
 
     offered = _type_selector(result).config["options"]
+    # Load-bearing: this is the assertion that fails without
+    # ``_offered_cover_types``, leaving the field to open on an arbitrary
+    # alternative and claim the instance is a type it is not.
     assert CoverType.VENETIAN in offered
+    # Weaker, and true for a structural reason rather than this change's doing:
+    # ``_eligible_cover_types`` ``continue``s past the current type, so venetian
+    # lands in neither ``eligible`` nor ``blocked`` and the screen has nothing
+    # to name it with. Kept as a lock on the rendered result all the same — the
+    # value the field opens on must never also be listed as one the bound
+    # covers rule out.
     assert (
         get_policy(CoverType.VENETIAN).display_label()
         not in result["description_placeholders"]["blocked_types"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -8,6 +8,7 @@ source of truth. DE/FR must match en.json exactly for every section including
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -773,29 +774,39 @@ def test_manual_override_duration_mode_options_translated_in_en():
 
 
 # ---------------------------------------------------------------------------
-# Issue #1200 — the picker dropdown and the screen after it must name the same
-# cover type. ``selector.mode.options`` labels the dropdown; the confirm step
-# renders ``get_policy(key).display_label()``. Two independent English sources
-# for one value, and nothing cross-checked them, so ``cover_awning`` shipped as
-# "Horizontal blind" in one and "Horizontal Awning" in the other.
+# Issues #1200 / #1201 — the picker dropdown and the screen after it must name
+# the same cover type. ``selector.mode.options`` labels the dropdown; the
+# confirm step renders ``get_policy(key).display_label(labels)``. Two
+# independent bundles name one value, and nothing cross-checked them, so
+# ``cover_awning`` shipped in English as "Horizontal blind" on one screen and
+# "Horizontal Awning" on the other (#1200), and DE/FR shipped a drop-arm awning
+# as "Gelenkarmmarkise"/"Schwenkmarkise" and "Store banne à bras articulé"/
+# "Store oscillant" (#1201).
 #
-# English-only by design. ``display_label()`` has no per-language form to
-# compare against, and DE/FR carry pre-existing label drift of their own —
-# tracked separately as issue #1201. Widening this guard to those files would
-# turn the suite red on that drift rather than on anything a change here did.
+# Runs over every shipped language. The rule is deliberately language-neutral:
+# #1200's first cut matched on the English head noun (last token), which does
+# not survive contact with German compounding ("Doppelpaneel-Beschattung" is
+# one token, not two) or French postposed adjectives.
 # ---------------------------------------------------------------------------
 
 
-def _label_tokens(label: str) -> list[str]:
-    """Normalize a cover-type label to comparable tokens.
+_PAREN_TAIL = re.compile(r"\s*\(([^()]*)\)\s*$")
 
-    Lower-cases, drops one trailing parenthesised qualifier (the selector adds
-    hardware hints the summary label omits — "(dual-axis)", "(drop-arm)"), and
-    splits on whitespace.
+
+def _split_label(label: str) -> tuple[list[str], str | None]:
+    """Split a cover-type label into (stem tokens, trailing qualifier).
+
+    Case-folds, then peels off one trailing parenthesised qualifier — the
+    picker adds hardware hints the summary label routinely omits ("(dual-axis)",
+    "(drop-arm)", "(sheer + blackout)"). Returns ``None`` for the qualifier when
+    the label carries none.
     """
-    import re
-
-    return re.sub(r"\s*\([^()]*\)\s*$", "", label.lower()).split()
+    text = label.casefold().strip()
+    qualifier: str | None = None
+    if match := _PAREN_TAIL.search(text):
+        qualifier = " ".join(match.group(1).split())
+        text = text[: match.start()]
+    return text.split(), qualifier
 
 
 def _is_prefix(shorter: list[str], longer: list[str]) -> bool:
@@ -803,26 +814,38 @@ def _is_prefix(shorter: list[str], longer: list[str]) -> bool:
     return len(shorter) <= len(longer) and longer[: len(shorter)] == shorter
 
 
-def test_selector_mode_labels_name_the_same_cover_type_as_the_policy() -> None:
-    """Every ``selector.mode`` option names the type its policy names (#1200).
+@pytest.mark.parametrize("language", sorted(SHIPPED_LANGUAGES))
+def test_selector_mode_labels_name_the_same_cover_type_as_the_policy(
+    language: str,
+) -> None:
+    """Every ``selector.mode`` option names the type its policy names (#1201).
 
-    The two labels are allowed to differ in casing and in trailing
-    parenthesised detail, so the pair agrees when either the head noun (last
-    token) matches — "Tilted blind" vs "Venetian / Tilt Blind" — or one token
-    list is a token-wise prefix of the other — "Dual panel" vs "Dual Panel
-    Shade". What it refuses is a different noun for the same value.
+    Two clauses, both language-neutral:
 
-    Known limitation: a wrong *modifier* in front of a right head noun
-    ("Vertical awning" for ``cover_awning``) still passes. This guards the
-    failure that actually shipped — two screens calling one cover type two
-    different things — not every possible wording slip.
+    * **Stem** — after case-folding and peeling one trailing parenthetical, the
+      two stems must be equal, or one must be a token-wise prefix of the other
+      ("Dual panel" vs "Dual Panel Shade"). No head-noun shortcut: a rule that
+      compares only the last token passes "Jalousette" against "Jalousie" in a
+      language that welds its nouns together.
+    * **Qualifier** — when *both* labels carry a trailing parenthetical they
+      must say the same thing. The picker is free to add a hint the summary
+      omits; it is not free to call the same hardware "(double axe)" on one
+      screen and "(deux axes)" on the next.
+
+    Deliberately no exemption list. Every shipped row satisfies the rule on its
+    own wording — a carve-out here is drift with a comment attached.
     """
+    from custom_components.adaptive_cover_pro.config_flow import (
+        _load_summary_labels_sync,
+    )
     from custom_components.adaptive_cover_pro.cover_types import (
         POLICY_REGISTRY,
         get_policy,
     )
 
-    options = _load(TRANSLATIONS_DIR / "en.json")["selector"]["mode"]["options"]
+    options = _load(TRANSLATIONS_DIR / f"{language}.json")["selector"]["mode"][
+        "options"
+    ]
 
     unknown = [key for key in options if key not in POLICY_REGISTRY]
     assert not unknown, (
@@ -830,25 +853,73 @@ def test_selector_mode_labels_name_the_same_cover_type_as_the_policy() -> None:
         f"labels are never cross-checked against one: {unknown}"
     )
 
+    # The same resolution the confirm step performs: the language bundle
+    # overlaid on the code-owned English defaults, per key.
+    labels = _load_summary_labels_sync(language)
+
     mismatched: list[str] = []
     for key, label in options.items():
-        selector_tokens = _label_tokens(label)
-        policy_tokens = _label_tokens(get_policy(key).display_label())
-        same_head = selector_tokens[-1:] == policy_tokens[-1:]
-        prefix = _is_prefix(selector_tokens, policy_tokens) or _is_prefix(
-            policy_tokens, selector_tokens
+        policy_label = get_policy(key).display_label(labels)
+        selector_stem, selector_qualifier = _split_label(label)
+        policy_stem, policy_qualifier = _split_label(policy_label)
+
+        stem_agrees = _is_prefix(selector_stem, policy_stem) or _is_prefix(
+            policy_stem, selector_stem
         )
-        if not (same_head or prefix):
+        qualifier_agrees = (
+            selector_qualifier is None
+            or policy_qualifier is None
+            or selector_qualifier == policy_qualifier
+        )
+        if not (stem_agrees and qualifier_agrees):
             mismatched.append(
-                f"  - {key}: selector says {label!r}, "
-                f"policy says {get_policy(key).display_label()!r}"
+                f"  - {key}: picker says {label!r}, confirm says {policy_label!r}"
             )
 
     assert not mismatched, (
-        "selector.mode and display_label() name the same cover type "
-        "differently, so the picker and the screen after it disagree:\n"
+        f"[{language}] selector.mode and display_label() name the same cover "
+        "type differently, so the picker and the screen after it disagree:\n"
         + "\n".join(mismatched)
     )
+
+
+@pytest.mark.parametrize("language", sorted(SHIPPED_LANGUAGES))
+def test_cover_type_labels_are_distinct_within_a_language(language: str) -> None:
+    """No two cover types may share a label in either bundle (#1201).
+
+    The parity guard above compares one key's two labels, which says nothing
+    about two keys colliding. Reconciling a pair by deleting whatever made it
+    specific satisfies parity and still breaks the UI: a first pass at #1201
+    settled both German venetian rows on a bare "Jalousie", so tilt-only and
+    dual-axis became the same word on the confirm screen and in the config
+    summary. The picker is worse — two identical dropdown entries are
+    unpickable.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import (
+        _load_summary_labels_sync,
+    )
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    options = _load(TRANSLATIONS_DIR / f"{language}.json")["selector"]["mode"][
+        "options"
+    ]
+    labels = _load_summary_labels_sync(language)
+
+    for surface, rendered in (
+        ("picker (selector.mode.options)", dict(options)),
+        (
+            "confirm (display_label)",
+            {key: get_policy(key).display_label(labels) for key in options},
+        ),
+    ):
+        by_label: dict[str, list[str]] = {}
+        for key, text in rendered.items():
+            by_label.setdefault(text.casefold(), []).append(key)
+        collisions = {text: keys for text, keys in by_label.items() if len(keys) > 1}
+        assert not collisions, (
+            f"[{language}] {surface} gives one name to several cover types, so "
+            f"the user cannot tell them apart: {collisions}"
+        )
 
 
 def test_every_offered_cover_type_has_a_selector_mode_label() -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -778,6 +778,11 @@ def test_manual_override_duration_mode_options_translated_in_en():
 # renders ``get_policy(key).display_label()``. Two independent English sources
 # for one value, and nothing cross-checked them, so ``cover_awning`` shipped as
 # "Horizontal blind" in one and "Horizontal Awning" in the other.
+#
+# English-only by design. ``display_label()`` has no per-language form to
+# compare against, and DE/FR carry pre-existing label drift of their own —
+# tracked separately as issue #1201. Widening this guard to those files would
+# turn the suite red on that drift rather than on anything a change here did.
 # ---------------------------------------------------------------------------
 
 
@@ -843,4 +848,31 @@ def test_selector_mode_labels_name_the_same_cover_type_as_the_policy() -> None:
         "selector.mode and display_label() name the same cover type "
         "differently, so the picker and the screen after it disagree:\n"
         + "\n".join(mismatched)
+    )
+
+
+def test_every_offered_cover_type_has_a_selector_mode_label() -> None:
+    """The other direction: no offerable type may be missing its label (#1200).
+
+    ``test_selector_mode_labels_name_the_same_cover_type_as_the_policy`` walks
+    the label bundle and checks each key resolves to a policy, which says
+    nothing about a policy that ships with no key at all. A new cover type
+    registered without one renders its raw ``cover_*`` string in both the
+    create flow's dropdown and the change-cover-type picker.
+
+    Scoped to ``SENSOR_TYPE_MENU``, not ``POLICY_REGISTRY``: the menu is what
+    both dropdowns are built from — ``CONFIG_SCHEMA`` passes it straight to the
+    selector, and ``_eligible_cover_types``/``_offered_cover_types`` iterate it
+    — while the registry also holds virtual entry types (Building Profile,
+    Group, Command Queue) that no cover-type dropdown ever offers and that
+    therefore need no ``selector.mode`` label.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import SENSOR_TYPE_MENU
+
+    options = _load(TRANSLATIONS_DIR / "en.json")["selector"]["mode"]["options"]
+
+    missing = [key for key in SENSOR_TYPE_MENU if key not in options]
+    assert not missing, (
+        "cover types the picker offers with no selector.mode.options label, so "
+        f"the dropdown renders their raw key: {missing}"
     )

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -770,3 +770,77 @@ def test_manual_override_duration_mode_options_translated_in_en():
     step = en["options"]["step"]["manual_override"]
     assert step["data"][CONF_MANUAL_OVERRIDE_DURATION_MODE].strip()
     assert step["data_description"][CONF_MANUAL_OVERRIDE_DURATION_MODE].strip()
+
+
+# ---------------------------------------------------------------------------
+# Issue #1200 — the picker dropdown and the screen after it must name the same
+# cover type. ``selector.mode.options`` labels the dropdown; the confirm step
+# renders ``get_policy(key).display_label()``. Two independent English sources
+# for one value, and nothing cross-checked them, so ``cover_awning`` shipped as
+# "Horizontal blind" in one and "Horizontal Awning" in the other.
+# ---------------------------------------------------------------------------
+
+
+def _label_tokens(label: str) -> list[str]:
+    """Normalize a cover-type label to comparable tokens.
+
+    Lower-cases, drops one trailing parenthesised qualifier (the selector adds
+    hardware hints the summary label omits — "(dual-axis)", "(drop-arm)"), and
+    splits on whitespace.
+    """
+    import re
+
+    return re.sub(r"\s*\([^()]*\)\s*$", "", label.lower()).split()
+
+
+def _is_prefix(shorter: list[str], longer: list[str]) -> bool:
+    """Whether *shorter* is a token-wise prefix of *longer*."""
+    return len(shorter) <= len(longer) and longer[: len(shorter)] == shorter
+
+
+def test_selector_mode_labels_name_the_same_cover_type_as_the_policy() -> None:
+    """Every ``selector.mode`` option names the type its policy names (#1200).
+
+    The two labels are allowed to differ in casing and in trailing
+    parenthesised detail, so the pair agrees when either the head noun (last
+    token) matches — "Tilted blind" vs "Venetian / Tilt Blind" — or one token
+    list is a token-wise prefix of the other — "Dual panel" vs "Dual Panel
+    Shade". What it refuses is a different noun for the same value.
+
+    Known limitation: a wrong *modifier* in front of a right head noun
+    ("Vertical awning" for ``cover_awning``) still passes. This guards the
+    failure that actually shipped — two screens calling one cover type two
+    different things — not every possible wording slip.
+    """
+    from custom_components.adaptive_cover_pro.cover_types import (
+        POLICY_REGISTRY,
+        get_policy,
+    )
+
+    options = _load(TRANSLATIONS_DIR / "en.json")["selector"]["mode"]["options"]
+
+    unknown = [key for key in options if key not in POLICY_REGISTRY]
+    assert not unknown, (
+        "selector.mode.options has keys with no registered policy, so their "
+        f"labels are never cross-checked against one: {unknown}"
+    )
+
+    mismatched: list[str] = []
+    for key, label in options.items():
+        selector_tokens = _label_tokens(label)
+        policy_tokens = _label_tokens(get_policy(key).display_label())
+        same_head = selector_tokens[-1:] == policy_tokens[-1:]
+        prefix = _is_prefix(selector_tokens, policy_tokens) or _is_prefix(
+            policy_tokens, selector_tokens
+        )
+        if not (same_head or prefix):
+            mismatched.append(
+                f"  - {key}: selector says {label!r}, "
+                f"policy says {get_policy(key).display_label()!r}"
+            )
+
+    assert not mismatched, (
+        "selector.mode and display_label() name the same cover type "
+        "differently, so the picker and the screen after it disagree:\n"
+        + "\n".join(mismatched)
+    )


### PR DESCRIPTION
## Summary

The Change Cover Type picker filtered the entry's own type out of the list and set no default, so Home Assistant highlighted whatever happened to be first. On a vertical blind that was the awning row, whose English label also read "Horizontal blind" while the confirm screen called the same value "Horizontal Awning". Two names for one type, and a dropdown that opened on something you had not chosen.

The picker now offers the current type and pre-selects it via `add_suggested_values_to_schema`, matching the idiom every other field in the flow already uses. Picking it returns to the menu instead of walking a no-op switch into the geometry step, which on submit was rewriting `fov_left`, `fov_right` and `window_width` from schema defaults. Reverting a pending switch gets its own confirm step so it no longer reads as "Vertical Blind to Vertical Blind".

`_eligible_cover_types` is byte-identical. The current type is added by a new `_offered_cover_types` sibling, so the "nothing to switch to" abort keeps working and the current type never lands in the blocked list.

While guarding the label fix I found the same divergence live in German and French, filed as #1201 and fixed here. The picker reads `translations/*.json` and the confirm screen reads `summary_i18n/*.json`, so the two sets drifted with nothing watching. The worst rows named different machines: `Gelenkarmmarkise` against `Schwenkmarkise`, and `store banne a bras articule` against `store oscillant`, for what is a drop-arm awning. Both languages now say `Fallarmmarkise` and `store a projection`.

The parity guard is parametrized over every shipped language, using a stem-plus-qualifier rule rather than the English-shaped head-noun rule I started with. There is also a distinctness guard, because the translation pass initially resolved the German failure by calling both tilt and venetian plain `Jalousie`. Satisfying parity by deleting what makes each type specific is a regression parity cannot see on its own.

Nothing is stored: no option key, no schema, no migration, no config-entry version movement.

## Testing

- ✅ 12632 tests passing (4 skipped, 17 xfailed)
- Two independent opus audits, both zero must-fix
- Guard tests unchanged and green: `test_picker_aborts_when_nothing_eligible`, `test_round_trip_switch_*`, `test_config_entry_version_unchanged`, `test_policy_summary_i18n`

## Related Issues

Refs #1200
Refs #1201
