### PR TITLE
fix: honour triage-exempt in release-issue-lifecycle (hotfix)

### DIFF
--- a/.github/workflows/release-issue-lifecycle.yml
+++ b/.github/workflows/release-issue-lifecycle.yml
@@ -116,6 +116,10 @@ jobs:
 
             // Tag a referenced OPEN issue `released`; the sweep below closes it.
             async function tagReferencedIssue(num, labels) {
+              if (labels.includes('triage-exempt')) {
+                console.log(`#${num} is triage-exempt — not tagging released.`);
+                return;
+              }
               if (labels.includes('awaiting-release')) await removeLabelSafe(num, 'awaiting-release');
               if (labels.includes('reopened')) await removeLabelSafe(num, 'reopened');
               if (!labels.includes('released')) {
@@ -180,13 +184,18 @@ jobs:
             }
 
             // Sweep: close every OPEN issue carrying `released` (just-tagged + any
-            // stragglers). This is what "all issues tagged released are closed" means.
+            // stragglers), skipping any that also carry `triage-exempt`.
             const releasedOpen = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: 'released', per_page: 100,
             });
             let closed = 0;
             for (const item of releasedOpen) {
               if (item.pull_request) continue; // never close PRs
+              const labels = item.labels.map(l => l.name);
+              if (labels.includes('triage-exempt')) {
+                console.log(`#${item.number} is triage-exempt — not closing.`);
+                continue;
+              }
               await github.rest.issues.createComment({ owner, repo, issue_number: item.number, body: closeComment });
               await github.rest.issues.update({ owner, repo, issue_number: item.number, state: 'closed', state_reason: 'completed' });
               console.log(`Closed released issue #${item.number}.`);


### PR DESCRIPTION
## Summary

Cherry-pick of the `triage-exempt` guard onto `main` so it can ship as an in-month patch.

This one genuinely needs the stable branch. `release: published` carries no branch ref, so GitHub resolves `release-issue-lifecycle.yml` from the **default branch** — `main`. A monthly stable is fine either way (`develop` → `main` merges before `./scripts/release` fires the event), but a `2026.8.x` in-month patch is cut from a `hotfix/*` off `main` and would run the sweep from `main`'s unguarded copy. Same for any `workflow_dispatch` re-run before the next stable.

The change itself: a `triage-exempt` guard on both mutation paths — first statement of `tagReferencedIssue()` (before the `awaiting-release`/`reopened` stripping, so an exempt issue is left entirely untouched), and inside the sweep's loop, which needs its own gate because it queries GitHub by label independently.

## Testing

No committed tests — the repo has no automated coverage for `.github/workflows/*.yml`. The diff against `main` is byte-identical to what landed on `develop` (both branches carried the same version of the file), and the file parses. Upstream verification was a disposable RED/GREEN Node harness over 7 scenarios plus `node --check` on the extracted script.

## Related Issues

Refs #1188

Cherry-picked from #1205 for a hotfix release.