### PR TITLE
fix: honour triage-exempt in release-issue-lifecycle (#1188)

### DIFF
--- a/.github/workflows/release-issue-lifecycle.yml
+++ b/.github/workflows/release-issue-lifecycle.yml
@@ -184,7 +184,7 @@ jobs:
             }
 
             // Sweep: close every OPEN issue carrying `released` (just-tagged + any
-            // stragglers). This is what "all issues tagged released are closed" means.
+            // stragglers), skipping any that also carry `triage-exempt`.
             const releasedOpen = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: 'released', per_page: 100,
             });

--- a/.github/workflows/release-issue-lifecycle.yml
+++ b/.github/workflows/release-issue-lifecycle.yml
@@ -116,6 +116,10 @@ jobs:
 
             // Tag a referenced OPEN issue `released`; the sweep below closes it.
             async function tagReferencedIssue(num, labels) {
+              if (labels.includes('triage-exempt')) {
+                console.log(`#${num} is triage-exempt — not tagging released.`);
+                return;
+              }
               if (labels.includes('awaiting-release')) await removeLabelSafe(num, 'awaiting-release');
               if (labels.includes('reopened')) await removeLabelSafe(num, 'reopened');
               if (!labels.includes('released')) {
@@ -187,6 +191,11 @@ jobs:
             let closed = 0;
             for (const item of releasedOpen) {
               if (item.pull_request) continue; // never close PRs
+              const labels = item.labels.map(l => l.name);
+              if (labels.includes('triage-exempt')) {
+                console.log(`#${item.number} is triage-exempt — not closing.`);
+                continue;
+              }
               await github.rest.issues.createComment({ owner, repo, issue_number: item.number, body: closeComment });
               await github.rest.issues.update({ owner, repo, issue_number: item.number, state: 'closed', state_reason: 'completed' });
               console.log(`Closed released issue #${item.number}.`);


### PR DESCRIPTION
## Summary

`release-issue-lifecycle.yml` tagged every referenced open issue `released` and then closed it in the sweep, with no way to exempt one - a commit only had to mention an issue number for that issue to be closed as fixed at the next stable cut. It bit twice during the v2026.8.0 release: #1173, whose only referencing commit rewrote xfail reasons and changed no behaviour, and #943, which carried `reopened` because the beta.1 work didn't cover the whole request.

I added a `triage-exempt` guard to both mutation paths:

- In `tagReferencedIssue()` it goes first, before the `awaiting-release`/`reopened` stripping, so an exempt issue is left entirely untouched rather than partially mutated. Both call sites get it through the shared function.
- The sweep needs its own gate because it queries GitHub by label independently, so an issue already carrying `released` from an earlier run would still be closed.

I deliberately left out a `reopened` guard. `issue-reopen-on-request.yml` strips `released` on reopen precisely so a later genuine fix can re-tag and re-close through this workflow, so skipping every reopened issue would break that recovery path to guard a case hand-applied `triage-exempt` already covers.

The `triage-exempt` label description has been updated to mention the release lifecycle alongside issue-hygiene.

## Testing

No committed tests - this repo has no automated coverage for `.github/workflows/*.yml`, and adding a harness for one guard clause would invent a pattern the repo has never had. Verified instead with a disposable RED/GREEN Node harness that ran the real script bodies through 7 scenarios: plain referenced issue still tagged and closed; exempt issue untouched with `awaiting-release` retained; exempt straggler already carrying `released` skipped by the sweep; non-exempt straggler still closed; non-exempt `reopened` still closed; exempt + `reopened` untouched; and the PR-body `linkedIssueQueue` path inheriting the guard. Plus a YAML parse check and `node --check` on the extracted script.

## Related Issues

Refs #1188