### PR TITLE
fix: keep scripts/release log output out of the published release body (hotfix)

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -34,7 +34,7 @@ RETRY_DELAY=5
 # Colors and Formatting
 # ============================================================================
 
-if [[ -t 1 ]]; then
+if [[ -t 2 ]]; then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
     YELLOW='\033[1;33m'
@@ -77,15 +77,15 @@ CREATED_COMMIT=""
 # ============================================================================
 
 log_info() {
-    echo -e "${BLUE}ℹ${RESET} $*"
+    echo -e "${BLUE}ℹ${RESET} $*" >&2
 }
 
 log_success() {
-    echo -e "${GREEN}✓${RESET} $*"
+    echo -e "${GREEN}✓${RESET} $*" >&2
 }
 
 log_warning() {
-    echo -e "${YELLOW}⚠${RESET} $*"
+    echo -e "${YELLOW}⚠${RESET} $*" >&2
 }
 
 log_error() {
@@ -93,11 +93,11 @@ log_error() {
 }
 
 log_step() {
-    echo -e "${MAGENTA}▸${RESET} ${BOLD}$*${RESET}"
+    echo -e "${MAGENTA}▸${RESET} ${BOLD}$*${RESET}" >&2
 }
 
 log_dry_run() {
-    echo -e "${CYAN}[DRY RUN]${RESET} $*"
+    echo -e "${CYAN}[DRY RUN]${RESET} $*" >&2
 }
 
 # ============================================================================
@@ -740,7 +740,12 @@ open_editor_for_notes() {
     log_info "Opening $editor for release notes..."
     log_info "Edit the release notes, save, and close the editor"
 
-    "$editor" "$notes_file"
+    # A full-screen editor needs a real terminal to draw on. Routing its
+    # stdout to `&2` would only work when stderr happens to be a TTY (not
+    # true under e.g. `./scripts/release beta --editor 2>log.txt`), so
+    # connect it directly to the controlling terminal instead — this stays
+    # correct no matter how the script's own stdout/stderr are redirected.
+    "$editor" "$notes_file" </dev/tty >/dev/tty
 
     # Read edited notes
     local notes
@@ -808,10 +813,10 @@ wait_for_workflow() {
 
         sleep $WORKFLOW_POLL_INTERVAL
         elapsed=$((elapsed + WORKFLOW_POLL_INTERVAL))
-        echo -n "."
+        echo -n "." >&2
     done
 
-    echo ""
+    echo "" >&2
     log_error "Workflow did not complete within ${WORKFLOW_TIMEOUT}s"
     log_info "Check workflow status: gh run list --workflow=publish-release.yml"
     exit 1
@@ -1005,20 +1010,26 @@ confirm_release() {
     local current_branch
     current_branch=$(git branch --show-current)
 
-    echo ""
-    echo -e "${BOLD}Release Summary:${RESET}"
-    echo ""
-    echo "  Current version: $current_version"
-    echo "  New version:     $new_version"
-    echo "  Release type:    $release_type"
-    echo "  Branch:          $current_branch"
-    echo "  Tag:             v$new_version"
-    echo ""
-
-    if [[ $DRY_RUN == true ]]; then
-        echo -e "${CYAN}  Mode: DRY RUN (no changes will be made)${RESET}"
+    # Human-facing chatter, not a return value — stderr (also required to
+    # keep the -t 2 color gate correct: this is the last block that put
+    # colored escapes on stdout, which would silently lose color under
+    # `2>log.txt` if left there while colors are gated on fd 2).
+    {
         echo ""
-    fi
+        echo -e "${BOLD}Release Summary:${RESET}"
+        echo ""
+        echo "  Current version: $current_version"
+        echo "  New version:     $new_version"
+        echo "  Release type:    $release_type"
+        echo "  Branch:          $current_branch"
+        echo "  Tag:             v$new_version"
+        echo ""
+
+        if [[ $DRY_RUN == true ]]; then
+            echo -e "${CYAN}  Mode: DRY RUN (no changes will be made)${RESET}"
+            echo ""
+        fi
+    } >&2
 
     confirm "Proceed with release?" "n"
 }
@@ -1061,7 +1072,7 @@ main() {
                 ;;
             -*)
                 log_error "Unknown option: $1"
-                echo "Run with --help for usage information"
+                echo "Run with --help for usage information" >&2
                 exit 1
                 ;;
             *)
@@ -1076,12 +1087,14 @@ main() {
         esac
     done
 
-    # Print header
-    echo ""
-    echo -e "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
-    echo -e "${BOLD}  Adaptive Cover Pro ⛅ Release Automation${RESET}"
-    echo -e "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
-    echo ""
+    # Print header (human-facing chatter, not a return value — stderr)
+    {
+        echo ""
+        echo -e "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+        echo -e "${BOLD}  Adaptive Cover Pro ⛅ Release Automation${RESET}"
+        echo -e "${BOLD}${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+        echo ""
+    } >&2
 
     # Validate environment
     validate_environment
@@ -1142,15 +1155,18 @@ main() {
     local release_url
     release_url=$(get_release_url "v$NEW_VERSION")
 
-    echo ""
-    echo -e "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
-    echo -e "${BOLD}${GREEN}  Release created successfully! 🎉${RESET}"
-    echo -e "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
-    echo ""
-    echo "  Version:      v$NEW_VERSION"
-    echo "  Release type: $RELEASE_TYPE"
-    echo "  URL:          $release_url"
-    echo ""
+    # Success banner (human-facing chatter, not a return value — stderr)
+    {
+        echo ""
+        echo -e "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+        echo -e "${BOLD}${GREEN}  Release created successfully! 🎉${RESET}"
+        echo -e "${BOLD}${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+        echo ""
+        echo "  Version:      v$NEW_VERSION"
+        echo "  Release type: $RELEASE_TYPE"
+        echo "  URL:          $release_url"
+        echo ""
+    } >&2
 
     if [[ $RELEASE_TYPE == "beta" ]]; then
         log_warning "This is a BETA release - please test thoroughly"
@@ -1161,4 +1177,6 @@ main() {
 # Entry Point
 # ============================================================================
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test_scripts_release.py
+++ b/tests/test_scripts_release.py
@@ -1,0 +1,148 @@
+"""Regression test for issue #1187 — `scripts/release` log leak.
+
+`get_release_notes()` is captured wholesale via
+`RELEASE_NOTES=$(get_release_notes ...)` in `main()`, so anything the
+function's call graph writes to stdout becomes part of the published GitHub
+release body / tag message. `log_info` and its siblings (`log_success`,
+`log_warning`, `log_step`, `log_dry_run`) wrote to stdout instead of
+stderr — only `log_error` redirected correctly. These tests prove the
+captured return value of `get_release_notes` is exactly the expected
+notes/template content for each of its branches, with no leaked `log_info`
+line prepended, and that the log line itself still reaches stderr.
+
+`scripts/release` is guarded at its bottom (`if [[ "${BASH_SOURCE[0]}" ==
+"${0}" ]]; then main "$@"; fi`) so it is safe to `source` for testing without
+triggering `main`'s interactive release flow — sourcing the file (rather
+than executing it) makes `BASH_SOURCE[0]` differ from `$0`.
+
+`scripts/release` unconditionally runs `cd "$(dirname "$0")/.."` at the top
+of the file, before any function definition (and before the entry-point
+guard, which only wraps `main`), so each helper pins a fake `scripts/release`
+path under `tmp_path` as `$0` — this keeps the cd from mutating the real
+test-process working directory and lands the shell inside `tmp_path`, which
+the auto-detect case relies on for its relative `release_notes/v${version}.md`
+lookup.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_RELEASE_SCRIPT = _REPO_ROOT / "scripts" / "release"
+
+
+def _run_get_release_notes(
+    tmp_path: pathlib.Path,
+    *,
+    notes_file: pathlib.Path | None = None,
+    auto_notes: bool = False,
+    version: str = "2026.7.0",
+    release_type: str = "stable",
+) -> subprocess.CompletedProcess[str]:
+    """Source scripts/release in a fresh bash process and call get_release_notes.
+
+    `$0` is pinned to a fake `scripts/release` path under `tmp_path` so
+    scripts/release's unconditional top-level `cd "$(dirname "$0")/.."`
+    lands inside `tmp_path` (the real `scripts/` directory is untouched) and
+    so `BASH_SOURCE[0]` (the real script path passed to `source`) differs
+    from `$0`, keeping the entry-point guard from invoking `main`.
+    """
+    fake_scripts_dir = tmp_path / "scripts"
+    fake_scripts_dir.mkdir(exist_ok=True)
+    fake_self = fake_scripts_dir / "release"
+
+    notes_file_assignment = f'NOTES_FILE="{notes_file}"' if notes_file else ""
+    auto_notes_assignment = "AUTO_NOTES=true" if auto_notes else ""
+
+    script = f"""
+set -e
+source "{_RELEASE_SCRIPT}"
+{notes_file_assignment}
+{auto_notes_assignment}
+get_release_notes "{version}" "{release_type}"
+"""
+    return subprocess.run(
+        ["bash", "-c", script, str(fake_self)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def test_get_release_notes_stdout_matches_notes_file_for_explicit_notes(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The `--notes FILE` branch of `get_release_notes` must not leak `log_info`."""
+    notes_file = tmp_path / "notes.md"
+    notes_file.write_text("## What's new\n- Fixed the thing\n")
+
+    result = _run_get_release_notes(tmp_path, notes_file=notes_file)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == notes_file.read_text()
+    # The log line must still fire — just on stderr, not mixed into stdout.
+    assert "Reading release notes from" in result.stderr
+
+
+def test_get_release_notes_stdout_matches_notes_file_for_auto_detect(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The auto-detect `release_notes/vX.Y.Z.md` branch of `get_release_notes` must not leak `log_info`."""
+    version = "2026.7.0"
+    notes_dir = tmp_path / "release_notes"
+    notes_dir.mkdir()
+    notes_file = notes_dir / f"v{version}.md"
+    notes_file.write_text("## Auto-detected notes\n- Another thing\n")
+
+    result = _run_get_release_notes(tmp_path, version=version)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == notes_file.read_text()
+    # The log line must still fire — just on stderr, not mixed into stdout.
+    assert "Using release notes from" in result.stderr
+
+
+def test_get_release_notes_auto_notes_flag_does_not_leak(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The `--auto-notes` branch (`AUTO_NOTES=true`) of `get_release_notes` must not leak `log_info`."""
+    result = _run_get_release_notes(tmp_path, auto_notes=True, release_type="stable")
+
+    assert result.returncode == 0, result.stderr
+    # A generated template has no notes file to compare against — the
+    # meaningful assertions are that stdout is exactly the template (no
+    # leading log icon/line) and that the log line landed on stderr instead.
+    assert not result.stdout.startswith("ℹ")
+    assert "Using auto-generated release notes" not in result.stdout
+    assert result.stdout.startswith("# Adaptive Cover Pro")
+    assert "Using auto-generated release notes" in result.stderr
+
+
+def test_get_release_notes_generated_template_fallback_does_not_leak(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The generated-template fallback branch (no notes file, no `--auto-notes`,
+    no `--editor`, and no `release_notes/vX.Y.Z.md` on disk) of
+    `get_release_notes` must not leak `log_info`.
+    """
+    # No notes_file, no auto_notes, and no release_notes/ dir created under
+    # tmp_path — this naturally falls through to the else/else branch.
+    result = _run_get_release_notes(tmp_path)
+
+    expected_log_line = "Using auto-generated release notes (use --editor to customize)"
+
+    assert result.returncode == 0, result.stderr
+    # A generated template isn't a notes file, so it won't equal one — the
+    # meaningful assertions are: no leading log icon/line on stdout, and the
+    # log line present on stderr instead.
+    assert not result.stdout.startswith("ℹ")
+    assert expected_log_line not in result.stdout
+    assert result.stdout.startswith("# Adaptive Cover Pro")
+    assert expected_log_line in result.stderr


### PR DESCRIPTION
## Summary

`get_release_notes()` is captured via `RELEASE_NOTES=$(get_release_notes ...)`, so its stdout is its return value. `log_info` wrote to stdout, which put an `ℹ Using release notes from: ...` line at the top of the published GitHub release body and in HACS. v2026.7.5 still shows it live.

`log_info`, `log_success`, `log_warning`, `log_step`, and `log_dry_run` now carry the same `>&2` redirect `log_error` already had, so the whole helper family is safe inside a stdout-captured function rather than just the one call site that leaked. That also closes three dormant leak paths a narrow fix would have missed (`--auto-notes`, `open_editor_for_notes`, and `validate_version_format` via `calculate_new_version`).

With every `log_*` on stderr, the leftovers on stdout were the inconsistent half: the header and success banners, the release summary, the workflow progress dots, and the unknown-option hint. Those moved too. Genuine return values stay on stdout. The color gate moved from `-t 1` to `-t 2` to match where the output now goes, and `open_editor_for_notes` runs the editor against `/dev/tty` so editor drawing cannot reach the capture pipe.

`main "$@"` is wrapped in a `BASH_SOURCE` guard so the script can be sourced by a test without kicking off a real release.

Staged as a hotfix because an in-month patch is cut directly from `main`: until this lands there, every `YYYY.M.N` patch release still publishes the leaked line. A stable release merges `develop` first and would pick the fix up either way.

## Testing
- ✅ 11482 tests passing on `main`

## Related Issues
Refs #1187

Cherry-picked from #1207 for a hotfix release.