### PR TITLE
fix: trust the strategy, not the thermometer, for climate labels (#1196)

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -455,10 +455,13 @@ class ClimateHandler(OverrideHandler):
     Priority 50 — lower than override handlers, higher than solar/default.
     Builds ClimateCoverData from ClimateReadings + ClimateOptions, runs
     ClimateCoverState strategy, and returns the computed position.
-    The control method is set based on the climate season:
-    - SUMMER when over the high-temp threshold (heat blocking)
-    - WINTER when under the low-temp threshold (solar heat gain)
-    - SOLAR for all other climate-mode states (glare control)
+    The control method is set from the strategy that produced the position,
+    not from the temperature alone (issue #1196) — see _SEASON_STRATEGIES:
+    - SUMMER / WINTER only when a season strategy ran (cooling, heating,
+      insulation) and the matching temperature predicate holds
+    - EXTREME_HEAT and DEFAULT for the all-day heat hold and the season gate
+    - DEFAULT for a LOW_LIGHT fall-through to the default position
+    - SOLAR for glare control, in any season
     """
 
     name = "climate"

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -427,11 +427,11 @@ def inactive_reason_from_result(
     return ClimateInactiveReason.MODE_OFF
 
 
-# The strategies whose label genuinely comes from the season. ``is_summer`` /
-# ``is_winter`` are pure temperature predicates (ClimateCoverData, climate.py:103-142)
+# The strategies whose label genuinely comes from the season.
+# ``ClimateCoverData.is_summer`` / ``.is_winter`` are pure temperature predicates
 # and say nothing about which rule table branch actually fired, so they are only
 # trusted when a season strategy is what ran. Ungated they shadow the LOW_LIGHT and
-# GLARE_CONTROL branches below, stamping "summer" on a default-position hold and on
+# GLARE_CONTROL branches below, stamping "summer" on a low-light fall-through and on
 # in-FOV glare tracking (issue #1196). Same reasoning as the TRACKING_SEASON_GATE
 # branch in evaluate(): checked against the strategy because the strategy, not the
 # thermometer, is what the label is describing.

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -460,9 +460,9 @@ class ClimateHandler(OverrideHandler):
     - SUMMER / WINTER only when a season strategy ran (cooling, heating,
       insulation) and the matching temperature predicate holds
     - EXTREME_HEAT for the all-day heat hold, DEFAULT for the season gate
-    - DEFAULT for the LOW_LIGHT branch, whose position is whatever its own
-      rule returned (the default position in the normal tables, the solar
-      angle in the tilt tables) — not a promise the cover is at its default
+    - DEFAULT for the LOW_LIGHT branch. This labels the branch, not the
+      position: the rule tables pick that with _default or _solar, so DEFAULT
+      is not a promise the cover sits at its default position
     - SOLAR for glare control, in any season
     """
 
@@ -552,9 +552,9 @@ class ClimateHandler(OverrideHandler):
             method = ControlMethod.WINTER
             season_code = ReasonCode.FRAGMENT_SEASON_WINTER
         elif strategy == ClimateStrategy.LOW_LIGHT:
-            # Low-light / no-sun branch — the cover stops tracking the sun and
-            # holds whatever its rule returned (the default position in the
-            # normal tables, the solar angle in the tilt ones).  Emitting SOLAR
+            # Low-light / no-sun branch.  The position came from the rule
+            # table (_default or _solar), so DEFAULT labels the branch rather
+            # than promising the cover is at its default.  Emitting SOLAR
             # here would cause VenetianPolicy to synthesise a tilt from the
             # still-drifting azimuth even when the sun has set (issue #33).
             # Now that the season arms above are strategy-guarded this branch is

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -459,8 +459,10 @@ class ClimateHandler(OverrideHandler):
     not from the temperature alone (issue #1196) — see _SEASON_STRATEGIES:
     - SUMMER / WINTER only when a season strategy ran (cooling, heating,
       insulation) and the matching temperature predicate holds
-    - EXTREME_HEAT and DEFAULT for the all-day heat hold and the season gate
-    - DEFAULT for a LOW_LIGHT fall-through to the default position
+    - EXTREME_HEAT for the all-day heat hold, DEFAULT for the season gate
+    - DEFAULT for the LOW_LIGHT branch, whose position is whatever its own
+      rule returned (the default position in the normal tables, the solar
+      angle in the tilt tables) — not a promise the cover is at its default
     - SOLAR for glare control, in any season
     """
 
@@ -550,9 +552,10 @@ class ClimateHandler(OverrideHandler):
             method = ControlMethod.WINTER
             season_code = ReasonCode.FRAGMENT_SEASON_WINTER
         elif strategy == ClimateStrategy.LOW_LIGHT:
-            # Low-light / no-sun branch — the cover returns to its default
-            # position rather than tracking the sun.  Emitting SOLAR here
-            # would cause VenetianPolicy to synthesise a tilt from the
+            # Low-light / no-sun branch — the cover stops tracking the sun and
+            # holds whatever its rule returned (the default position in the
+            # normal tables, the solar angle in the tilt ones).  Emitting SOLAR
+            # here would cause VenetianPolicy to synthesise a tilt from the
             # still-drifting azimuth even when the sun has set (issue #33).
             # Now that the season arms above are strategy-guarded this branch is
             # reachable in any season, not just at intermediate temperatures.

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -427,6 +427,23 @@ def inactive_reason_from_result(
     return ClimateInactiveReason.MODE_OFF
 
 
+# The strategies whose label genuinely comes from the season. ``is_summer`` /
+# ``is_winter`` are pure temperature predicates (ClimateCoverData, climate.py:103-142)
+# and say nothing about which rule table branch actually fired, so they are only
+# trusted when a season strategy is what ran. Ungated they shadow the LOW_LIGHT and
+# GLARE_CONTROL branches below, stamping "summer" on a default-position hold and on
+# in-FOV glare tracking (issue #1196). Same reasoning as the TRACKING_SEASON_GATE
+# branch in evaluate(): checked against the strategy because the strategy, not the
+# thermometer, is what the label is describing.
+_SEASON_STRATEGIES: frozenset[ClimateStrategy] = frozenset(
+    {
+        ClimateStrategy.SUMMER_COOLING,
+        ClimateStrategy.WINTER_HEATING,
+        ClimateStrategy.WINTER_INSULATION,
+    }
+)
+
+
 # ---------------------------------------------------------------------------
 # ClimateHandler
 # ---------------------------------------------------------------------------
@@ -506,33 +523,36 @@ class ClimateHandler(OverrideHandler):
 
         position = round(raw_position)
 
-        if climate_cover_state.climate_strategy == ClimateStrategy.EXTREME_HEAT:
+        strategy = climate_cover_state.climate_strategy
+        is_season_strategy = strategy in _SEASON_STRATEGIES
+
+        if strategy == ClimateStrategy.EXTREME_HEAT:
             # Checked FIRST: extreme heat is an all-day force-hold that pre-empts
             # every season strategy (issue #766). The hold position already rode
             # get_state()/apply_snapshot_limits above — this branch only sets the
             # label + control method, never a short-circuit before get_state().
             method = ControlMethod.EXTREME_HEAT
             season_code = ReasonCode.FRAGMENT_SEASON_EXTREME_HEAT
-        elif (
-            climate_cover_state.climate_strategy == ClimateStrategy.TRACKING_SEASON_GATE
-        ):
+        elif strategy == ClimateStrategy.TRACKING_SEASON_GATE:
             # Season-scope gate fired: glare tracking is not permitted in the
             # current season, so the cover holds its default position. Checked
             # before is_summer/is_winter because the gate can fire in any season
             # the user deselected, and DEFAULT is the honest control method.
             method = ControlMethod.DEFAULT
             season_code = ReasonCode.FRAGMENT_SEASON_TRACKING_OFF
-        elif climate_data.is_summer:
+        elif is_season_strategy and climate_data.is_summer:
             method = ControlMethod.SUMMER
             season_code = ReasonCode.FRAGMENT_SEASON_SUMMER
-        elif climate_data.is_winter:
+        elif is_season_strategy and climate_data.is_winter:
             method = ControlMethod.WINTER
             season_code = ReasonCode.FRAGMENT_SEASON_WINTER
-        elif climate_cover_state.climate_strategy == ClimateStrategy.LOW_LIGHT:
+        elif strategy == ClimateStrategy.LOW_LIGHT:
             # Low-light / no-sun branch — the cover returns to its default
             # position rather than tracking the sun.  Emitting SOLAR here
             # would cause VenetianPolicy to synthesise a tilt from the
             # still-drifting azimuth even when the sun has set (issue #33).
+            # Now that the season arms above are strategy-guarded this branch is
+            # reachable in any season, not just at intermediate temperatures.
             method = ControlMethod.DEFAULT
             season_code = ReasonCode.FRAGMENT_SEASON_GLARE_LOW_LIGHT
         else:
@@ -547,7 +567,7 @@ class ClimateHandler(OverrideHandler):
                 {"season": Reason(season_code), "position": position},
             ),
             climate_state=position,
-            climate_strategy=climate_cover_state.climate_strategy,
+            climate_strategy=strategy,
             climate_data=climate_data,
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -330,6 +330,25 @@ class TestPostPipelineResolve:
         assert out.tilt is None
         assert policy._last_blend is None
 
+    def test_default_climate_fallthrough_clears_blend(self) -> None:
+        """Issue #1196: DEFAULT falls to the else branch even with is_summer data
+        attached — the method, not the thermometer, picks the fabric.
+        """
+        policy = DayNightShadePolicy()
+        policy._last_blend = 40
+        kw = _resolve_kwargs()
+        climate = MagicMock()
+        climate.is_summer = True
+        result = PipelineResult(
+            position=60,
+            control_method=ControlMethod.DEFAULT,
+            reason="default",
+            climate_data=climate,
+        )
+        out = policy.post_pipeline_resolve(result, cover=None, **kw)
+        assert out.tilt is None
+        assert policy._last_blend is None
+
     def test_solar_without_direct_sun_clears_blend(self) -> None:
         policy = DayNightShadePolicy()
         policy._last_blend = 40

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -290,6 +290,14 @@ class TestResolveBackDeployDecision:
         # No heat/privacy/night active → retracted (open, 100).
         assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
 
+    def test_back_retracts_for_default_climate_fallthrough(self) -> None:
+        """Issue #1196: a climate LOW_LIGHT fall-through is DEFAULT, not SUMMER,
+        so it must not fire the heat blackout trigger.
+        """
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.DEFAULT, triggers=["heat"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
     def test_night_uses_sol_elev(self) -> None:
         policy = DualPanelPolicy()
         _resolve(policy, sol_elev=-3.0, triggers=["night"])

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -242,6 +242,7 @@ def _resolve(
     triggers=None,
     front: str | None = _FRONT,
     inverse: bool = False,
+    climate_data=None,
 ) -> PipelineResult:
     """Run ``post_pipeline_resolve`` so the per-cycle dispatch cache is set."""
     opts = _opts(triggers=triggers, front=front, inverse=inverse)
@@ -256,6 +257,7 @@ def _resolve(
         reason="test",
         bypass_auto_control=bypass,
         position_constraint_applied=floor_clamp,
+        climate_data=climate_data,
     )
     return policy.post_pipeline_resolve(result, cover=_sunset_cover(sunset_valid), **kw)
 
@@ -291,11 +293,28 @@ class TestResolveBackDeployDecision:
         assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
 
     def test_back_retracts_for_default_climate_fallthrough(self) -> None:
-        """Issue #1196: a climate LOW_LIGHT fall-through is DEFAULT, not SUMMER,
-        so it must not fire the heat blackout trigger.
+        """Issue #1196 end-to-end: summer climate data + a DEFAULT method → no heat.
+
+        The #1196 scenario reaches this seam as a result that genuinely carries
+        ``is_summer=True`` climate data while the honest label for the LOW_LIGHT
+        branch that produced it is DEFAULT. The blackout must follow the method.
+
+        What this discriminates against: ``_derive_active_triggers`` reading the
+        thermometer instead of ``control_method``. It reads only
+        ``control_method`` today, so the attached ``climate_data`` is a forward
+        guard, not a live one — and since ``_HEAT_METHODS`` already excludes
+        every method but SUMMER/EXTREME_HEAT, the DEFAULT half alone would only
+        catch someone widening that frozenset.
         """
         policy = DualPanelPolicy()
-        _resolve(policy, control_method=ControlMethod.DEFAULT, triggers=["heat"])
+        climate = MagicMock()
+        climate.is_summer = True
+        _resolve(
+            policy,
+            control_method=ControlMethod.DEFAULT,
+            triggers=["heat"],
+            climate_data=climate,
+        )
         assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
 
     def test_night_uses_sol_elev(self) -> None:

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -607,9 +607,6 @@ class TestWinterInsulation:
         from custom_components.adaptive_cover_pro.const import ClimateStrategy
 
         assert result.climate_strategy != ClimateStrategy.WINTER_INSULATION
-        # Issue #1196: the cover is holding its default position, so the honest
-        # label is DEFAULT — is_winter must not shadow the LOW_LIGHT strategy.
-        assert result.control_method == ControlMethod.DEFAULT
 
     def test_winter_heating_takes_priority_without_presence(self) -> None:
         """Winter + sun in FOV → open (100%), even when insulation is enabled."""
@@ -1089,10 +1086,10 @@ class TestClimateHandlerControlMethodOnLowLightBranch:
 # ---------------------------------------------------------------------------
 
 
-def _make_tilt_mode2_cover(
+def _make_tilt_cover(
     *, gamma_deg: float, valid: bool, min_pos: int, mode: str = "mode2"
 ):
-    """Mock AdaptiveTiltCover for the issue-#373 GLARE_CONTROL pipeline test."""
+    """Mock AdaptiveTiltCover for the GLARE_CONTROL pipeline tests (#373, #1196)."""
     from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
 
     cover = MagicMock(spec=AdaptiveTiltCover)
@@ -1143,7 +1140,7 @@ class TestIssue373PipelineGlareControl:
         """
         from custom_components.adaptive_cover_pro.const import ClimateStrategy
 
-        cover = _make_tilt_mode2_cover(gamma_deg=90.0, valid=False, min_pos=50)
+        cover = _make_tilt_cover(gamma_deg=90.0, valid=False, min_pos=50)
         snap = make_snapshot(
             cover=cover,
             cover_type="cover_tilt",
@@ -1184,12 +1181,25 @@ class TestIssue373PipelineGlareControl:
 class TestIssue1196SeasonPredicatesDoNotShadowStrategy:
     """``is_summer``/``is_winter`` may only label a season strategy's result.
 
-    Both are pure temperature predicates (``ClimateCoverData``) and say nothing
-    about which rule-table branch actually fired. Evaluated ahead of the
-    strategy they stamped "summer"/"winter" onto a LOW_LIGHT default-position
-    hold and onto GLARE_CONTROL slat tracking, which then flipped real
-    downstream behaviour (dual-panel heat blackout, day/night fabric choice,
-    the sunset-dispatch override guard).
+    Both are pure temperature predicates on ``ClimateCoverData`` and say nothing
+    about which rule-table branch actually fired. Evaluated ahead of the strategy
+    they stamped "summer"/"winter" onto the LOW_LIGHT and GLARE_CONTROL branches,
+    neither of which runs a season strategy at all.
+
+    Only the LOW_LIGHT half moves behaviour. Relabelling it DEFAULT changes what
+    the dual-panel heat blackout, the day/night fabric choice and the
+    sunset-dispatch override guard see — all three key on ``control_method``, and
+    a spurious SUMMER made them act as though a cooling strategy had won. DEFAULT
+    names the branch here, not the position: the rule tables reach LOW_LIGHT via
+    ``_solar`` as well as ``_default``, so it is no promise the cover is sitting
+    at its default.
+
+    The GLARE_CONTROL half is label-only today. The policies that can observe it
+    are tilt-primary (``TiltPolicy``, ``LouveredRoofPolicy``) and neither reads
+    ``control_method``; the position-primary policies never see it, because for
+    them GLARE_CONTROL yields no position and ``evaluate()`` returns early. SOLAR
+    is still the honest label, and these tests pin it so the next consumer to
+    read ``control_method`` inherits the strategy rather than the thermometer.
     """
 
     handler = ClimateHandler()
@@ -1246,7 +1256,7 @@ class TestIssue1196SeasonPredicatesDoNotShadowStrategy:
 
     def test_tilt_glare_control_fallthrough_in_summer_is_solar(self) -> None:
         """Tilt + summer temps + sun out of FOV → GLARE_CONTROL, labelled SOLAR."""
-        cover = _make_tilt_mode2_cover(gamma_deg=90.0, valid=False, min_pos=0)
+        cover = _make_tilt_cover(gamma_deg=90.0, valid=False, min_pos=0)
         snap = make_snapshot(
             cover=cover,
             cover_type="cover_tilt",
@@ -1266,6 +1276,11 @@ class TestIssue1196SeasonPredicatesDoNotShadowStrategy:
         result = self.handler.evaluate(snap)
         assert result is not None
         assert result.climate_strategy == ClimateStrategy.GLARE_CONTROL
+        assert result.climate_data is not None
+        # GLARE_CONTROL reaches SOLAR through the else arm in any season, so
+        # without this the test would keep passing if the fixture temperatures
+        # drifted out of summer — and stop exercising the shadow entirely.
+        assert result.climate_data.is_summer is True
         assert result.control_method == ControlMethod.SOLAR
 
     def test_tilt_glare_control_in_fov_in_winter_is_solar(self) -> None:
@@ -1278,9 +1293,7 @@ class TestIssue1196SeasonPredicatesDoNotShadowStrategy:
         cover runs MODE1. Labelling that "winter" told every downstream
         consumer a heating strategy had won when the slats were tracking glare.
         """
-        cover = _make_tilt_mode2_cover(
-            gamma_deg=90.0, valid=True, min_pos=0, mode="mode1"
-        )
+        cover = _make_tilt_cover(gamma_deg=90.0, valid=True, min_pos=0, mode="mode1")
         snap = make_snapshot(
             cover=cover,
             cover_type="cover_tilt",
@@ -1307,7 +1320,7 @@ class TestIssue1196SeasonPredicatesDoNotShadowStrategy:
         before #1196, so nothing stopped the fix from relabelling genuine
         slat tracking on every tilt install.
         """
-        cover = _make_tilt_mode2_cover(gamma_deg=90.0, valid=True, min_pos=0)
+        cover = _make_tilt_cover(gamma_deg=90.0, valid=True, min_pos=0)
         snap = make_snapshot(
             cover=cover,
             cover_type="cover_tilt",

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -607,6 +607,9 @@ class TestWinterInsulation:
         from custom_components.adaptive_cover_pro.const import ClimateStrategy
 
         assert result.climate_strategy != ClimateStrategy.WINTER_INSULATION
+        # Issue #1196: the cover is holding its default position, so the honest
+        # label is DEFAULT — is_winter must not shadow the LOW_LIGHT strategy.
+        assert result.control_method == ControlMethod.DEFAULT
 
     def test_winter_heating_takes_priority_without_presence(self) -> None:
         """Winter + sun in FOV → open (100%), even when insulation is enabled."""
@@ -1086,7 +1089,9 @@ class TestClimateHandlerControlMethodOnLowLightBranch:
 # ---------------------------------------------------------------------------
 
 
-def _make_tilt_mode2_cover(*, gamma_deg: float, valid: bool, min_pos: int):
+def _make_tilt_mode2_cover(
+    *, gamma_deg: float, valid: bool, min_pos: int, mode: str = "mode2"
+):
     """Mock AdaptiveTiltCover for the issue-#373 GLARE_CONTROL pipeline test."""
     from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
 
@@ -1098,7 +1103,7 @@ def _make_tilt_mode2_cover(*, gamma_deg: float, valid: bool, min_pos: int):
     cover.calculate_position = MagicMock(return_value=90.0)
     cover.gamma = gamma_deg  # SunGeometry.gamma is in degrees
     cover.beta = 0.0
-    cover.mode = "mode2"
+    cover.mode = mode
     config = MagicMock()
     config.min_pos = min_pos
     config.max_pos = 100
@@ -1166,3 +1171,156 @@ class TestIssue373PipelineGlareControl:
             f"MODE2, the documented footgun. Got {result.position}."
         )
         assert result.climate_strategy == ClimateStrategy.GLARE_CONTROL
+        # Issue #1196: GLARE_CONTROL is a glare-tracking strategy, so the label
+        # is SOLAR — the summer temperature predicate must not shadow it.
+        assert result.control_method == ControlMethod.SOLAR
+
+
+# ---------------------------------------------------------------------------
+# Issue #1196 — season predicates must not shadow the strategy's own label
+# ---------------------------------------------------------------------------
+
+
+class TestIssue1196SeasonPredicatesDoNotShadowStrategy:
+    """``is_summer``/``is_winter`` may only label a season strategy's result.
+
+    Both are pure temperature predicates (``ClimateCoverData``) and say nothing
+    about which rule-table branch actually fired. Evaluated ahead of the
+    strategy they stamped "summer"/"winter" onto a LOW_LIGHT default-position
+    hold and onto GLARE_CONTROL slat tracking, which then flipped real
+    downstream behaviour (dual-panel heat blackout, day/night fabric choice,
+    the sunset-dispatch override guard).
+    """
+
+    handler = ClimateHandler()
+
+    def test_low_light_fallthrough_in_summer_is_default(self) -> None:
+        """Summer temps + sun out of FOV + no presence → LOW_LIGHT holds default."""
+        cover = _make_blind_cover(direct_sun_valid=False)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                outside_temperature=30.0,
+                inside_temperature=27.0,
+                is_presence=False,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(
+                temp_low=18.0,
+                temp_high=26.0,
+                temp_summer_outside=22.0,
+            ),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.climate_strategy == ClimateStrategy.LOW_LIGHT
+        assert result.climate_data is not None
+        # The season predicate really is true — the fix must gate on the
+        # strategy, not on the thermometer being wrong.
+        assert result.climate_data.is_summer is True
+        assert result.control_method == ControlMethod.DEFAULT
+
+    def test_low_light_fallthrough_in_winter_is_default(self) -> None:
+        """Winter temps + sun out of FOV + insulation off → LOW_LIGHT holds default."""
+        cover = _make_blind_cover(direct_sun_valid=False)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=10.0,
+                is_presence=False,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(
+                temp_low=18.0,
+                winter_close_insulation=False,
+            ),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.climate_strategy == ClimateStrategy.LOW_LIGHT
+        assert result.climate_data is not None
+        assert result.climate_data.is_winter is True
+        assert result.control_method == ControlMethod.DEFAULT
+
+    def test_tilt_glare_control_fallthrough_in_summer_is_solar(self) -> None:
+        """Tilt + summer temps + sun out of FOV → GLARE_CONTROL, labelled SOLAR."""
+        cover = _make_tilt_mode2_cover(gamma_deg=90.0, valid=False, min_pos=0)
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_tilt",
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                outside_temperature=30.0,
+                inside_temperature=27.0,
+                is_presence=True,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(
+                temp_low=18.0,
+                temp_high=26.0,
+                temp_summer_outside=22.0,
+            ),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.climate_strategy == ClimateStrategy.GLARE_CONTROL
+        assert result.control_method == ControlMethod.SOLAR
+
+    def test_tilt_glare_control_in_fov_in_winter_is_solar(self) -> None:
+        """Tilt + winter temps + sun IS in FOV → real glare tracking, so SOLAR.
+
+        ``valid=True`` means the sun is inside the window's field of view, so
+        this is genuine glare tracking rather than a catch-all fall-through:
+        ``TILT_WITHOUT_PRESENCE``'s ``cover_valid``-guarded GLARE_CONTROL rule
+        fires because the winter-heating rule above it is MODE2-only and this
+        cover runs MODE1. Labelling that "winter" told every downstream
+        consumer a heating strategy had won when the slats were tracking glare.
+        """
+        cover = _make_tilt_mode2_cover(
+            gamma_deg=90.0, valid=True, min_pos=0, mode="mode1"
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_tilt",
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=10.0,
+                is_presence=False,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(temp_low=18.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.climate_strategy == ClimateStrategy.GLARE_CONTROL
+        assert result.climate_data is not None
+        assert result.climate_data.is_winter is True
+        assert result.control_method == ControlMethod.SOLAR
+
+    def test_tilt_glare_control_in_fov_intermediate_stays_solar(self) -> None:
+        """In-FOV glare tracking at intermediate temps stays SOLAR after the fix.
+
+        Green before and after — this pins the SOLAR-not-DEFAULT half of the
+        decision. No test covered GLARE_CONTROL with ``cover_valid=True``
+        before #1196, so nothing stopped the fix from relabelling genuine
+        slat tracking on every tilt install.
+        """
+        cover = _make_tilt_mode2_cover(gamma_deg=90.0, valid=True, min_pos=0)
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_tilt",
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                outside_temperature=20.0,
+                inside_temperature=21.0,
+                is_presence=True,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(temp_low=18.0, temp_high=26.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.climate_strategy == ClimateStrategy.GLARE_CONTROL
+        assert result.control_method == ControlMethod.SOLAR


### PR DESCRIPTION
## Summary

`ClimateHandler.evaluate()` picked `control_method` from `is_summer` / `is_winter`, pure temperature predicates, before it consulted `climate_cover_state.climate_strategy`. Any strategy that was not a season strategy but still produced a position got stamped with a season label. A `LOW_LIGHT` fall-through reported `SUMMER`, and tilt `GLARE_CONTROL` reported `SUMMER` or `WINTER` even with the sun in FOV.

A new module-level `_SEASON_STRATEGIES` frozenset (`SUMMER_COOLING`, `WINTER_HEATING`, `WINTER_INSULATION`) gates the two season arms, so the season predicates are trusted only when a season strategy actually ran. Same reasoning the `TRACKING_SEASON_GATE` branch above already used.

Complete set of label changes, nothing else moves:

| strategy | season | before | after |
|---|---|---|---|
| `LOW_LIGHT` | summer | `SUMMER` | `DEFAULT` |
| `LOW_LIGHT` | winter | `WINTER` | `DEFAULT` |
| `GLARE_CONTROL` | summer | `SUMMER` | `SOLAR` |
| `GLARE_CONTROL` | winter | `WINTER` | `SOLAR` |

### Behaviour change, intentional

This is not diagnostics-only. Four consumers key on `control_method`, and the `LOW_LIGHT` half reaches three of them. On a `LOW_LIGHT` fall-through in hot or cold weather: the sunset and end-of-window force-sends are no longer suppressed (`coordinator._pipeline_has_active_override`), `dual_panel` no longer deploys the heat blackout, `day_night_shade` no longer forces blackout fabric, and a tilt-only `venetian` carriage is no longer pinned closed. All four are the corrections, not side effects. The `GLARE_CONTROL` half is label-only: the policies that can observe it are tilt-primary and neither reads `control_method`.

No `climate_modes.py` change, no new `ReasonCode`, no translation work. `LOW_LIGHT` keeps `FRAGMENT_SEASON_GLARE_LOW_LIGHT`; `GLARE_CONTROL` falls to the existing `else` and gets `FRAGMENT_SEASON_GLARE`, both of which already exist in all three `reason_i18n` bundles.

### Scope note

The issue proposed moving only the `LOW_LIGHT` check above the season checks. Investigation found the tilt tables' `GLARE_CONTROL` catch-alls carry the identical shadow, reproduced against issue #373's own fixture, so the fix covers both. Mapping `GLARE_CONTROL` to `DEFAULT` was considered and rejected: `TILT_WITHOUT_PRESENCE` has a `cover_valid`-guarded `GLARE_CONTROL` rule, so that mapping would have relabelled genuine in-FOV glare tracking on every `cover_tilt` and `louvered_roof` install.

## Testing

- ✅ 12639 tests passing (4 skipped, 17 xfailed)
- 5 new handler tests pinning both shadowed paths in both seasons, plus one that pins `GLARE_CONTROL` as `SOLAR` with the sun in FOV, closing a coverage hole where no test exercised `GLARE_CONTROL` with `cover_valid=True`
- 2 new consumer guards for the newly reachable `DEFAULT` behaviour in `dual_panel` and `day_night_shade`; the venetian and coordinator `DEFAULT` guards from #1153 and #266 already existed and are cited rather than duplicated

## Related Issues

Refs #1196