### PR TITLE
fix: judge a coupled hold against its own position (#1179)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2822,8 +2822,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         the instance mean the singular ``held_position`` carries. Without a
         verdict (a computed winner, a motion hold, a legacy snapshot, a cover
         absent from the dict, or a cover type whose entities do not move
-        independently) the singular ``skip_command`` and ``state`` answer for
-        every cover, exactly as before.
+        independently — including one that named its own abstract position via
+        ``CoverTypePolicy.hold_reference_position``, #1179) the singular
+        ``skip_command`` and ``state`` answer for every cover, exactly as
+        before. A coupled type's clamped position is deliberately routed that
+        way: ``state`` has already been through ``post_pipeline_resolve`` and
+        goes through ``_entity_target`` once, which is what makes a clamped hold
+        dispatch the same per-entity wire values as a computed winner at the
+        same position.
         """
         result = self._pipeline_result
         verdict = (result.hold_clamp_verdicts or {}).get(cover) if result else None

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -838,10 +838,15 @@ class CoverTypePolicy(ABC):
         install's frame changed, and ``day_night_shade.resolve_entity_target``
         already declines to unwind it in the forward direction for the same
         reason. It only bites where a read's linear meaning feeds a DECODE
-        rather than a bare comparison — a Model B wire near the fabric boundary
-        can stash the wrong fabric half, and the clamped hold then re-folds
-        behind a fabric the shade is not physically behind. Mapping a motor
-        reading back onto the linear scale is #925's territory, not this hook's.
+        rather than a bare comparison, and there it bites twice. A Model B wire
+        near the fabric boundary can stash the wrong fabric half, so the clamped
+        hold re-folds behind a fabric the shade is not physically behind — and,
+        boundary or not, the decode AMPLIFIES whatever error the curve left in
+        the read by the split-range scale. An install whose curve puts logical
+        wire 80 at a motor read of 85 decodes to coverage 70 against a true 60:
+        a 5-point wire error reaches the composed floor/ceiling as a 10-point
+        coverage error. Mapping a motor reading back onto the linear scale is
+        #925's territory, not this hook's.
         """
         return None
 

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -777,6 +777,10 @@ class CoverTypePolicy(ABC):
         before #1174. A policy that overrides one of them harmlessly may say so
         by overriding this predicate — and owes the argument for why, in its own
         docstring, because nothing else here can check it.
+
+        Answering ``False`` no longer means "judge the group's mean": it means
+        "ask :meth:`hold_reference_position` where this ONE geometry is". See
+        there for what a coupled type owes in return (#1179).
         """
         cls = type(self)
         return (
@@ -784,6 +788,47 @@ class CoverTypePolicy(ABC):
             and cls.post_pipeline_resolve is CoverTypePolicy.post_pipeline_resolve
             and cls.dispatch_order_key is CoverTypePolicy.dispatch_order_key
         )
+
+    def hold_reference_position(
+        self,
+        cover_positions: Mapping[str, int | None],  # noqa: ARG002
+        *,
+        inverted: bool,  # noqa: ARG002
+    ) -> int | None:
+        """Reduce these raw reads to ``PipelineResult.position``'s frame (#1179).
+
+        The algebraic INVERSE of the dispatch chain. Dispatch expands one
+        abstract position into per-entity wire values —
+        :meth:`post_pipeline_resolve` → ``coordinator._to_cover_frame`` →
+        :meth:`resolve_entity_target` — and this reduces the per-entity reads
+        back to that one abstract position. Only the policy knows the mapping,
+        which is why the registry could previously do nothing better than
+        average the reads.
+
+        Consulted ONLY when :meth:`entities_move_independently` is ``False``. A
+        coupled type's entities express one geometry, so a composed floor or
+        ceiling is a statement about that geometry, and the number it has to be
+        compared against is the geometry's own position — not the arithmetic
+        mean of values from different coordinate systems (a Model C middle rail
+        derived from the bottom rail's coverage, a dual-panel back panel's
+        binary privacy state, a Model B wire that folds coverage and fabric
+        together).
+
+        ``cover_positions`` are **RAW** cover-frame reads, exactly as
+        ``PipelineSnapshot.cover_positions`` carries them, and ``inverted``
+        names their frame — the same kwarg :meth:`resolve_entity_target` takes,
+        so the frame is stated and never guessed (#993). The return value is
+        **LOGICAL**: an override that reads a wire encoding must undo the
+        inversion and decode in wire space *before* returning
+        (CODING_GUIDELINES § "Inverse State").
+
+        ``None`` means "no single answer" — an unconfigured entity role, an
+        unreadable anchor, or a cover type with genuinely independent entities
+        — and keeps that cycle on the legacy summary mean. That is the base
+        answer, so a policy which never touches the dispatch hooks is never
+        asked and never has to care.
+        """
+        return None
 
     def order_for_dispatch(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -827,6 +827,21 @@ class CoverTypePolicy(ABC):
         — and keeps that cycle on the legacy summary mean. That is the base
         answer, so a policy which never touches the dispatch hooks is never
         asked and never has to care.
+
+        ⚠️ **The inverse is partial: interpolation is not unwound.** The forward
+        chain ends at ``coordinator._to_cover_frame``, which applies the
+        calibration curve *and* the inversion to every dispatched value, but an
+        implementation here is only asked to undo the inversion — the reads it
+        receives from an interpolated install sit on the motor's own scale and
+        are treated as if they were linear. Pre-existing and deliberate: the
+        summary mean this hook replaced ignored interpolation identically, so no
+        install's frame changed, and ``day_night_shade.resolve_entity_target``
+        already declines to unwind it in the forward direction for the same
+        reason. It only bites where a read's linear meaning feeds a DECODE
+        rather than a bare comparison — a Model B wire near the fabric boundary
+        can stash the wrong fabric half, and the clamped hold then re-folds
+        behind a fabric the shade is not physically behind. Mapping a motor
+        reading back onto the linear scale is #925's territory, not this hook's.
         """
         return None
 

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -120,11 +120,13 @@ _CLIMATE_METHODS = frozenset(
 # Dividing ``POSITION_OPEN`` exactly is necessary and nowhere near sufficient. A
 # midpoint of 25 divides 100 cleanly and yields an exact integer scale of 4, and
 # still breaks the codec in both directions: ``_split_range_wire(80, sheer)`` is
-# 45, so the encoder can never reach wires 51–100 at all, and
-# ``_split_range_decode(90)`` returns a coverage of 260, which flows straight
-# into ``clamp_to_bounds`` as the instance's held coverage. Moving the boundary
-# means redesigning the ``_split_range_wire`` / ``_split_range_decode`` pair so
-# each half still spans the whole domain — not editing a constant.
+# 45, and the scaled branch tops out at 50, so the only wire above it the encoder
+# can still emit is the 100 the fully-open short-circuit returns before any
+# scaling — 51–99, 49 of the 101 wires, become unreachable. In the other
+# direction ``_split_range_decode(90)`` returns a coverage of 260, which flows
+# straight into ``clamp_to_bounds`` as the instance's held coverage. Moving the
+# boundary means redesigning the ``_split_range_wire`` / ``_split_range_decode``
+# pair so each half still spans the whole domain — not editing a constant.
 # File-private — those two are this constant's only readers.
 _SPLIT_RANGE_SCALE = POSITION_OPEN // DAY_NIGHT_SPLIT_MIDPOINT
 
@@ -273,10 +275,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # branch of ``post_pipeline_resolve`` (mirrors venetian's ``_last_tilt``).
         self._last_blend: int | None = None
         # Model B: the fabric half read off the carriage by
-        # ``hold_reference_position`` this cycle, replayed by
-        # ``post_pipeline_resolve`` when a hold's own blend has been cleared.
-        # ``None`` = this cycle asked no reference, so there is nothing to
-        # replay. See ``sync_runtime_options`` for why it is cleared there.
+        # ``hold_reference_position``, replayed by ``post_pipeline_resolve`` when
+        # a HOLD's own blend has been cleared — and only then, because an
+        # off-cycle evaluate writes here too. ``None`` = nothing has asked for a
+        # reference since the last clear. See ``sync_runtime_options`` for why it
+        # is cleared there and ``hold_reference_position`` for why the hold gate,
+        # not the clear, is what keeps a stale fabric out.
         self._split_range_hold_fabric: int | None = None
         self._schedule_refresh_after: Any | None = None
         # Per-instance control model (Model A vs B vs C). Read from options and
@@ -702,6 +706,10 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         per-cycle ordering is: this hook clears → ``registry.evaluate`` may set
         it via :meth:`hold_reference_position` → ``post_pipeline_resolve``
         consumes it.
+
+        The clear is hygiene, not the safety argument — an off-cycle evaluate can
+        land after it. What makes the consume safe is the hold gate in
+        ``post_pipeline_resolve``; see :meth:`hold_reference_position`.
         """
         self._cache_runtime_options(options)
         self._split_range_hold_fabric = None
@@ -956,11 +964,19 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             # fabric half that number happened to land in. The carriage's own
             # decoded fabric is the honest replacement: same fabric, new
             # coverage (#1179).
-            blend = (
-                resolved.tilt
-                if resolved.tilt is not None
-                else self._split_range_hold_fabric
-            )
+            #
+            # ``held_position`` is what licenses that replay. The stash is a side
+            # channel on the live policy, and an off-cycle
+            # ``async_apply_user_position`` evaluate can write it while this cycle
+            # is suspended on one of ``_async_update_data``'s awaits — so a
+            # leftover fabric may well be sitting here. A cycle whose own winner
+            # is COMPUTED never asked the reduction hook anything and has no
+            # claim on it; reading it would fold behind a fabric this cycle never
+            # chose. A hold winner always wrote it itself — see
+            # :meth:`hold_reference_position`.
+            blend = resolved.tilt
+            if blend is None and resolved.held_position is not None:
+                blend = self._split_range_hold_fabric
             if blend is not None:
                 return self._apply_split_range(resolved, blend=blend)
         if self._control_model == DAY_NIGHT_MODEL_DUAL_ENTITY:
@@ -1318,6 +1334,30 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         :meth:`post_pipeline_resolve` can re-fold the clamped coverage back onto
         the wire behind the fabric the user is physically already behind. A floor
         moves coverage; it does not change fabric.
+
+        **Why the stash cannot be replayed against the wrong cycle.** It is
+        mutable state on the live policy and ``async_apply_user_position``
+        evaluates the pipeline off-cycle on that same policy, with no
+        ``sync_runtime_options`` ahead of it and no lock holding it off while
+        ``_async_update_data`` sits on one of its two awaits — so a leftover write
+        genuinely can outlive the per-cycle clear. Two facts make it unreadable
+        anyway:
+
+        * ``coordinator._calculate_cover_state`` is **synchronous** from
+          ``registry.evaluate`` through ``post_pipeline_resolve``, so this cycle's
+          own evaluate is the last thing that can touch the stash before the
+          consume — a later off-cycle write cannot exist;
+        * the consume fires only when ``PipelineResult.held_position`` is set, and
+          a Model B hold ALWAYS wrote the stash itself. ``held_position`` is
+          ``snapshot.current_cover_position``, which the coordinator computes as
+          the mean of the very ``cover_positions`` the same snapshot carries, so a
+          non-``None`` hold implies a numeric read; ``entities_move_independently``
+          is ``False`` for Model B, so the registry always takes the coupled
+          branch and asks this hook; and with a numeric read this branch always
+          stashes.
+
+        So the fabric a hold replays is its own evaluate's. A cycle that ends on a
+        computed winner asked nothing and reads nothing.
 
         ⚠️ The decode un-flips but does NOT un-interpolate, per the base
         contract's caveat. On an interpolated install the wire read arrives on

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -109,6 +109,13 @@ _CLIMATE_METHODS = frozenset(
     {ControlMethod.SUMMER, ControlMethod.WINTER, ControlMethod.EXTREME_HEAT}
 )
 
+# Model B compresses the full coverage range into ONE fabric half of the physical
+# travel, so a coverage point costs half a wire point. Derived rather than
+# written as 2, because the ratio IS the split: change where the halves meet and
+# the scale follows. File-private — ``_split_range_wire`` and its inverse
+# ``_split_range_decode`` are its only readers.
+_SPLIT_RANGE_SCALE = POSITION_OPEN // DAY_NIGHT_SPLIT_MIDPOINT
+
 
 def _pct_slider() -> selector.NumberSelector:
     """Return a 0–100 % slider selector for the fabric opacity/threshold fields."""
@@ -253,6 +260,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # the position axis won't fire this cycle. Cleared on every suppressed
         # branch of ``post_pipeline_resolve`` (mirrors venetian's ``_last_tilt``).
         self._last_blend: int | None = None
+        # Model B: the fabric half read off the carriage by
+        # ``hold_reference_position`` this cycle, replayed by
+        # ``post_pipeline_resolve`` when a hold's own blend has been cleared.
+        # ``None`` = this cycle asked no reference, so there is nothing to
+        # replay. See ``sync_runtime_options`` for why it is cleared there.
+        self._split_range_hold_fabric: int | None = None
         self._schedule_refresh_after: Any | None = None
         # Per-instance control model (Model A vs B vs C). Read from options and
         # cached once per cycle in ``sync_runtime_options`` — the generic hook the
@@ -670,8 +683,16 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         at a single-carriage Model B/C on the coordinator's very first cycle,
         rather than reporting a position-only cover as a contradiction against
         the ``__init__`` Model A default.
+
+        The Model B hold-fabric stash is cleared here and NOT inside
+        :meth:`_cache_runtime_options`, because ``post_pipeline_resolve`` calls
+        that one too and would wipe the stash on its way to consuming it. The
+        per-cycle ordering is: this hook clears → ``registry.evaluate`` may set
+        it via :meth:`hold_reference_position` → ``post_pipeline_resolve``
+        consumes it.
         """
         self._cache_runtime_options(options)
+        self._split_range_hold_fabric = None
 
     def build_calc_engine(
         self,
@@ -793,10 +814,40 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """
         if position == POSITION_OPEN:
             return POSITION_OPEN
-        half = round(position / 2)
+        half = round(position / _SPLIT_RANGE_SCALE)
         if blend >= DAY_NIGHT_SPLIT_MIDPOINT:
             return DAY_NIGHT_SPLIT_MIDPOINT + half
         return half
+
+    def _split_range_decode(self, wire: int) -> tuple[int, int]:
+        """Un-fold one physical split-range position into ``(coverage, fabric)``.
+
+        The algebraic inverse of :meth:`_split_range_wire`, kept beside it so the
+        pair cannot drift (CODING_GUIDELINES.md "Single-Source-of-Truth Helpers").
+        A held Model B carriage reports one number that means both things at
+        once, and a composed coverage floor can only be compared against the
+        coverage half (#1179).
+
+        Lossy in one direction only: the 2:1 compression means two adjacent
+        coverages share a wire, so a decoded coverage can differ from the encoded
+        one by 1. Re-encoding a decoded wire is exactly idempotent, which is what
+        the clamp path needs — a carriage nothing moved is re-dispatched to the
+        wire it is already sitting at.
+
+        ONE wire is genuinely ambiguous: 50 is reached by ``(0, sheer)``,
+        ``(1, sheer)`` and ``(99, blackout)``, because the encoder is
+        discontinuous at the top of the blackout half (98 → 49, 99 → 50,
+        100 → 100). It resolves here as sheer/0, the conservative direction —
+        reading a nearly-closed blackout carriage as fully open can make a floor
+        fire but never suppress one. Wire 100 collapses both fabrics onto the one
+        fully-open endpoint, which is the encoder's documented intent rather than
+        an ambiguity: a carriage covering nothing is behind no fabric.
+        """
+        if wire >= DAY_NIGHT_SPLIT_MIDPOINT:
+            return (wire - DAY_NIGHT_SPLIT_MIDPOINT) * _SPLIT_RANGE_SCALE, (
+                DAY_NIGHT_SHEER
+            )
+        return wire * _SPLIT_RANGE_SCALE, DAY_NIGHT_BLACKOUT
 
     def forecast_secondary_axes(
         self,
@@ -886,11 +937,20 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             options=options,
             cover=cover,
         )
-        if (
-            self._control_model == DAY_NIGHT_MODEL_SPLIT_RANGE
-            and resolved.tilt is not None
-        ):
-            return self._apply_split_range(resolved)
+        if self._control_model == DAY_NIGHT_MODEL_SPLIT_RANGE:
+            # ``_resolve_blend`` clears the blend for every hold winner, so a
+            # clamped hold used to skip the fold entirely and put its abstract
+            # coverage straight onto the wire — half the travel, in whichever
+            # fabric half that number happened to land in. The carriage's own
+            # decoded fabric is the honest replacement: same fabric, new
+            # coverage (#1179).
+            blend = (
+                resolved.tilt
+                if resolved.tilt is not None
+                else self._split_range_hold_fabric
+            )
+            if blend is not None:
+                return self._apply_split_range(resolved, blend=blend)
         if self._control_model == DAY_NIGHT_MODEL_DUAL_ENTITY:
             self._cache_dual_entity(resolved, options)
         return resolved
@@ -1199,6 +1259,100 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             return None
         return self._dispatch_frame(self._dual_entity_dispatch_inverse)
 
+    # ---- Held-position reduction (the dispatch chain, inverted) -------- #
+
+    def entities_move_independently(self) -> bool:
+        """Only Model A's entities are unrelated covers (#1179).
+
+        The base predicate is derived from three overridden hooks, and this
+        policy overrides all three — but for Model A every one of them is
+        **inert**, so the derived answer is a false negative that excluded a
+        plain multi-shade instance from #1174's per-cover hold judging:
+
+        * :meth:`resolve_entity_target` returns ``position`` unchanged at its
+          very first statement for every model that is not ``dual_entity``;
+        * :meth:`dispatch_order_key` returns its constant for the same set, so
+          ``order_for_dispatch`` is a stable-sort no-op;
+        * :meth:`post_pipeline_resolve` only fills ``result.tilt`` — Model A
+          reaches neither ``_apply_split_range`` nor ``_cache_dual_entity`` and
+          never rewrites ``result.position``.
+
+        Model B genuinely folds coverage and fabric into one wire and Model C
+        genuinely derives its middle rail from the bottom rail, so both stay
+        coupled and answer :meth:`hold_reference_position` instead.
+
+        ``_control_model`` is primed by :meth:`sync_runtime_options`, which the
+        coordinator drives from ``_update_options`` before the pipeline runs —
+        including on the very first cycle — so this is never answered against
+        the ``__init__`` default in production.
+        """
+        return self._control_model == DAY_NIGHT_MODEL_POSITION_TILT
+
+    def hold_reference_position(
+        self,
+        cover_positions: Mapping[str, int | None],
+        *,
+        inverted: bool,
+    ) -> int | None:
+        """Reduce this instance's raw reads to its one abstract coverage (#1179).
+
+        **Model B (``split_range``)** — the carriage's single read, DECODED. One
+        physical axis encodes coverage and fabric together, so comparing a
+        coverage floor against the raw wire is a category error even on a
+        single-entity instance, where no mean is involved at all: wire 20 looks
+        like a violation of a 30 % floor while actually sitting at 40 % coverage.
+        The decode happens in WIRE space — un-flip first, then split — and the
+        fabric half is stashed on ``_split_range_hold_fabric`` so
+        :meth:`post_pipeline_resolve` can re-fold the clamped coverage back onto
+        the wire behind the fabric the user is physically already behind. A floor
+        moves coverage; it does not change fabric.
+
+        **Model C (``dual_entity``)** — the BOTTOM rail. It *is* the coverage
+        ``P``; the middle rail is ``M = 100 - blend * (100 - P) / 100``, a pure
+        function of ``P`` and the blend (:meth:`resolve_entity_target`), so it
+        carries no independent opinion and averaging it into the summary mixes a
+        coverage with a value derived from that coverage. Judged on the bottom
+        rail, a floor that binds the shade lifts the middle rail with it —
+        through the same remap that produced it — and the sheer band survives
+        the clamp instead of being silently compressed.
+
+        The bottom rail is "the entity that is not the middle rail", which is the
+        same rule :meth:`_dual_entity_bottom_rail` states for the travel gate.
+        ``None`` for an unconfigured middle rail or an unreadable bottom rail:
+        with no role map there is no anchor to name, and the cycle keeps the
+        legacy summary mean rather than guessing. ``_dual_entity_middle_rail`` is
+        primed by :meth:`sync_runtime_options` → :meth:`_cache_runtime_options`,
+        so it is current before the pipeline runs.
+
+        Frames per the base contract: ``cover_positions`` are RAW reads in the
+        frame ``inverted`` names, and the return is LOGICAL — the remap consumes
+        wire values and this is its inverse, so the flip happens here and the
+        registry must not repeat it.
+        """
+        if self._control_model == DAY_NIGHT_MODEL_SPLIT_RANGE:
+            raw = next((p for p in cover_positions.values() if p is not None), None)
+            if raw is None:
+                return None
+            coverage, fabric = self._split_range_decode(flip_if(raw, inverted=inverted))
+            self._split_range_hold_fabric = fabric
+            return coverage
+        if self._control_model == DAY_NIGHT_MODEL_DUAL_ENTITY:
+            middle = self._dual_entity_middle_rail
+            if middle is None:
+                return None
+            bottom = next(
+                (
+                    pos
+                    for eid, pos in cover_positions.items()
+                    if eid != middle and pos is not None
+                ),
+                None,
+            )
+            if bottom is None:
+                return None
+            return flip_if(bottom, inverted=inverted)
+        return None
+
     def resolve_entity_target(
         self,
         entity_id: str,
@@ -1263,15 +1417,20 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         m_open = max(m_open, p_open)
         return flip_if(m_open, inverted=inverse)
 
-    def _apply_split_range(self, resolved: PipelineResult) -> PipelineResult:
+    def _apply_split_range(
+        self, resolved: PipelineResult, *, blend: int
+    ) -> PipelineResult:
         """Fold the abstract ``(position, blend)`` pair into the split-range wire.
 
-        Keeps the abstract blend on ``result.tilt`` (the diagnostic/forecast Target
-        Tilt value) and rewrites ``result.position`` to the single physical
-        position that encodes both. Records the fold as a terminal
-        ``day_night_split_range`` trace step.
+        Rewrites ``result.position`` to the single physical position that encodes
+        both, and records the fold as a terminal ``day_night_split_range`` trace
+        step. It deliberately does NOT write ``result.tilt``: on a computed
+        winner the caller has already put the resolved blend there for the Target
+        Tilt sensor / forecast / diagnostics, and on a HOLD there is no blend to
+        report — only the fabric the carriage is physically behind, which the
+        trace names and the sensor must not present as a decision (#1179).
         """
-        wire = self._split_range_wire(resolved.position, resolved.tilt)
+        wire = self._split_range_wire(resolved.position, blend)
         trace = list(resolved.decision_trace)
         trace.append(
             DecisionStep(
@@ -1279,10 +1438,10 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
                 matched=True,
                 reason=(
                     f"split-range wire {wire}% "
-                    f"(coverage {resolved.position}%, blend {resolved.tilt}%)"
+                    f"(coverage {resolved.position}%, blend {blend}%)"
                 ),
                 position=wire,
-                tilt=resolved.tilt,
+                tilt=blend,
             )
         )
         return replace(resolved, position=wire, decision_trace=trace)

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -109,14 +109,22 @@ _CLIMATE_METHODS = frozenset(
     {ControlMethod.SUMMER, ControlMethod.WINTER, ControlMethod.EXTREME_HEAT}
 )
 
-# Model B compresses the full coverage range into ONE fabric half of the physical
-# travel, so a coverage point costs half a wire point. Derived rather than
-# written as 2 to keep the scale tied to the split it comes from — but the
-# derivation only holds while ``DAY_NIGHT_SPLIT_MIDPOINT`` divides
-# ``POSITION_OPEN`` exactly. This is integer division: a midpoint of 40 would
-# silently yield 2 where the true ratio is 2.5. Moving the boundary off a
-# divisor of 100 means reworking ``_split_range_wire`` / ``_split_range_decode``
-# to carry a non-integer scale, not just editing the midpoint.
+# Model B compresses the full 0–100 coverage domain into ONE fabric half of the
+# physical travel, so a coverage point costs half a wire point. Derived rather
+# than written as 2 to keep the scale tied to the split it comes from — but the
+# split is NOT a knob. The codec requires
+# ``DAY_NIGHT_SPLIT_MIDPOINT == POSITION_OPEN / 2``, and 50 is the only value
+# that satisfies it: each fabric half has to map the whole coverage domain onto
+# its own share of the wire range, which fits only when the two halves are equal.
+#
+# Dividing ``POSITION_OPEN`` exactly is necessary and nowhere near sufficient. A
+# midpoint of 25 divides 100 cleanly and yields an exact integer scale of 4, and
+# still breaks the codec in both directions: ``_split_range_wire(80, sheer)`` is
+# 45, so the encoder can never reach wires 51–100 at all, and
+# ``_split_range_decode(90)`` returns a coverage of 260, which flows straight
+# into ``clamp_to_bounds`` as the instance's held coverage. Moving the boundary
+# means redesigning the ``_split_range_wire`` / ``_split_range_decode`` pair so
+# each half still spans the whole domain — not editing a constant.
 # File-private — those two are this constant's only readers.
 _SPLIT_RANGE_SCALE = POSITION_OPEN // DAY_NIGHT_SPLIT_MIDPOINT
 

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -111,9 +111,13 @@ _CLIMATE_METHODS = frozenset(
 
 # Model B compresses the full coverage range into ONE fabric half of the physical
 # travel, so a coverage point costs half a wire point. Derived rather than
-# written as 2, because the ratio IS the split: change where the halves meet and
-# the scale follows. File-private — ``_split_range_wire`` and its inverse
-# ``_split_range_decode`` are its only readers.
+# written as 2 to keep the scale tied to the split it comes from — but the
+# derivation only holds while ``DAY_NIGHT_SPLIT_MIDPOINT`` divides
+# ``POSITION_OPEN`` exactly. This is integer division: a midpoint of 40 would
+# silently yield 2 where the true ratio is 2.5. Moving the boundary off a
+# divisor of 100 means reworking ``_split_range_wire`` / ``_split_range_decode``
+# to carry a non-integer scale, not just editing the midpoint.
+# File-private — those two are this constant's only readers.
 _SPLIT_RANGE_SCALE = POSITION_OPEN // DAY_NIGHT_SPLIT_MIDPOINT
 
 
@@ -1306,6 +1310,15 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         :meth:`post_pipeline_resolve` can re-fold the clamped coverage back onto
         the wire behind the fabric the user is physically already behind. A floor
         moves coverage; it does not change fabric.
+
+        ⚠️ The decode un-flips but does NOT un-interpolate, per the base
+        contract's caveat. On an interpolated install the wire read arrives on
+        the motor's scale, so a carriage sitting near the fabric boundary can be
+        decoded into the wrong half — and this branch, unlike the others, then
+        WRITES that half to the stash, so the re-fold can dispatch a fabric
+        change the hold never asked for. Model B under interpolation is already
+        approximate for the same reason in the forward direction; see the
+        ``interpolated`` paragraph in :meth:`resolve_entity_target`.
 
         **Model C (``dual_entity``)** — the BOTTOM rail. It *is* the coverage
         ``P``; the middle rail is ``M = 100 - blend * (100 - P) / 100``, a pure

--- a/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
@@ -19,6 +19,7 @@ coordinator already routes every per-entity command through.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import voluptuous as vol
@@ -344,10 +345,9 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
             CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
             list(DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS),
         )
-        self._front_entity = options.get(CONF_DUAL_PANEL_FRONT_ENTITY)
+        self._cache_runtime_options(options)
         self._deploy_back = blackout_should_deploy(active, configured)
         self._back_bypass = result.bypass_auto_control
-        self._cache_inverse_and_interp(options)
 
         # The back decision is only APPLIED on cycles where a front is designated
         # AND the safety/bypass path isn't overwriting every entity. Recording a
@@ -374,6 +374,86 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         from dataclasses import replace
 
         return replace(result, decision_trace=trace)
+
+    def _cache_runtime_options(self, options: dict) -> None:
+        """Cache every per-instance OPTION the dispatch seam reads.
+
+        The single seam for "read the raw options dict into policy state", which
+        both :meth:`sync_runtime_options` (the coordinator's per-cycle hook,
+        before the pipeline) and :meth:`post_pipeline_resolve` (self-sufficiency
+        for direct callers) go through, rather than each listing the reads
+        (CODING_GUIDELINES.md "No Code Duplication"). Mirrors the day/night
+        policy's hook of the same name.
+
+        Only options land here. ``_deploy_back`` and ``_back_bypass`` stay in
+        :meth:`post_pipeline_resolve` because they are derived from the pipeline
+        RESULT — the active triggers and the safety/bypass flag — and have no
+        honest value before a cycle has produced one.
+        """
+        self._front_entity = options.get(CONF_DUAL_PANEL_FRONT_ENTITY)
+        self._cache_inverse_and_interp(options)
+
+    def sync_runtime_options(self, options: dict) -> None:
+        """Resolve the per-instance options for this cycle (base hook, #1114).
+
+        The registry asks :meth:`entities_move_independently` — and, for a
+        coupled instance, :meth:`hold_reference_position` — before
+        :meth:`post_pipeline_resolve` has run at all, so the front designation
+        has to be current by then. The coordinator drives this from
+        ``_update_options`` ahead of the pipeline, including on its very first
+        cycle (#1179).
+        """
+        self._cache_runtime_options(options)
+
+    def entities_move_independently(self) -> bool:
+        """Coupled exactly while a front panel is designated (#1179).
+
+        The derived base predicate reads two overridden hooks, and with no front
+        entity BOTH are inert: :meth:`resolve_entity_target` returns ``position``
+        at its first statement, and :meth:`post_pipeline_resolve` records no
+        trace step and rewrites nothing. The policy has degraded to a plain
+        vertical blind, and its entities are as independent as a blind's — so
+        each held panel is judged on its own position (#1174).
+
+        With a front designated the window is ONE coverage: every other entity's
+        target is an absolute open/closed substitution that the pipeline position
+        never reaches, so a floor is a statement about the front alone and there
+        is no per-panel question to ask.
+
+        ``_front_entity`` is primed by :meth:`sync_runtime_options`, which the
+        coordinator drives before the pipeline runs.
+        """
+        return self._front_entity is None
+
+    def hold_reference_position(
+        self,
+        cover_positions: Mapping[str, int | None],
+        *,
+        inverted: bool,
+    ) -> int | None:
+        """Return the FRONT panel's read — this window's one coverage (#1179).
+
+        The back panel is an ABSOLUTE SUBSTITUTION — ``compute_layered``
+        discards ``front`` entirely — so its position is a binary privacy state,
+        not a coverage opinion. Averaging it into the summary let a blackout
+        deploy fire a coverage floor that the front panel already satisfied, and
+        hid a genuine front-panel violation behind a retracted back.
+
+        This hook only READS. The back's own wire space stays exactly where
+        #1035 put it: derived from ``options`` alone at dispatch, never from the
+        front's clamped value.
+
+        ``None`` with no front designated (the policy is then a plain blind and
+        never asked) or an unreadable front. Frames per the base contract: a RAW
+        read in, a LOGICAL position out.
+        """
+        front = self._front_entity
+        if front is None:
+            return None
+        position = cover_positions.get(front)
+        if position is None:
+            return None
+        return flip_if(position, inverted=inverted)
 
     def _cache_inverse_and_interp(self, options: dict) -> None:
         """Cache the back's wire-space transform (inverse XOR interpolation).

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -113,15 +113,13 @@ def _split_bounds_against_hold(
     return binding, yielded
 
 
-def _judges_per_cover(snapshot: PipelineSnapshot) -> bool:
-    """Whether this instance's covers may be judged one at a time (#1174).
+def _policy_for(snapshot: PipelineSnapshot):
+    """Resolve this snapshot's policy — one site, one local import.
 
-    Delegated whole to ``CoverTypePolicy.entities_move_independently`` — the
-    registry asks the polymorphic hook and never inspects a cover-type string
-    (CODING_GUIDELINES § "Cover Type Abstraction"). ``snapshot.policy or
-    get_policy(snapshot.cover_type)`` is the same resolution the glare-zone,
-    group-scene and climate handlers already use, so a snapshot built without a
-    policy object still gets its own cover type's answer rather than a default.
+    ``snapshot.policy or get_policy(snapshot.cover_type)`` is the same
+    resolution the glare-zone, group-scene and climate handlers already use, so
+    a snapshot built without a policy object still gets its own cover type's
+    answer rather than a default.
 
     Local import: ``cover_types`` pulls in policies that import from
     ``pipeline``, so a module-level import here would close the cycle — the same
@@ -130,8 +128,32 @@ def _judges_per_cover(snapshot: PipelineSnapshot) -> bool:
     """
     from ..cover_types import get_policy
 
-    policy = snapshot.policy or get_policy(snapshot.cover_type)
-    return policy.entities_move_independently()
+    return snapshot.policy or get_policy(snapshot.cover_type)
+
+
+def _judges_per_cover(snapshot: PipelineSnapshot) -> bool:
+    """Whether this instance's covers may be judged one at a time (#1174).
+
+    Delegated whole to ``CoverTypePolicy.entities_move_independently`` — the
+    registry asks the polymorphic hook and never inspects a cover-type string
+    (CODING_GUIDELINES § "Cover Type Abstraction").
+    """
+    return _policy_for(snapshot).entities_move_independently()
+
+
+def _hold_reference_position(snapshot: PipelineSnapshot) -> int | None:
+    """Ask the policy for the coupled instance's own LOGICAL position (#1179).
+
+    The second half of the same polymorphic question: a cover type whose
+    entities are ONE geometry has no per-cover answer, but it does have a
+    position of its own, and only the policy can reduce the raw per-entity reads
+    back to it. ``None`` means it has no single answer this cycle, which keeps
+    the legacy summary mean.
+    """
+    return _policy_for(snapshot).hold_reference_position(
+        snapshot.cover_positions or {},
+        inverted=snapshot.position_axis_inverted,
+    )
 
 
 def _judge_position_axis(
@@ -161,14 +183,23 @@ def _judge_position_axis(
     applies the floor last, so the shared ``final_pos`` can only ever name one
     of the two edges.
 
-    **Judged set** (holds only). ``snapshot.cover_positions`` when it carries
-    entries AND this cover type's entities move independently — a cover with an
-    unknown position falls back to the summary ``winner.held_position``, which
-    is today's judgment kept exactly for the covers where per-entity data is
-    missing. Otherwise a single pseudo-entry ``{None: winner.held_position}``,
-    reproducing the legacy singular comparison byte-for-byte; ``verdicts`` is
-    ``None`` on that path so every pre-#1174 consumer stays on the singular
-    ``skip_command`` route.
+    **Judged set** (holds only) — three cases, in order:
+
+    1. ``snapshot.cover_positions`` when it carries entries AND this cover
+       type's entities move independently. A cover with an unknown position
+       falls back to the summary ``winner.held_position``, which is today's
+       judgment kept exactly for the covers where per-entity data is missing.
+       ``verdicts`` is populated: #1174's path, unchanged.
+    2. Coupled, and the policy names a reference (#1179) — ONE entry carrying
+       that one number, which is the whole instance's own position. ``verdicts``
+       stays ``None``: the clamped value rides ``PipelineResult.position``
+       through the shared dispatch route a coupled type already uses, so
+       ``post_pipeline_resolve`` and ``resolve_entity_target`` re-expand it
+       exactly once — exactly as they do for a computed winner.
+    3. Everything else — a single pseudo-entry carrying
+       ``winner.held_position``, reproducing the legacy singular comparison
+       byte-for-byte. ``verdicts`` is ``None`` so every pre-#1174 consumer stays
+       on the singular ``skip_command`` route.
 
     **The independence gate** is the policy's own
     ``entities_move_independently`` (``cover_types/base.py``), never a
@@ -176,13 +207,18 @@ def _judge_position_axis(
     that remaps a shared position per entity, rewrites it after the pipeline, or
     orders physically coupled entities has no per-cover question to answer: its
     entities express ONE geometry, and judging them apart both double-applies
-    the remap and bypasses the rewrite. Those instances keep the shared target
-    they had before #1174.
+    the remap and bypasses the rewrite. What that geometry's own position IS is
+    the second half of the same polymorphic question, and
+    ``CoverTypePolicy.hold_reference_position`` answers it; ``None`` there keeps
+    the pre-#1174 summary mean.
 
     **Frames.** Held positions are RAW cover-frame reads and the bounds are
     logical user values, so each is converted before comparing — the #1036
-    conversion, now applied per cover instead of once to the mean. Every
-    ``target`` is on the logical side of that conversion, matching
+    conversion, now applied per cover instead of once to the mean. A policy's
+    reference arrives ALREADY LOGICAL: the reduction is the inverse of the whole
+    dispatch chain, wire decoding included, so the policy un-flips and decodes
+    it itself and this function must not flip it a second time. Every ``target``
+    is on the logical side of that conversion, matching
     ``PipelineResult.position``, so the coordinator maps it to the wire through
     the same ``_to_cover_frame`` seam it already uses for the shared value.
 
@@ -207,18 +243,36 @@ def _judge_position_axis(
             verdicts=None,
         )
     per_entity = snapshot.cover_positions or None
+    reference: int | None = None
     if per_entity is not None and not _judges_per_cover(snapshot):
+        # One geometry, one position: ask the policy for this instance's own
+        # position in the frame PipelineResult.position speaks (#1179). None
+        # means the policy has no single answer, which keeps the legacy mean.
+        reference = _hold_reference_position(snapshot)
         per_entity = None
-    judged: Mapping[str | None, int | None] = (
-        per_entity if per_entity is not None else {None: winner.held_position}
-    )
+    # (entity_id, raw read for the verdict, LOGICAL position to judge).
+    entries: list[tuple[str | None, int | None, int]]
+    if per_entity is None and reference is not None:
+        # Already LOGICAL — the policy un-flipped and decoded it itself, so the
+        # #1036 conversion below must NOT run a second time on this value.
+        entries = [(None, None, reference)]
+    else:
+        # #1174's per-entity set, or the legacy single pseudo-entry on the mean.
+        # One conversion site for both, because they are the same conversion.
+        judged: Mapping[str | None, int | None] = (
+            per_entity if per_entity is not None else {None: winner.held_position}
+        )
+        entries = []
+        for entity_id, position in judged.items():
+            raw = position if position is not None else winner.held_position
+            entries.append(
+                (entity_id, raw, flip_if(raw, inverted=snapshot.position_axis_inverted))
+            )
     verdicts: dict[str, HoldClampVerdict] = {}
     effective_positions: list[int] = []
     raised = False
     lowered = False
-    for entity_id, position in judged.items():
-        raw = position if position is not None else winner.held_position
-        eff = flip_if(raw, inverted=snapshot.position_axis_inverted)
+    for entity_id, raw, eff in entries:
         # This cover's own answer, and the only one that can be right for it:
         # the edge that binds IT when a bound does, and where it already sits
         # when none does — which is what a command forced by the other axis
@@ -236,8 +290,16 @@ def _judge_position_axis(
     elif lowered:
         effective_winner_pos = max(effective_positions)
     else:
-        effective_winner_pos = flip_if(
-            winner.held_position, inverted=snapshot.position_axis_inverted
+        # Nothing clamped, so this is what ``_release_hold_for_tilt_clamp``
+        # writes into ``result.position`` when the TILT axis forces a dispatch
+        # and the position axis stayed inert. For a coupled type that must be
+        # the policy's own abstract reference, not the raw read it decoded it
+        # from: the Model B fabric-change path re-folds this value with a new
+        # blend, and folding a wire a second time halves the coverage.
+        effective_winner_pos = (
+            reference
+            if reference is not None
+            else flip_if(winner.held_position, inverted=snapshot.position_axis_inverted)
         )
     return PositionAxisJudgment(
         effective_winner_pos=effective_winner_pos,

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -117,9 +117,25 @@ def _policy_for(snapshot: PipelineSnapshot):
     """Resolve this snapshot's policy — one site, one local import.
 
     ``snapshot.policy or get_policy(snapshot.cover_type)`` is the same
-    resolution the glare-zone, group-scene and climate handlers already use, so
-    a snapshot built without a policy object still gets its own cover type's
-    answer rather than a default.
+    resolution the glare-zone, group-scene and climate handlers already use.
+
+    ⚠️ The fallback builds the right policy CLASS but a **default-constructed**
+    instance — one that has never been handed ``sync_runtime_options``. Both
+    questions asked through here are instance-state-dependent since #1179, not
+    class-derived, so a policy-less day/night snapshot answers as Model A
+    (independent) and a policy-less dual panel as front-less (independent),
+    where the old class-derived predicate said coupled for either. The fallback
+    is therefore only safe for a snapshot whose cover type has no
+    option-dependent coupling: hand a real Model C entry a policy-less snapshot
+    and its rails get per-cover verdicts judged on raw wire values, which is the
+    double-remap #1174's gate exists to prevent.
+
+    Unreachable in production — ``snapshot_builder`` puts the coordinator's
+    live, already-synced policy on every snapshot it builds, and
+    ``tests/test_pipeline/conftest.make_snapshot`` documents the same hazard for
+    hand-built ones. The fresh-instance answers are pinned by
+    ``test_a_policy_less_snapshot_answers_from_a_default_constructed_policy``
+    so they cannot drift silently.
 
     Local import: ``cover_types`` pulls in policies that import from
     ``pipeline``, so a module-level import here would close the cycle — the same

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -120,15 +120,22 @@ def _policy_for(snapshot: PipelineSnapshot):
     resolution the glare-zone, group-scene and climate handlers already use.
 
     ⚠️ The fallback builds the right policy CLASS but a **default-constructed**
-    instance — one that has never been handed ``sync_runtime_options``. Both
-    questions asked through here are instance-state-dependent since #1179, not
-    class-derived, so a policy-less day/night snapshot answers as Model A
-    (independent) and a policy-less dual panel as front-less (independent),
-    where the old class-derived predicate said coupled for either. The fallback
-    is therefore only safe for a snapshot whose cover type has no
-    option-dependent coupling: hand a real Model C entry a policy-less snapshot
-    and its rails get per-cover verdicts judged on raw wire values, which is the
-    double-remap #1174's gate exists to prevent.
+    instance — one that has never been handed ``sync_runtime_options``. For most
+    registered policies that costs nothing: they answer
+    ``entities_move_independently`` from the class-derived base predicate (or
+    from a constant override, as venetian does) and inherit the base
+    ``hold_reference_position``, so a fresh instance gives exactly the answer the
+    live one would. That is what makes the fallback safe for them.
+
+    The hazard's boundary is the two policies that answer from INSTANCE state
+    since #1179 — ``DayNightShadePolicy`` (its cached control model) and
+    ``DualPanelPolicy`` (whether a front panel is designated). A fresh instance
+    holds their ``__init__`` defaults, so a policy-less day/night snapshot
+    answers as Model A (independent) and a policy-less dual panel as front-less
+    (independent), where the old class-derived predicate said coupled for either.
+    Hand a real Model C entry a policy-less snapshot and its rails get per-cover
+    verdicts judged on raw wire values, which is the double-remap #1174's gate
+    exists to prevent.
 
     Unreachable in production — ``snapshot_builder`` puts the coordinator's
     live, already-synced policy on every snapshot it builds, and

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -561,7 +561,12 @@ class HoldClampVerdict:
     (``CoverTypePolicy.entities_move_independently``). That is what makes
     ``target`` safe to hand straight to ``coordinator._entity_target``: a policy
     that would remap it per entity, or rewrite it after the pipeline, produces
-    no verdicts at all and keeps its shared-target path.
+    no verdicts at all and keeps its shared-target path — including when it
+    names its own position through ``CoverTypePolicy.hold_reference_position``
+    (#1179). A coupled type's clamped value is ONE abstract position, and it has
+    to ride ``PipelineResult.position`` so ``post_pipeline_resolve`` and
+    ``resolve_entity_target`` expand it exactly once; a verdict would bypass the
+    first and double-apply the second.
     """
 
     #: This cover's own position, a RAW cover-frame read (matching the frame
@@ -598,6 +603,9 @@ class PositionAxisJudgment:
     #: winner's own ``position``; for a hold, the *violating* cover's position
     #: (lowest when a floor raised, highest when a ceiling lowered) so the
     #: clamp trace step reads as a real cover rather than a mean nobody sits at.
+    #: For a coupled hold that judged nothing, the policy's own reference (#1179)
+    #: — the value ``_release_hold_for_tilt_clamp`` carries when the other axis
+    #: forces a dispatch.
     effective_winner_pos: int
     #: ``effective_winner_pos`` after the composed bounds, i.e. the shared
     #: clamp target the trace and ``PipelineResult.position`` carry.
@@ -617,8 +625,9 @@ class PositionAxisJudgment:
     lower_from: int | None
     #: Per-cover dispatch verdicts, or ``None`` for a computed winner, for a
     #: snapshot carrying no per-entity positions, and for a cover type whose
-    #: entities do not move independently — all of which keep the cycle on the
-    #: singular pre-#1174 path.
+    #: entities do not move independently — whether that type named its own
+    #: reference position (#1179) or fell back to the summary mean. All of those
+    #: keep the cycle on the singular pre-#1174 path.
     verdicts: Mapping[str, HoldClampVerdict] | None
 
 

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -33,6 +33,7 @@ from custom_components.adaptive_cover_pro.const import (
     DEFAULT_DAY_NIGHT_OPACITY_BLACKOUT,
     DEFAULT_DAY_NIGHT_OPACITY_SHEER,
     OPTION_RANGES,
+    POSITION_OPEN,
     ControlMethod,
     CoverType,
 )
@@ -718,6 +719,29 @@ def test_control_model_option_registered() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "model", [DAY_NIGHT_MODEL_POSITION_TILT, DAY_NIGHT_MODEL_SPLIT_RANGE]
+)
+@pytest.mark.parametrize("named_frame", [False, True])
+def test_model_a_and_b_dispatch_order_is_the_config_order(
+    model: str, named_frame: bool
+) -> None:
+    """Only Model C mandates a rail order; A and B leave the user's pick alone.
+
+    ``dispatch_order_key`` early-returns its constant for every model that is
+    not ``dual_entity`` and ``order_for_dispatch`` is a stable sort, so Model A
+    reporting independent entities (#1179) cannot move a single dispatch — the
+    #1115 / #1118 sequencing is Model C's alone, whether or not a seam names the
+    direction of travel.
+    """
+    policy = DayNightShadePolicy()
+    policy.sync_runtime_options({CONF_DAY_NIGHT_CONTROL_MODEL: model})
+
+    entities = ["cover.z", "cover.a"]
+    frame = {"position": 30, "inverted": True} if named_frame else {}
+    assert policy.order_for_dispatch(entities, **frame) == entities
+
+
 class TestSplitRangeWire:
     """``_split_range_wire`` folds (position, blend) into one physical position."""
 
@@ -740,6 +764,110 @@ class TestSplitRangeWire:
     def test_wire_matrix(self, position: int, blend: int, expected: int) -> None:
         policy = DayNightShadePolicy()
         assert policy._split_range_wire(position, blend) == expected
+
+
+class TestHoldReferenceHasNoSingleAnswer:
+    """``None`` means "keep the legacy mean" — never a guessed anchor (#1179)."""
+
+    def test_model_b_with_no_readable_carriage(self) -> None:
+        policy = DayNightShadePolicy()
+        policy.sync_runtime_options(
+            {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_SPLIT_RANGE}
+        )
+        assert policy.hold_reference_position({"cover.x": None}, inverted=False) is None
+        # Nothing decoded, so nothing was stashed for the re-encode either.
+        assert policy._split_range_hold_fabric is None
+
+    def test_model_c_with_no_middle_rail_configured(self) -> None:
+        policy = DayNightShadePolicy()
+        policy.sync_runtime_options(
+            {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY}
+        )
+        assert policy.hold_reference_position({"cover.x": 40}, inverted=False) is None
+
+    def test_model_c_with_no_readable_bottom_rail(self) -> None:
+        policy = DayNightShadePolicy()
+        policy.sync_runtime_options(
+            {
+                CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+                CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: "cover.middle",
+            }
+        )
+        assert (
+            policy.hold_reference_position(
+                {"cover.middle": 70, "cover.bottom": None}, inverted=False
+            )
+            is None
+        )
+
+
+class TestSplitRangeDecode:
+    """``_split_range_decode`` is the algebraic inverse of ``_split_range_wire``.
+
+    A held Model B carriage reports ONE wire value that encodes both coverage and
+    fabric, so a coverage floor can only be compared against it after the two are
+    pulled apart (#1179). The fix depends on that being possible, which is what
+    these pin.
+    """
+
+    #: The single wire whose preimage spans both fabric halves. See the test.
+    AMBIGUOUS_WIRE = 50
+
+    def test_split_range_wire_round_trips_through_its_decode(self) -> None:
+        """Every encodable pair comes back as the same fabric and ~the same coverage.
+
+        Coverage tolerance is 1, not 0: the encoder halves the range, so two
+        adjacent coverages share a wire. That is a hardware property of the 2:1
+        compression, not a decode error.
+        """
+        policy = DayNightShadePolicy()
+        for position in range(POSITION_OPEN + 1):
+            for fabric in (DAY_NIGHT_BLACKOUT, DAY_NIGHT_SHEER):
+                wire = policy._split_range_wire(position, fabric)
+                if wire == self.AMBIGUOUS_WIRE:
+                    continue  # pinned by the collision test below
+                coverage, decoded = policy._split_range_decode(wire)
+                assert abs(coverage - position) <= 1, (position, fabric, wire)
+                if position == POSITION_OPEN:
+                    # The encoder's documented endpoint collapse: a fully-open
+                    # carriage covers nothing, so it has no fabric to be behind
+                    # and both halves map onto the one physical endpoint.
+                    assert decoded == DAY_NIGHT_SHEER, (position, fabric)
+                else:
+                    assert decoded == fabric, (position, fabric, wire)
+
+    @pytest.mark.parametrize("wire", list(range(POSITION_OPEN + 1)))
+    def test_re_encoding_a_decoded_wire_is_idempotent(self, wire: int) -> None:
+        """``encode(decode(w)) == w`` for every physical position, no exceptions.
+
+        The property the clamp path actually needs: a held carriage that nothing
+        moves must be re-dispatched to the wire it is already sitting at, or the
+        fold itself would nudge the shade every cycle.
+        """
+        policy = DayNightShadePolicy()
+        assert policy._split_range_wire(*policy._split_range_decode(wire)) == wire
+
+    def test_split_range_wire_50_is_the_one_ambiguous_carriage_position(self) -> None:
+        """Wire 50 is the only cross-fabric collision, and it resolves to sheer.
+
+        It is reached by ``(0, sheer)``, ``(1, sheer)`` AND ``(99, blackout)``,
+        because the encoder is discontinuous at the top of the blackout half:
+        98 → 49, 99 → 50, 100 → 100. The decode resolves it as sheer/0 — the
+        conservative direction, since reading a nearly-closed blackout carriage
+        as fully open can only ever make a floor fire, never suppress one.
+
+        The discontinuity itself is the encoder's, and out of scope here.
+        """
+        policy = DayNightShadePolicy()
+
+        assert policy._split_range_wire(99, DAY_NIGHT_BLACKOUT) == 50
+        assert policy._split_range_wire(0, DAY_NIGHT_SHEER) == 50
+        assert policy._split_range_wire(1, DAY_NIGHT_SHEER) == 50
+        assert policy._split_range_decode(50) == (0, DAY_NIGHT_SHEER)
+
+        # The encoder discontinuity that produces it, documented in place.
+        assert policy._split_range_wire(98, DAY_NIGHT_BLACKOUT) == 49
+        assert policy._split_range_wire(100, DAY_NIGHT_BLACKOUT) == POSITION_OPEN
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -753,10 +753,12 @@ def test_the_split_midpoint_must_be_half_the_wire_range() -> None:
 
     A midpoint of 25 divides 100 cleanly and yields an exact integer scale of 4,
     and still breaks ``_split_range_wire`` / ``_split_range_decode`` in both
-    directions: the encoder could never emit a wire above 50, and decoding wire
-    90 would return a coverage of 260. Every property ``TestSplitRangeDecode``
-    pins — surjectivity onto the wire range, the round trip, the single
-    ambiguous wire — holds at 50 and at no other midpoint.
+    directions: the scaled branch would top out at wire 50, leaving 51–99
+    unreachable — 100 still comes out of the fully-open short-circuit, which
+    returns before any scaling — and decoding wire 90 would return a coverage of
+    260. Every property ``TestSplitRangeDecode`` pins — surjectivity onto the
+    wire range, the round trip, the single ambiguous wire — holds at 50 and at no
+    other midpoint.
 
     The second half asserts the codomain that fact protects: the decode feeds
     ``clamp_to_bounds`` as the instance's held coverage, so it must never hand
@@ -834,18 +836,24 @@ class TestSplitRangeHoldFabricLifecycle:
 
     ``post_pipeline_resolve`` replays a stashed fabric only when the winner's own
     blend was cleared, so a fabric left over from an earlier evaluate would
-    re-fold a later hold behind stale opacity.
+    re-fold a later winner behind stale opacity.
 
-    What rules that out is NOT that every write is preceded by a clear.
+    The clear does not rule that out on its own.
     ``coordinator.async_apply_user_position`` evaluates the pipeline off-cycle
-    with no ``sync_runtime_options`` ahead of it, and that evaluate can reach
-    ``hold_reference_position`` and set the stash. It is that the stash has
-    exactly ONE consumer: ``post_pipeline_resolve`` is called from a single site,
-    in ``coordinator._calculate_cover_state``, which only ``_async_update_data``
-    calls — after ``_update_options`` → ``sync_runtime_options`` has already
-    cleared — and which is synchronous, so nothing can interleave between that
-    cycle's own ``registry.evaluate`` and the consume. An off-cycle write is
-    therefore always wiped before anything can replay it.
+    with no ``sync_runtime_options`` ahead of it, that evaluate can reach
+    ``hold_reference_position`` and set the stash, and ``_async_update_data``
+    suspends twice — ``prime_cache`` and ``manager.reset_if_needed`` — between the
+    clear and the consume with nothing serialising the two. A write really can
+    land in that window.
+
+    What keeps it out of the fold is the consume side. ``post_pipeline_resolve``
+    reads the stash only for a winner carrying ``held_position``, and a Model B
+    hold always wrote it during its own evaluate (the argument is spelled out on
+    ``hold_reference_position``); ``coordinator._calculate_cover_state`` is
+    synchronous from ``registry.evaluate`` to the consume, so no later write can
+    slip in either. The stale-fold this excludes is pinned by
+    ``test_pipeline/test_hold_clamp_per_cover.py::
+    test_an_off_cycle_reference_cannot_fold_a_computed_winner``.
     """
 
     def test_a_re_synced_policy_starts_the_cycle_with_no_stashed_fabric(self) -> None:

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -28,6 +28,7 @@ from custom_components.adaptive_cover_pro.const import (
     DAY_NIGHT_MODEL_DUAL_ENTITY,
     DAY_NIGHT_MODEL_POSITION_TILT,
     DAY_NIGHT_MODEL_SPLIT_RANGE,
+    DAY_NIGHT_SPLIT_MIDPOINT,
     DEFAULT_DAY_NIGHT_BLACKOUT_THRESHOLD,
     DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     DEFAULT_DAY_NIGHT_OPACITY_BLACKOUT,
@@ -742,6 +743,33 @@ def test_model_a_and_b_dispatch_order_is_the_config_order(
     assert policy.order_for_dispatch(entities, **frame) == entities
 
 
+def test_the_split_midpoint_must_be_half_the_wire_range() -> None:
+    """50 is load-bearing for the codec, not a tunable constant.
+
+    ``_SPLIT_RANGE_SCALE`` is *derived* from ``DAY_NIGHT_SPLIT_MIDPOINT``, which
+    reads like the boundary is a knob with a divisibility caveat. It is not.
+    Each fabric half has to map the whole 0–100 coverage domain onto its own
+    share of the wire range, so the split can only sit at ``POSITION_OPEN / 2``.
+
+    A midpoint of 25 divides 100 cleanly and yields an exact integer scale of 4,
+    and still breaks ``_split_range_wire`` / ``_split_range_decode`` in both
+    directions: the encoder could never emit a wire above 50, and decoding wire
+    90 would return a coverage of 260. Every property ``TestSplitRangeDecode``
+    pins — surjectivity onto the wire range, the round trip, the single
+    ambiguous wire — holds at 50 and at no other midpoint.
+
+    The second half asserts the codomain that fact protects: the decode feeds
+    ``clamp_to_bounds`` as the instance's held coverage, so it must never hand
+    back a number outside the domain those bounds are expressed in.
+    """
+    assert DAY_NIGHT_SPLIT_MIDPOINT * 2 == POSITION_OPEN
+
+    policy = DayNightShadePolicy()
+    coverages = [policy._split_range_decode(w)[0] for w in range(POSITION_OPEN + 1)]
+    assert min(coverages) == 0
+    assert max(coverages) == POSITION_OPEN
+
+
 class TestSplitRangeWire:
     """``_split_range_wire`` folds (position, blend) into one physical position."""
 
@@ -805,11 +833,19 @@ class TestSplitRangeHoldFabricLifecycle:
     """The Model B fabric stash is per-cycle, and the clearing edge is the seam (#1179).
 
     ``post_pipeline_resolve`` replays a stashed fabric only when the winner's own
-    blend was cleared, so a fabric left over from an earlier cycle would re-fold
-    a later hold behind stale opacity. The design leans on ``sync_runtime_options``
-    clearing it at the top of every cycle — the coordinator drives that hook from
-    ``_update_options``, before ``registry.evaluate`` can set it and before
-    ``post_pipeline_resolve`` consumes it.
+    blend was cleared, so a fabric left over from an earlier evaluate would
+    re-fold a later hold behind stale opacity.
+
+    What rules that out is NOT that every write is preceded by a clear.
+    ``coordinator.async_apply_user_position`` evaluates the pipeline off-cycle
+    with no ``sync_runtime_options`` ahead of it, and that evaluate can reach
+    ``hold_reference_position`` and set the stash. It is that the stash has
+    exactly ONE consumer: ``post_pipeline_resolve`` is called from a single site,
+    in ``coordinator._calculate_cover_state``, which only ``_async_update_data``
+    calls — after ``_update_options`` → ``sync_runtime_options`` has already
+    cleared — and which is synchronous, so nothing can interleave between that
+    cycle's own ``registry.evaluate`` and the consume. An off-cycle write is
+    therefore always wiped before anything can replay it.
     """
 
     def test_a_re_synced_policy_starts_the_cycle_with_no_stashed_fabric(self) -> None:

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -801,6 +801,43 @@ class TestHoldReferenceHasNoSingleAnswer:
         )
 
 
+class TestSplitRangeHoldFabricLifecycle:
+    """The Model B fabric stash is per-cycle, and the clearing edge is the seam (#1179).
+
+    ``post_pipeline_resolve`` replays a stashed fabric only when the winner's own
+    blend was cleared, so a fabric left over from an earlier cycle would re-fold
+    a later hold behind stale opacity. The design leans on ``sync_runtime_options``
+    clearing it at the top of every cycle — the coordinator drives that hook from
+    ``_update_options``, before ``registry.evaluate`` can set it and before
+    ``post_pipeline_resolve`` consumes it.
+    """
+
+    def test_a_re_synced_policy_starts_the_cycle_with_no_stashed_fabric(self) -> None:
+        """Set by the reduction hook, gone again on the next cycle's sync.
+
+        The second assertion pins WHERE the clear lives: moving it into
+        ``_cache_runtime_options`` would still satisfy the first (``sync``
+        delegates there) while wiping the stash from under
+        ``post_pipeline_resolve``, which calls the same helper on its way to
+        consuming it.
+        """
+        policy = DayNightShadePolicy()
+        options = {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_SPLIT_RANGE}
+        policy.sync_runtime_options(options)
+
+        # Wire 20 is in the blackout half: coverage 40, fabric blackout.
+        assert policy.hold_reference_position({"cover.x": 20}, inverted=False) == 40
+        assert policy._split_range_hold_fabric == DAY_NIGHT_BLACKOUT
+
+        # The consume path's own re-read must NOT clear it.
+        policy._cache_runtime_options(options)
+        assert policy._split_range_hold_fabric == DAY_NIGHT_BLACKOUT
+
+        # The next cycle's coordinator hook does.
+        policy.sync_runtime_options(options)
+        assert policy._split_range_hold_fabric is None
+
+
 class TestSplitRangeDecode:
     """``_split_range_decode`` is the algebraic inverse of ``_split_range_wire``.
 

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -260,6 +260,62 @@ def _resolve(
     return policy.post_pipeline_resolve(result, cover=_sunset_cover(sunset_valid), **kw)
 
 
+def test_front_entity_is_cached_before_the_pipeline_runs() -> None:
+    """``sync_runtime_options`` primes the front designation, like day/night (#1179).
+
+    The registry asks ``entities_move_independently`` — and, when coupled,
+    ``hold_reference_position`` — BEFORE ``post_pipeline_resolve`` has run, so a
+    front designation that only landed at the post-pipeline seam would make the
+    very first cycle of every restart answer as though no front were configured.
+    The coordinator drives this hook from ``_update_options``, ahead of the
+    pipeline.
+    """
+    policy = DualPanelPolicy()
+    assert policy._front_entity is None
+
+    policy.sync_runtime_options(_opts())
+    assert policy._front_entity == _FRONT
+    # The back's wire-space cache is primed by the same seam, so a pre-pipeline
+    # caller never resolves the back against a stale inverse flag (#996/#1035).
+    assert policy._back_inverse is False
+
+    policy.sync_runtime_options(_opts(inverse=True))
+    assert policy._back_inverse is True
+
+
+class TestHoldReferencePosition:
+    """The front panel's read is the window's coverage, or there is none (#1179)."""
+
+    def test_front_read_is_the_reference(self) -> None:
+        policy = DualPanelPolicy()
+        policy.sync_runtime_options(_opts())
+        assert (
+            policy.hold_reference_position({_FRONT: 40, _BACK: 100}, inverted=False)
+            == 40
+        )
+
+    def test_front_read_is_un_flipped_on_an_inverse_install(self) -> None:
+        policy = DualPanelPolicy()
+        policy.sync_runtime_options(_opts())
+        assert (
+            policy.hold_reference_position({_FRONT: 40, _BACK: 100}, inverted=True)
+            == 60
+        )
+
+    def test_no_front_designated_has_no_reference(self) -> None:
+        policy = DualPanelPolicy()
+        policy.sync_runtime_options(_opts(front=None))
+        assert policy.hold_reference_position({_BACK: 100}, inverted=False) is None
+
+    def test_an_unreadable_front_has_no_reference(self) -> None:
+        policy = DualPanelPolicy()
+        policy.sync_runtime_options(_opts())
+        assert (
+            policy.hold_reference_position({_FRONT: None, _BACK: 100}, inverted=False)
+            is None
+        )
+
+
 class TestResolveFrontPassThrough:
     """The front sheer panel always dispatches its adaptive position verbatim."""
 

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -515,14 +515,68 @@ def test_a_policy_that_overrides_a_dispatch_hook_opts_out_or_says_why() -> None:
 
 
 @pytest.mark.unit
-def test_the_coupled_cover_types_are_judged_as_one_unit() -> None:
-    """The shipped answers, pinned: day/night and dual panel are coupled.
+def test_hold_reference_position_defaults_to_none(policy: CoverTypePolicy) -> None:
+    """The reduction hook's base answer is "no single position" (#1179).
 
-    Both derive one entity's target from another's (or fold a second axis into
-    the position wire), so a floor that moves one of their entities moves the
-    whole geometry. Naming them explicitly keeps the derived predicate honest —
-    a refactor that made either look "untouched" would flip this.
+    ``_judge_position_axis`` consults it only for a coupled cover type, and
+    ``None`` there keeps that instance on the legacy summary mean. A policy that
+    has been handed no runtime options knows nothing about its own entity roles,
+    so it must give that answer rather than invent an anchor — which is also the
+    permanent answer for every policy whose entities are just covers.
     """
-    assert get_policy("cover_day_night_shade").entities_move_independently() is False
-    assert get_policy("cover_dual_panel").entities_move_independently() is False
+    assert policy.hold_reference_position({}, inverted=False) is None
+    assert policy.hold_reference_position({"cover.a": 40}, inverted=True) is None
+
+
+@pytest.mark.unit
+def test_day_night_coupling_is_per_control_model() -> None:
+    """Coupling is a property of the CONTROL MODEL, not of the policy class (#1179).
+
+    Model B folds coverage and fabric into one wire and Model C derives its
+    middle rail from the bottom rail, so a bound that moves either instance moves
+    the whole geometry. Model A does none of that: ``resolve_entity_target``
+    returns its argument before touching anything, ``dispatch_order_key`` returns
+    its constant, and ``post_pipeline_resolve`` only fills the blend. Its shades
+    are ordinary covers, and the class-level answer was pinning the derived
+    gate's false negative rather than a real coupling.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DAY_NIGHT_CONTROL_MODEL,
+        DAY_NIGHT_MODEL_DUAL_ENTITY,
+        DAY_NIGHT_MODEL_POSITION_TILT,
+        DAY_NIGHT_MODEL_SPLIT_RANGE,
+    )
+
+    expected = {
+        DAY_NIGHT_MODEL_POSITION_TILT: True,
+        DAY_NIGHT_MODEL_SPLIT_RANGE: False,
+        DAY_NIGHT_MODEL_DUAL_ENTITY: False,
+    }
+    for model, independent in expected.items():
+        policy = get_policy("cover_day_night_shade")
+        policy.sync_runtime_options({CONF_DAY_NIGHT_CONTROL_MODEL: model})
+        assert policy.entities_move_independently() is independent, model
+
+
+@pytest.mark.unit
+def test_dual_panel_coupling_follows_the_front_designation() -> None:
+    """The dual panel is coupled exactly while it has a front panel (#1179).
+
+    With a front designated, every other bound entity is the blackout back and
+    its target is an absolute substitution the pipeline position never reaches —
+    one window, one coverage. With no front the policy degrades to a plain
+    vertical blind, every hook is identity, and its entities are as independent
+    as any blind's, so it must say so rather than inherit the derived answer for
+    a remap it is not performing.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DUAL_PANEL_FRONT_ENTITY
+
+    with_front = get_policy("cover_dual_panel")
+    with_front.sync_runtime_options({CONF_DUAL_PANEL_FRONT_ENTITY: "cover.sheer"})
+    assert with_front.entities_move_independently() is False
+
+    no_front = get_policy("cover_dual_panel")
+    no_front.sync_runtime_options({})
+    assert no_front.entities_move_independently() is True
+
     assert get_policy("cover_blind").entities_move_independently() is True

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from unittest.mock import MagicMock
 
+from custom_components.adaptive_cover_pro.cover_types.base import CoverTypePolicy
 from custom_components.adaptive_cover_pro.pipeline.types import (
     ClimateOptions,
     CustomPositionSensorState,
@@ -66,6 +67,7 @@ def make_snapshot(
     *,
     cover=None,
     cover_type: str = "cover_blind",
+    policy: CoverTypePolicy | None = None,
     default_position: int = 0,
     is_sunset_active: bool = False,
     climate_readings=None,
@@ -112,6 +114,13 @@ def make_snapshot(
     blank release thresholds) so existing cloud-suppression tests that only set
     readings + enabled keep exercising the handler. Pass an explicit bool to
     decouple the resolved latch from the raw readings (issue #864).
+
+    ``policy`` mirrors production, where ``coordinator`` puts its own live policy
+    instance on every snapshot. Leaving it ``None`` makes the registry fall back
+    to a FRESH policy built from ``cover_type``, which carries none of the
+    per-instance runtime options a real cycle has already synced — so a test
+    whose expectations depend on those options must pass the same instance it
+    resolves through afterwards (#1179).
     """
     if cover is None:
         cover = _make_mock_cover(
@@ -134,6 +143,7 @@ def make_snapshot(
         cover=cover,
         config=cover.config,
         cover_type=cover_type,
+        policy=policy,
         default_position=default_position,
         is_sunset_active=is_sunset_active,
         climate_readings=climate_readings,

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -1473,3 +1473,64 @@ async def test_a_clamped_hold_dispatches_the_same_wire_as_a_computed_winner(
     )
 
     assert targets == {_DN_SHADE: expected_wire}
+
+
+def test_an_off_cycle_reference_cannot_fold_a_computed_winner() -> None:
+    """Only a HOLD may read the fabric stash, because only a hold wrote it (#1179).
+
+    The stash is a side channel between two calls on the live policy, and the two
+    are NOT the only pair that can use it. ``async_apply_user_position`` evaluates
+    the pipeline off-cycle on that same policy with no ``sync_runtime_options``
+    ahead of it, and ``_async_update_data`` suspends twice — on the
+    ``prime_cache`` executor job and on ``manager.reset_if_needed`` — between
+    clearing the stash and consuming it, with no lock serialising a service call
+    against the cycle. So a ``set_position`` tap landing on one of those awaits
+    can leave a fabric behind that this cycle never asked for.
+
+    What the fallback is gated on is the only thing that rules it out: this
+    cycle's OWN winner being a hold. A Model B hold always writes the stash
+    itself — ``held_position`` is ``current_cover_position``, the mean of the very
+    ``cover_positions`` the snapshot carries, so a non-``None`` hold implies a
+    numeric read; ``entities_move_independently`` is ``False`` for Model B, so the
+    registry always asks ``hold_reference_position``; and that branch always
+    stashes when it has a read. A computed winner reads nothing, so the leftover
+    below can only be ignored.
+    """
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.engine.covers.day_night_shade import (
+        DAY_NIGHT_BLACKOUT,
+    )
+    from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+    options = _model_b_options()
+    policy = _day_night_policy(options)
+
+    # The interleaved off-cycle evaluate: a user command's preemption check on
+    # the live policy, whose winner is a hold, so the registry reduces the
+    # carriage read and the Model B branch stashes its fabric half.
+    off_cycle = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions={_DN_SHADE: _DN_WIRE_BLACKOUT_40},
+        current_cover_position=_DN_WIRE_BLACKOUT_40,
+        blend=None,
+    )
+    assert off_cycle.held_position == _DN_WIRE_BLACKOUT_40
+    assert policy._split_range_hold_fabric == DAY_NIGHT_BLACKOUT
+
+    # The suspended cycle resumes and finishes on a computed winner whose method
+    # carries no fabric opinion — ``_resolve_blend`` clears ``tilt`` for it.
+    # Nothing this cycle decided says anything about fabric, so nothing folds.
+    resolved = _resolve_through_policy(
+        PipelineResult(
+            position=60,
+            control_method=ControlMethod.SOLAR,
+            reason="computed",
+        ),
+        policy,
+        options,
+    )
+
+    assert resolved.tilt is None
+    assert resolved.position == 60
+    assert [s.handler for s in resolved.decision_trace] == []

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -836,6 +836,41 @@ def test_an_independent_policy_never_consults_the_reduction_hook() -> None:
     assert policy.reference_calls == 0
 
 
+def test_a_policy_less_snapshot_answers_from_a_default_constructed_policy() -> None:
+    """``registry._policy_for``'s fallback, pinned to the FRESH instance (#1179).
+
+    A snapshot carrying no ``policy`` makes the registry resolve
+    ``get_policy(cover_type)`` — the right class, but an instance that has never
+    seen ``sync_runtime_options``. Both coupling questions became
+    instance-state-dependent in #1179, so the fallback answers from ``__init__``
+    defaults: day/night reads as Model A and the dual panel as front-less, both
+    independent, neither naming a reference — where the pre-#1179 class-derived
+    predicate said coupled for either.
+
+    Production never reaches this path (``snapshot_builder`` attaches the
+    coordinator's live, synced policy to every snapshot), which is exactly why
+    the answer needs pinning: it is a documented hazard for a future caller that
+    skips that step, not behaviour anyone observes today.
+    """
+    from custom_components.adaptive_cover_pro.pipeline.registry import (
+        _hold_reference_position,
+        _judges_per_cover,
+        _policy_for,
+    )
+
+    for cover_type in ("cover_day_night_shade", "cover_dual_panel"):
+        snapshot = make_snapshot(
+            cover=_climate_cover(direct_sun_valid=False),
+            cover_type=cover_type,
+            cover_positions={"cover.a": 40, "cover.b": 70},
+        )
+        assert snapshot.policy is None, cover_type
+        fallback = _policy_for(snapshot)
+        assert fallback.__class__ is get_policy(cover_type).__class__, cover_type
+        assert _judges_per_cover(snapshot) is True, cover_type
+        assert _hold_reference_position(snapshot) is None, cover_type
+
+
 def _day_night_policy(options: dict | None = None):
     """Build a day/night policy already synced to ``options``, as production has it.
 

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -20,6 +20,7 @@ authority.
 
 from __future__ import annotations
 
+from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -29,6 +30,11 @@ from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
 from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    POSITION_AXIS,
+    CoverAxis,
+    CoverTypePolicy,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
@@ -664,24 +670,39 @@ def _coupled_hold(
     cover_type: str,
     cover_positions,
     current_cover_position: int,
-    blend: int,
+    blend: int | None,
+    policy=None,
     floor: int | None = None,
+    floor_priority: int = ABOVE_HOLDER,
     ceiling: int | None = None,
     tilt_min: int | None = None,
+    position_axis_inverted: bool = False,
 ):
     """Evaluate a manual hold on a dual-fabric shade with the named bounds active.
 
     Slot 1 is a tilt-only contribution below the holder, which is how the
     fabric blend reaches ``PipelineResult.tilt`` on a real day/night instance.
+    ``blend=None`` emits no tilt slot at all — the shape a real hold cycle has
+    once ``_resolve_blend`` has cleared the tilt.
+
+    ``policy`` is the SAME instance the caller resolves through afterwards, which
+    is what production does (``coordinator._policy`` rides every snapshot). A
+    ``None`` policy makes the registry build a fresh one from ``cover_type``,
+    still sitting on its ``__init__`` defaults (#1179).
     """
-    sensors = [_slot(1, tilt=blend, tilt_only=True, priority=BELOW_HOLDER)]
-    handlers = [
-        CustomPositionHandler(slot=1, position=None, priority=BELOW_HOLDER, tilt=blend),
-        ManualOverrideHandler(),
-    ]
+    sensors = []
+    handlers = []
+    if blend is not None:
+        sensors.append(_slot(1, tilt=blend, tilt_only=True, priority=BELOW_HOLDER))
+        handlers.append(
+            CustomPositionHandler(
+                slot=1, position=None, priority=BELOW_HOLDER, tilt=blend
+            )
+        )
+    handlers.append(ManualOverrideHandler())
     if floor is not None:
-        sensors.append(_slot(2, position=floor, min_mode=True, priority=ABOVE_HOLDER))
-        handlers.append(_cp_handler(2, floor, priority=ABOVE_HOLDER))
+        sensors.append(_slot(2, position=floor, min_mode=True, priority=floor_priority))
+        handlers.append(_cp_handler(2, floor, priority=floor_priority))
     if ceiling is not None:
         sensors.append(_slot(3, position_max=ceiling, priority=ABOVE_HOLDER))
         handlers.append(
@@ -697,34 +718,205 @@ def _coupled_hold(
         make_snapshot(
             cover=_climate_cover(direct_sun_valid=False),
             cover_type=cover_type,
+            policy=policy,
             manual_override_active=True,
             current_cover_position=current_cover_position,
             cover_positions=cover_positions,
             default_position=100,
             direct_sun_valid=False,
+            position_axis_inverted=position_axis_inverted,
             custom_position_sensors=sensors,
         )
     )
 
 
-def _model_c_policy():
+class _CoupledStubPolicy(CoverTypePolicy):
+    """A coupled policy that names its own reference position (#1179).
+
+    Overriding ``resolve_entity_target`` is what trips the derived independence
+    gate, so this stub is coupled for exactly the reason a real remapping policy
+    is — the registry is asked one polymorphic question and reads no cover-type
+    string. ``reference_calls`` records whether the reduction hook was consulted
+    at all, which is the half an assertion on the resolved position cannot see.
+    """
+
+    cover_type: ClassVar[str] = "cover_reference_stub"
+    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
+
+    def __init__(self, reference: int | None) -> None:
+        self._reference = reference
+        self.reference_calls = 0
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+        return MagicMock()
+
+    def resolve_entity_target(
+        self,
+        entity_id: str,  # noqa: ARG002
+        position: int,
+        *,
+        inverted: bool | None = None,  # noqa: ARG002
+        interpolated: bool = False,  # noqa: ARG002
+    ) -> int:
+        return position
+
+    def hold_reference_position(
+        self,
+        cover_positions,  # noqa: ARG002
+        *,
+        inverted: bool,  # noqa: ARG002
+    ) -> int | None:
+        self.reference_calls += 1
+        return self._reference
+
+
+class _IndependentStubPolicy(_CoupledStubPolicy):
+    """The same stub, declaring its entities independent after all."""
+
+    cover_type: ClassVar[str] = "cover_reference_stub_independent"
+
+    def entities_move_independently(self) -> bool:
+        """Independent by declaration; the remap above is a documented identity."""
+        return True
+
+
+def _stub_reference_hold(policy):
+    """Build a hold whose mean (64) clears the floor while its reference does not.
+
+    Separating the two numbers is the whole point: judging the summary mean
+    leaves this hold alone, and judging the policy's named reference clamps it.
+    """
+    return _coupled_hold(
+        cover_type="cover_blind",
+        policy=policy,
+        cover_positions={"cover.x": 58, "cover.y": 70},
+        current_cover_position=64,
+        blend=None,
+        floor=60,
+    )
+
+
+def test_a_coupled_policy_that_names_a_reference_is_judged_on_it() -> None:
+    """The seam, with zero cover-type knowledge: one hook, one judged number.
+
+    The stub reports 40 — below the 60 floor — while the instance mean is 64 and
+    clears it. So the clamp fires, the trace's ``from_pos`` names the reference
+    rather than the mean, and the coupled path still emits no verdicts: the
+    clamped abstract value rides ``PipelineResult.position`` through the shared
+    dispatch route the coupled types already use.
+    """
+    policy = _CoupledStubPolicy(reference=40)
+    result = _stub_reference_hold(policy)
+
+    assert result.position == 60
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+    assert result.hold_clamp_verdicts is None
+    assert policy.reference_calls == 1
+
+    steps = {s.handler: s for s in result.decision_trace}
+    assert steps["floor_clamp"].reason_payload.params["from_pos"] == 40
+
+
+def test_an_independent_policy_never_consults_the_reduction_hook() -> None:
+    """#1174's path is untouched: independence answers first, and totally.
+
+    A policy that reports independent entities is judged per cover exactly as it
+    was before #1179, and the reduction hook is not called at all — so no
+    reference a policy happens to define can leak into the eleven cover types
+    that never needed one.
+    """
+    policy = _IndependentStubPolicy(reference=40)
+    result = _stub_reference_hold(policy)
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.x"].released is True
+    assert verdicts["cover.y"].released is False
+    assert policy.reference_calls == 0
+
+
+def _day_night_policy(options: dict | None = None):
+    """Build a day/night policy already synced to ``options``, as production has it.
+
+    ``coordinator._update_options`` drives ``sync_runtime_options`` before the
+    pipeline runs, so by the time the registry asks the policy anything it knows
+    its control model and its rail roles. A test that skips that step hands the
+    registry a policy sitting on its ``__init__`` defaults (#1179).
+    """
     from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
         DayNightShadePolicy,
     )
 
-    return DayNightShadePolicy()
+    policy = DayNightShadePolicy()
+    if options is not None:
+        policy.sync_runtime_options(options)
+    return policy
+
+
+def _model_c_options():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+        DAY_NIGHT_MODEL_DUAL_ENTITY,
+    )
+
+    return _day_night_options(
+        DAY_NIGHT_MODEL_DUAL_ENTITY,
+        **{CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _DN_MIDDLE},
+    )
+
+
+def _model_b_options():
+    from custom_components.adaptive_cover_pro.const import DAY_NIGHT_MODEL_SPLIT_RANGE
+
+    return _day_night_options(DAY_NIGHT_MODEL_SPLIT_RANGE)
+
+
+def _model_a_options():
+    from custom_components.adaptive_cover_pro.const import (
+        DAY_NIGHT_MODEL_POSITION_TILT,
+    )
+
+    return _day_night_options(DAY_NIGHT_MODEL_POSITION_TILT)
+
+
+def test_model_a_judges_each_shade_on_its_own_position() -> None:
+    """Model A binds ordinary covers, so #1174's per-cover fix reaches it too.
+
+    ``position_tilt`` drives one position axis and one physical tilt axis per
+    entity: it remaps nothing, orders nothing, and rewrites no position after the
+    pipeline. Its shades are as independent as a plain blind's, so the derived
+    gate excluding them was a false negative — and the verbatim #1174 repro
+    (40/40/0 against a 40 % floor, mean 27) dragged the two shades already
+    sitting on the floor down to it.
+    """
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=_day_night_policy(_model_a_options()),
+        cover_positions=_ISSUE_POSITIONS,
+        current_cover_position=_ISSUE_MEAN,
+        blend=_DN_BLEND,
+        floor=_FLOOR,
+    )
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.c"].released is True
+    assert verdicts["cover.a"].released is False
+    assert verdicts["cover.b"].released is False
+    assert verdicts["cover.c"].held_position == 0
 
 
 def test_a_coupled_cover_type_produces_no_verdicts_at_all() -> None:
     """One question, asked of the policy, and its answer is total.
 
-    Same snapshot shape, same numbers, two cover types: the coupled one is
-    judged on the instance summary exactly as it was before #1174 (mean 55,
-    below the 60 floor, so the shared result is the floor), and the
-    independent one gets a verdict per cover. Nothing here reads a cover-type
-    string — ``entities_move_independently`` is the whole gate.
+    Same snapshot shape, same numbers, two cover types: the coupled one resolves
+    ONE position for the whole geometry — its bottom rail at 40 violates the 60
+    floor, so the shared result is the floor — and the independent one gets a
+    verdict per cover. Nothing here reads a cover-type string;
+    ``entities_move_independently`` is the whole gate.
     """
-    positions = {"cover.one": 40, "cover.two": 70}
+    positions = {_DN_BOTTOM: 40, _DN_MIDDLE: 70}
     kwargs = {
         "cover_positions": positions,
         "current_cover_position": 55,
@@ -732,15 +924,19 @@ def test_a_coupled_cover_type_produces_no_verdicts_at_all() -> None:
         "floor": 60,
     }
 
-    coupled = _coupled_hold(cover_type="cover_day_night_shade", **kwargs)
+    coupled = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=_day_night_policy(_model_c_options()),
+        **kwargs,
+    )
     assert coupled.hold_clamp_verdicts is None
     assert coupled.position == 60
     assert coupled.position_constraint_applied is True
 
     independent = _coupled_hold(cover_type="cover_blind", **kwargs)
     assert independent.hold_clamp_verdicts is not None
-    assert independent.hold_clamp_verdicts["cover.one"].released is True
-    assert independent.hold_clamp_verdicts["cover.two"].released is False
+    assert independent.hold_clamp_verdicts[_DN_BOTTOM].released is True
+    assert independent.hold_clamp_verdicts[_DN_MIDDLE].released is False
 
 
 @pytest.mark.asyncio
@@ -757,29 +953,20 @@ async def test_model_c_rails_are_never_judged_apart() -> None:
     Coupled: the pair resolves ONE position (60), and the remap derives the
     middle rail from it exactly once → 80.
     """
-    policy = _model_c_policy()
-    from custom_components.adaptive_cover_pro.const import (
-        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
-        DAY_NIGHT_MODEL_DUAL_ENTITY,
-    )
+    options = _model_c_options()
+    policy = _day_night_policy(options)
 
     positions = {_DN_BOTTOM: 40, _DN_MIDDLE: 70}
     result = _coupled_hold(
         cover_type="cover_day_night_shade",
+        policy=policy,
         cover_positions=positions,
         current_cover_position=55,
         blend=_DN_BLEND,
         floor=60,
         ceiling=65,
     )
-    resolved = _resolve_through_policy(
-        result,
-        policy,
-        _day_night_options(
-            DAY_NIGHT_MODEL_DUAL_ENTITY,
-            **{CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _DN_MIDDLE},
-        ),
-    )
+    resolved = _resolve_through_policy(result, policy, options)
 
     targets = await _dispatch_targets(
         resolved, positions, "custom_position_2", policy=policy
@@ -797,34 +984,365 @@ async def test_model_c_middle_rail_follows_a_floor_that_binds_the_bottom() -> No
     the moment the bottom rail rises to 60. The rails are geometry, not two
     opinions.
     """
-    policy = _model_c_policy()
-    from custom_components.adaptive_cover_pro.const import (
-        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
-        DAY_NIGHT_MODEL_DUAL_ENTITY,
-    )
+    options = _model_c_options()
+    policy = _day_night_policy(options)
 
     positions = {_DN_BOTTOM: 40, _DN_MIDDLE: 70}
     result = _coupled_hold(
         cover_type="cover_day_night_shade",
+        policy=policy,
         cover_positions=positions,
         current_cover_position=55,
         blend=_DN_BLEND,
         floor=60,
     )
-    resolved = _resolve_through_policy(
-        result,
-        policy,
-        _day_night_options(
-            DAY_NIGHT_MODEL_DUAL_ENTITY,
-            **{CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _DN_MIDDLE},
-        ),
-    )
+    resolved = _resolve_through_policy(result, policy, options)
 
     targets = await _dispatch_targets(
         resolved, positions, "custom_position_2", policy=policy
     )
 
     assert targets == {_DN_BOTTOM: 60, _DN_MIDDLE: 80}
+
+
+# ---------------------------------------------------------------------------
+# Model C: the BOTTOM rail is the coverage the bounds are about (#1179)
+# ---------------------------------------------------------------------------
+#
+# The middle rail is ``M = 100 - blend * (100 - P) / 100`` — a pure function of
+# the bottom rail. Averaging it into ``held_position`` mixes a coverage with a
+# value derived from that coverage, and the result is a number neither rail
+# sits at. Judged against a floor it hides violations; against a ceiling it
+# invents them, because the middle rail is always at or above the bottom one.
+
+#: Blend used by the reduction fixtures: 20 % sheer, so the middle rail sits far
+#: enough above the bottom to make the mean visibly wrong in both directions.
+_DN_NARROW_BLEND = 20
+
+
+@pytest.mark.asyncio
+async def test_a_floor_below_the_mean_still_moves_a_violating_bottom_rail() -> None:
+    """Bottom rail 40, middle 88 — the mean is 64 and clears a 60 floor.
+
+    The shade's coverage is 40 and violates the floor, but the derived middle
+    rail drags the average above it, so the whole geometry was left where it was.
+    Judged on the bottom rail the floor binds, and the middle rail follows it up
+    to 92 through the remap that already owns that arithmetic.
+    """
+    options = _model_c_options()
+    policy = _day_night_policy(options)
+
+    positions = {_DN_BOTTOM: 40, _DN_MIDDLE: 88}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=64,
+        blend=_DN_NARROW_BLEND,
+        floor=60,
+    )
+
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+    steps = {s.handler: s for s in result.decision_trace}
+    # The trace names the rail the floor actually lifted, not the mean.
+    assert steps["floor_clamp"].reason_payload.params["from_pos"] == 40
+
+    resolved = _resolve_through_policy(result, policy, options)
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DN_BOTTOM: 60, _DN_MIDDLE: 92}
+
+
+@pytest.mark.asyncio
+async def test_a_ceiling_the_bottom_rail_satisfies_does_not_move_the_shade() -> None:
+    """The mirror: bottom rail 55, middle 91, mean 73 against a 60 ceiling.
+
+    The coverage is 55 and already clears the ceiling; only the derived middle
+    rail is "above" it, and the middle rail is always above the bottom one by
+    construction. Judging the mean therefore invented a violation and closed a
+    hold the user had placed by hand.
+    """
+    options = _model_c_options()
+    policy = _day_night_policy(options)
+
+    positions = {_DN_BOTTOM: 55, _DN_MIDDLE: 91}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=73,
+        blend=_DN_NARROW_BLEND,
+        ceiling=60,
+    )
+
+    assert result.position_constraint_applied is False
+    assert result.skip_command is True
+
+    resolved = _resolve_through_policy(result, policy, options)
+    targets = await _dispatch_targets(
+        resolved, positions, "manual_override", policy=policy
+    )
+
+    assert targets == {_DN_BOTTOM: None, _DN_MIDDLE: None}
+
+
+def test_a_sub_priority_bound_cannot_move_a_coupled_hold() -> None:
+    """#1170's gate still runs first, and a coupled reference cannot slip past it.
+
+    The same violating fixture, with the floor demoted below the holder: the
+    bound is stripped before anything is judged, so there is nothing for the
+    reduction hook's answer to be compared against.
+    """
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=_day_night_policy(_model_c_options()),
+        cover_positions={_DN_BOTTOM: 40, _DN_MIDDLE: 88},
+        current_cover_position=64,
+        blend=_DN_NARROW_BLEND,
+        floor=60,
+        floor_priority=BELOW_HOLDER,
+    )
+
+    assert result.skip_command is True
+    assert result.position_constraint_applied is False
+    assert result.hold_clamp_verdicts is None
+
+
+def test_the_reduction_hook_reads_raw_and_returns_logical() -> None:
+    """The frames, pinned: raw reads in, a logical position out (#993).
+
+    On an inverse install the bottom rail's raw 90 IS logical 10 and violates a
+    logical 25 floor. The raw mean of 90 and 18 is 54 → logical 46, which clears
+    the floor outright, so getting the frame wrong here is not a rounding
+    difference — it is the whole answer.
+    """
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=_day_night_policy(_model_c_options()),
+        cover_positions={_DN_BOTTOM: 90, _DN_MIDDLE: 18},
+        current_cover_position=54,
+        blend=_DN_NARROW_BLEND,
+        floor=25,
+        position_axis_inverted=True,
+    )
+
+    assert result.position == 25
+    assert result.position_constraint_applied is True
+    steps = {s.handler: s for s in result.decision_trace}
+    assert steps["floor_clamp"].reason_payload.params["from_pos"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Dual panel: the FRONT is the coverage the bounds are about (#1179)
+# ---------------------------------------------------------------------------
+#
+# ``compute_layered`` discards ``front`` when it computes ``back`` — the back
+# panel is a binary privacy state, not a coverage opinion. Averaging it in gives
+# a number that moves with a blackout deploy the bounds were never about.
+
+_DP_FRONT = "cover.sheer_front"
+_DP_BACK = "cover.blackout_back"
+
+
+def _dual_panel_policy(options: dict):
+    """Build a dual-panel policy already synced to ``options``, as production has."""
+    from custom_components.adaptive_cover_pro.cover_types.dual_panel import (
+        DualPanelPolicy,
+    )
+
+    policy = DualPanelPolicy()
+    policy.sync_runtime_options(options)
+    return policy
+
+
+def _dual_panel_options(front: str | None = _DP_FRONT) -> dict:
+    from custom_components.adaptive_cover_pro.const import CONF_DUAL_PANEL_FRONT_ENTITY
+
+    return {CONF_DUAL_PANEL_FRONT_ENTITY: front} if front is not None else {}
+
+
+@pytest.mark.asyncio
+async def test_a_floor_below_the_mixed_mean_still_moves_a_violating_front_panel() -> (
+    None
+):
+    """Front 40, back retracted at 100 — the mean is 70 and clears a 60 floor.
+
+    The window's coverage is the front panel's 40 and violates the floor; the
+    back is simply "not deployed", a state the floor has nothing to say about.
+    Judged on the front the floor binds, and the back keeps its own absolute
+    target rather than being dragged onto the front's clamp (#1035).
+    """
+    options = _dual_panel_options()
+    policy = _dual_panel_policy(options)
+
+    positions = {_DP_FRONT: 40, _DP_BACK: 100}
+    result = _coupled_hold(
+        cover_type="cover_dual_panel",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=70,
+        blend=None,
+        floor=60,
+    )
+
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+    assert result.hold_clamp_verdicts is None
+
+    resolved = _resolve_through_policy(result, policy, options)
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DP_FRONT: 60, _DP_BACK: 100}
+
+
+@pytest.mark.asyncio
+async def test_a_back_panel_privacy_state_cannot_drag_a_compliant_front_panel() -> None:
+    """The mirror: front 80 clears the 60 floor, but a deployed back means 0.
+
+    The mean of 80 and 0 is 40, so the floor "fired" and closed a front panel the
+    user had placed at 80 — a move driven entirely by a blackout deploy that is
+    not a coverage opinion at all.
+    """
+    options = _dual_panel_options()
+    policy = _dual_panel_policy(options)
+
+    positions = {_DP_FRONT: 80, _DP_BACK: 0}
+    result = _coupled_hold(
+        cover_type="cover_dual_panel",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=40,
+        blend=None,
+        floor=60,
+    )
+
+    assert result.position_constraint_applied is False
+    assert result.skip_command is True
+
+    resolved = _resolve_through_policy(result, policy, options)
+    targets = await _dispatch_targets(
+        resolved, positions, "manual_override", policy=policy
+    )
+
+    assert targets == {_DP_FRONT: None, _DP_BACK: None}
+
+
+# ---------------------------------------------------------------------------
+# Model B: one wire carries coverage AND fabric, so a hold's read must be decoded
+# ---------------------------------------------------------------------------
+#
+# ``split_range`` has no second physical axis. The carriage's raw read is a
+# composite ``(coverage, fabric)`` encoding, and comparing a coverage floor
+# against it is a category error even on a SINGLE-entity instance, where the
+# mean is not the culprit. And ``_resolve_blend`` clears ``tilt`` for every hold
+# winner, so a clamped hold used to be dispatched unfolded — the abstract
+# coverage sent straight onto the wire, halving the carriage's travel.
+
+#: Carriage read decoding to coverage 40 behind the BLACKOUT fabric.
+_DN_WIRE_BLACKOUT_40 = 20
+#: Carriage read decoding to the same coverage 40, behind the SHEER fabric.
+_DN_WIRE_SHEER_40 = 70
+
+
+def test_a_split_range_floor_the_carriage_already_clears_leaves_it_alone() -> None:
+    """Wire 20 is coverage 40, and a 30 % floor has nothing to say to it.
+
+    Read as a raw position, 20 looks like a violation — and the fold then sent
+    the "clamped" 30 back out as wire 15, closing a shade the floor was supposed
+    to be opening.
+    """
+    options = _model_b_options()
+    policy = _day_night_policy(options)
+
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions={_DN_SHADE: _DN_WIRE_BLACKOUT_40},
+        current_cover_position=_DN_WIRE_BLACKOUT_40,
+        blend=10,
+        floor=30,
+    )
+
+    assert result.position_constraint_applied is False
+    assert result.skip_command is True
+
+
+@pytest.mark.asyncio
+async def test_a_split_range_floor_the_decoded_coverage_violates_moves_the_carriage() -> (
+    None
+):
+    """Wire 70 is coverage 40 behind sheer, and a 60 % floor DOES bind it.
+
+    The mirror failure: read raw, 70 clears the floor and the shade stayed at 40
+    % coverage against a 60 % bound. Decoded, the floor lifts the coverage to 60
+    and the fold puts it back on the wire in the same fabric half → 80.
+    """
+    options = _model_b_options()
+    policy = _day_night_policy(options)
+
+    positions = {_DN_SHADE: _DN_WIRE_SHEER_40}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=_DN_WIRE_SHEER_40,
+        blend=80,
+        floor=60,
+    )
+
+    assert result.position_constraint_applied is True
+    assert result.skip_command is False
+
+    resolved = _resolve_through_policy(result, policy, options)
+    assert resolved.position == 80
+
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DN_SHADE: 80}
+
+
+@pytest.mark.asyncio
+async def test_a_clamped_split_range_hold_is_dispatched_folded_not_raw() -> None:
+    """No blend survives a hold, and the fold has to happen anyway.
+
+    ``_resolve_blend`` clears ``tilt`` for every hold winner, so with no tilt slot
+    at all the re-encode gate never fired and the clamped abstract coverage 60
+    went onto the wire verbatim — physically 60 % of travel into the SHEER half,
+    which is coverage 20 behind the wrong fabric. The carriage's own decoded
+    fabric is the honest blend to fold with: same fabric, new coverage → wire 30.
+    """
+    options = _model_b_options()
+    policy = _day_night_policy(options)
+
+    positions = {_DN_SHADE: _DN_WIRE_BLACKOUT_40}
+    result = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=_DN_WIRE_BLACKOUT_40,
+        blend=None,
+        floor=60,
+    )
+
+    assert result.position == 60
+    resolved = _resolve_through_policy(result, policy, options)
+    # A hold gains no fabricated blend on the Target Tilt sensor; only the wire
+    # and the trace learn which fabric the carriage is physically behind.
+    assert resolved.tilt is None
+    assert resolved.position == 30
+
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DN_SHADE: 30}
 
 
 @pytest.mark.asyncio
@@ -837,29 +1355,86 @@ async def test_model_b_fabric_change_still_reaches_the_hardware() -> None:
     the raw position it is already sitting at makes the command a genuine no-op
     and silently drops the clamp.
 
-    Carriage at wire 20 (blackout half, coverage 40); the tilt bound raises the
-    blend to 60, which is the sheer half → wire 60.
+    The carriage read is a WIRE, not an abstract coverage: wire 20 is coverage 40
+    behind blackout. The tilt bound raises the blend to 60, the sheer half — so
+    the same coverage in the new fabric is wire 70. Folding the raw 20 instead
+    treated it as abstract coverage and halved it to 20 while changing fabric,
+    which is a move the fabric change never asked for.
     """
-    policy = _model_c_policy()
-    from custom_components.adaptive_cover_pro.const import DAY_NIGHT_MODEL_SPLIT_RANGE
+    options = _model_b_options()
+    policy = _day_night_policy(options)
 
-    positions = {_DN_SHADE: 20}
+    positions = {_DN_SHADE: _DN_WIRE_BLACKOUT_40}
     result = _coupled_hold(
         cover_type="cover_day_night_shade",
+        policy=policy,
         cover_positions=positions,
-        current_cover_position=20,
+        current_cover_position=_DN_WIRE_BLACKOUT_40,
         blend=10,
         tilt_min=60,
     )
-    resolved = _resolve_through_policy(
-        result, policy, _day_night_options(DAY_NIGHT_MODEL_SPLIT_RANGE)
-    )
+    resolved = _resolve_through_policy(result, policy, options)
 
     assert resolved.tilt == 60
-    assert resolved.position == 60
+    assert resolved.position == 70
 
     targets = await _dispatch_targets(
         resolved, positions, "manual_override", policy=policy
     )
 
-    assert targets == {_DN_SHADE: 60}
+    assert targets == {_DN_SHADE: 70}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("carriage", "computed_blend", "expected_wire"),
+    [
+        pytest.param(_DN_WIRE_BLACKOUT_40, 20, 30, id="blackout"),
+        pytest.param(_DN_WIRE_SHEER_40, 80, 80, id="sheer"),
+    ],
+)
+async def test_a_clamped_hold_dispatches_the_same_wire_as_a_computed_winner(
+    carriage: int, computed_blend: int, expected_wire: int
+) -> None:
+    """The governing invariant: coverage 60 dispatches one wire, however it got there.
+
+    A clamped hold at abstract coverage X must reach the hardware as exactly the
+    wire a computed winner at X would — the property that makes reducing the
+    per-entity reads to one abstract number defensible at all. The hold's fabric
+    comes from its own carriage; the computed winner's comes from the pipeline;
+    same half, same wire.
+    """
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+    options = _model_b_options()
+
+    computed = _resolve_through_policy(
+        PipelineResult(
+            position=60,
+            control_method=ControlMethod.CUSTOM_POSITION,
+            reason="computed",
+            tilt=computed_blend,
+        ),
+        _day_night_policy(options),
+        options,
+    )
+    assert computed.position == expected_wire
+
+    policy = _day_night_policy(options)
+    positions = {_DN_SHADE: carriage}
+    held = _coupled_hold(
+        cover_type="cover_day_night_shade",
+        policy=policy,
+        cover_positions=positions,
+        current_cover_position=carriage,
+        blend=None,
+        floor=60,
+    )
+    resolved = _resolve_through_policy(held, policy, options)
+
+    targets = await _dispatch_targets(
+        resolved, positions, "custom_position_2", policy=policy
+    )
+
+    assert targets == {_DN_SHADE: expected_wire}


### PR DESCRIPTION
## Summary

`#1174` made the floor/ceiling hold verdict per-cover, but only for cover types whose entities move independently. Day/night shades and dual panels stayed on the old path, where the hold was judged against `_compute_mean_cover_position` — an average of values from different coordinate systems, so whether a bound clamped depended on where the other entities happened to sit.

I added one polymorphic reduction hook, `CoverTypePolicy.hold_reference_position`, the algebraic inverse of the abstract-to-per-entity dispatch chain that already existed. `_judge_position_axis` is now three-way: independent policies keep `#1174`'s per-cover path unchanged, a policy that names a reference has that one number judged against the composed bounds, and a coupled policy with no single answer retains the mean as a fallback. The clamped value rides the existing shared-target route, so there is no new dispatch machinery and no coordinator logic change.

Per configuration: day/night Model C reports the bottom rail (the middle is a pure function of it); Model B decodes the split-range wire back to coverage and stashes the fabric half, which also fixes a clamped hold being dispatched unfolded; Model A and a dual panel with no front designation turn out to be independent, false negatives of the derived gate, and gain the `#1174` fix; a dual panel with a front reports the front.

Three follow-up commits came out of the pre-merge audit. The substantive one closes a stale-fabric race the new stash introduced: two awaits sit between the clear in `sync_runtime_options` and the consume in `post_pipeline_resolve`, and an off-cycle `evaluate` landing in that window could leave a fabric the resuming cycle never asked for. The fold is now gated on the winner carrying a `held_position`.

## Testing
- ✅ 12778 tests passing

All `#1174`/`#1180`, `#1170`/`#1176`, `#996`/`#1000`, `#1115`/`#1118` and cover-type abstraction guards stay green. `test_scalar_snapshot_without_cover_positions_is_byte_identical` and `tests/test_dual_panel_dispatch.py` are unmodified.

## Related Issues
Refs #1179