### PR TITLE
fix: keep tilt bounds on a tilt-only slot with no fixed tilt (#1215)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -1226,8 +1226,11 @@ def _custom_position_tilt_specs() -> list[FieldSpec]:
                 make_selector=_bool(),
             )
         )
-        # Tilt bounds (issue #943). Absent = off. `tilt_only` (a FIXED tilt
-        # claim) wins over these — normalized once in the snapshot builder.
+        # Tilt bounds (issue #943). Absent = off. A REAL fixed tilt
+        # (`tilt_only` *with* a configured slat angle) wins over these —
+        # normalized once in the snapshot builder via `has_fixed_tilt`. A
+        # `tilt_only` slot with no slat angle makes no FIXED claim, so its
+        # bounds are NOT discarded (issue #1215).
         for sub in ("tilt_min", "tilt_max"):
             specs.append(
                 FieldSpec(

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2586,6 +2586,18 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 # values — reporting the conflict is its job.
                 _is_min = bool(config.get(_keys["min_mode"])) and not _tilt_only
                 _use_my_effective = _use_my and not _tilt_only
+                # ``position_mode`` is NONE for every tilt_only slot regardless
+                # of a fixed tilt (types.py's ``position_mode`` keys on the
+                # bare flag, unlike ``tilt_mode``), and snapshot_builder.py
+                # wipes ``position_max`` the same way. Normalize both the
+                # stored position claim and its ceiling here too, or a
+                # tilt_only slot that also stores a ``custom_position_N`` /
+                # ``position_max`` would render a phantom "→ N%" / "(at most
+                # N%)" the handler never applies (issue #1215 audit findings
+                # 1-2).
+                if _tilt_only:
+                    _pos = None
+                    _pos_max = None
                 # A constraint-only slot names no position — the pipeline's own
                 # result is what gets clamped (issue #943).
                 target = (

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -377,6 +377,7 @@ from .pipeline.handlers import (  # noqa: E402
     HANDLER_PRIORITY_CONF,
     resolve_handler_priority,
 )
+from .pipeline.types import has_fixed_tilt  # noqa: E402
 from .priority_chain import build_priority_chain  # noqa: E402
 from .managers.cover_command.queue import normalize_queue_name  # noqa: E402
 from .profile_link import (  # noqa: E402
@@ -2560,10 +2561,11 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 L["fragments.safety"] if _pri >= CUSTOM_POSITION_SAFETY_PRIORITY else ""
             )
             _order = _HID_CUSTOM_ORDER_BASE + _slot
-            if _tilt_only:
-                # Tilt-only fixes the slat angle and lets the position pipeline
-                # (solar etc.) drive the carriage — min_mode/use_my are ignored.
-                slat = _slot_tilt if _slot_tilt is not None else 0
+            if has_fixed_tilt(tilt_only=_tilt_only, tilt=_slot_tilt):
+                # A REAL fixed tilt (tilt_only + a configured slat angle)
+                # fixes the slat angle and lets the position pipeline (solar
+                # etc.) drive the carriage — min_mode/use_my are ignored.
+                slat = _slot_tilt
                 _open(
                     _pri,
                     _order,
@@ -2574,11 +2576,20 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             else:
                 _keys = CUSTOM_POSITION_SLOTS[_slot]
                 _pos_max = config.get(_keys["position_max"])
-                _is_min = bool(config.get(_keys["min_mode"]))
+                # tilt_only normalizes min_mode / use_my off unconditionally
+                # (snapshot_builder.py:617-619) — a slot only reaches this
+                # branch under tilt_only when it has no fixed slat angle (a
+                # real fixed tilt takes the branch above), so both flags must
+                # render as off here too, or the summary would claim a floor
+                # / My-path the runtime never applies (issue #1215 residual
+                # risk). The mutual-exclusion ⚠️ warning below reads the raw
+                # values — reporting the conflict is its job.
+                _is_min = bool(config.get(_keys["min_mode"])) and not _tilt_only
+                _use_my_effective = _use_my and not _tilt_only
                 # A constraint-only slot names no position — the pipeline's own
                 # result is what gets clamped (issue #943).
                 target = (
-                    _pos_label(_pos, _use_my)
+                    _pos_label(_pos, _use_my_effective)
                     if _pos is not None
                     else L["custom.no_position_claim"]
                 )

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1693,6 +1693,14 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
         "⚠️ {label}: tilt only is on — "
         "Use as minimum / Use My position are ignored for this slot."
     ),
+    "warnings.custom_tilt_only_bounds_discarded": (
+        "⚠️ {label}: slat fixed at {slat}% — the configured tilt bounds are "
+        "ignored for this slot."
+    ),
+    "warnings.custom_tilt_only_no_effect": (
+        "⚠️ {label}: tilt only is on with no slat angle and no tilt bounds "
+        "configured — this slot has no effect."
+    ),
     "warnings.custom_and_no_sensors": (
         "⚠️ {label}: combine mode AND is set but no trigger sensors are "
         "configured — the template alone activates the slot."
@@ -2561,25 +2569,40 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 L["fragments.safety"] if _pri >= CUSTOM_POSITION_SAFETY_PRIORITY else ""
             )
             _order = _HID_CUSTOM_ORDER_BASE + _slot
+            _keys = CUSTOM_POSITION_SLOTS[_slot]
+            # Read once, used by both branches below (issue #1215 finding 2 —
+            # a real fixed tilt still needs these to know whether it is
+            # discarding a configured bound; the constraint-rendering branch
+            # needs them to render the bound itself).
+            _t_min = config.get(_keys["tilt_min"])
+            _t_max = config.get(_keys["tilt_max"])
             if has_fixed_tilt(tilt_only=_tilt_only, tilt=_slot_tilt):
                 # A REAL fixed tilt (tilt_only + a configured slat angle)
                 # fixes the slat angle and lets the position pipeline (solar
                 # etc.) drive the carriage — min_mode/use_my are ignored.
-                slat = _slot_tilt
                 _open(
                     _pri,
                     _order,
                     L["rules.custom_tilt_only"].format(
-                        label=_slot_label, trigger=_trigger, slat=slat
+                        label=_slot_label, trigger=_trigger, slat=_slot_tilt
                     ),
                 )
+                # Footgun (issue #1215 finding 2): the #514 precedence above
+                # is deliberate and preserved, but it silently drops any
+                # tilt_min/tilt_max also configured on this slot. Say so.
+                if _t_min is not None or _t_max is not None:
+                    _sub(
+                        L["warnings.custom_tilt_only_bounds_discarded"].format(
+                            label=_slot_label, slat=_slot_tilt
+                        )
+                    )
             else:
-                _keys = CUSTOM_POSITION_SLOTS[_slot]
                 _pos_max = config.get(_keys["position_max"])
                 # tilt_only normalizes min_mode / use_my off unconditionally
-                # (snapshot_builder.py:617-619) — a slot only reaches this
-                # branch under tilt_only when it has no fixed slat angle (a
-                # real fixed tilt takes the branch above), so both flags must
+                # (snapshot_builder.py's tilt_only mutual-exclusion pass,
+                # keyed on the bare flag) — a slot only reaches this branch
+                # under tilt_only when it has no fixed slat angle (a real
+                # fixed tilt takes the branch above), so both flags must
                 # render as off here too, or the summary would claim a floor
                 # / My-path the runtime never applies (issue #1215 residual
                 # risk). The mutual-exclusion ⚠️ warning below reads the raw
@@ -2589,14 +2612,18 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 # ``position_mode`` is NONE for every tilt_only slot regardless
                 # of a fixed tilt (types.py's ``position_mode`` keys on the
                 # bare flag, unlike ``tilt_mode``), and snapshot_builder.py
-                # wipes ``position_max`` the same way. Normalize both the
-                # stored position claim and its ceiling here too, or a
-                # tilt_only slot that also stores a ``custom_position_N`` /
-                # ``position_max`` would render a phantom "→ N%" / "(at most
-                # N%)" the handler never applies (issue #1215 audit findings
-                # 1-2).
+                # wipes ``position_max`` the same way — on the bare tilt_only
+                # flag, and independently on ``use_my`` too (issue #1215
+                # finding 1, mirroring snapshot_builder.py's own ``if
+                # tilt_only or use_my: position_max = None``). Normalize both
+                # the stored position claim and its ceiling here too, or a
+                # tilt_only / use_my slot that also stores a
+                # ``custom_position_N`` / ``position_max`` would render a
+                # phantom "→ N%" / "(at most N%)" the handler never applies
+                # (issue #1215 audit findings 1-2).
                 if _tilt_only:
                     _pos = None
+                if _tilt_only or _use_my:
                     _pos_max = None
                 # A constraint-only slot names no position — the pipeline's own
                 # result is what gets clamped (issue #943).
@@ -2621,8 +2648,6 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                     cp_min += L["fragments.as_maximum"].format(max=_pos_max)
                 # Tilt bounds (issue #943). Mutually exclusive with the fixed
                 # tilt note above — tilt_only is handled in the other branch.
-                _t_min = config.get(_keys["tilt_min"])
-                _t_max = config.get(_keys["tilt_max"])
                 if _t_min is not None and _t_max is not None:
                     tilt_note += L["custom.tilt_bound_range"].format(
                         min=_t_min, max=_t_max
@@ -2664,6 +2689,15 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 config.get(f"custom_position_min_mode_{_slot}") or _use_my
             ):
                 _sub(L["warnings.custom_tilt_only_conflict"].format(label=_slot_label))
+            # Footgun (issue #1215 finding 6): tilt_only with no slat angle
+            # AND no tilt bounds leaves the slot with position_mode == NONE
+            # and tilt_mode == NONE — it does nothing at all. ``_slot_tilt is
+            # None`` is implied whenever ``_tilt_only`` reaches here without
+            # having taken the ``has_fixed_tilt`` branch above, but spelling
+            # it out keeps this check correct even if the branch above ever
+            # changes shape.
+            if _tilt_only and _slot_tilt is None and _t_min is None and _t_max is None:
+                _sub(L["warnings.custom_tilt_only_no_effect"].format(label=_slot_label))
             # Footgun (issue #711): a safety-priority slot with a live trigger
             # bypasses the auto-control toggle, manual override, and the time
             # window — it can move the cover at any hour with automation off.

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -131,6 +131,7 @@ from .types import (
     CustomPositionSensorState,
     GroupIntent,
     PipelineSnapshot,
+    has_fixed_tilt,
 )
 
 if TYPE_CHECKING:
@@ -613,7 +614,10 @@ class PipelineSnapshotBuilder:
             # position as a floor / via My — not both. Normalize here, the
             # single read site, mirroring the existing use_my-over-min_mode
             # precedent. The config-summary surfaces a warning when a user
-            # configured a conflicting combination.
+            # configured a conflicting combination. Deliberately keyed on the
+            # bare flag, unlike the tilt-bound wipe below (issue #1215):
+            # tilt_only disclaims the position axis whether or not a slat
+            # angle is configured — do not gate this on ``has_fixed_tilt``.
             if tilt_only:
                 min_mode = False
                 use_my = False
@@ -625,18 +629,22 @@ class PipelineSnapshotBuilder:
             position_max = _opt_int(options, slot_keys["position_max"])
             tilt_min = _opt_int(options, slot_keys["tilt_min"])
             tilt_max = _opt_int(options, slot_keys["tilt_max"])
-            # Same mutual-exclusion pass as min_mode / use_my above: tilt_only
-            # fixes the slat angle and lets the position pipeline drive the
-            # carriage, so the slot carries no bounds on either axis. The My
-            # path is hardware-pinned — a position ceiling cannot apply to it.
-            # Normalizing the stored values here (rather than only deriving
-            # around them) keeps what diagnostics surface honest about what is
-            # actually in effect.
-            if tilt_only:
-                position_max = None
+            # Same mutual-exclusion pass as min_mode / use_my above: a REAL
+            # fixed tilt (tilt_only + a configured slat angle) wins over
+            # tilt_min/tilt_max on the same axis (issue #514), so the slot's
+            # tilt bounds are dropped only then — a tilt_only slot with no
+            # slat angle configured makes no FIXED claim, and its tilt_min /
+            # tilt_max are exactly what the slot exists to enforce (issue
+            # #1215). tilt_only, on the bare flag, always disclaims the
+            # position axis regardless of whether a slat angle is set — the
+            # My path is likewise hardware-pinned, so a position ceiling
+            # cannot apply to either. Normalizing the stored values here
+            # (rather than only deriving around them) keeps what diagnostics
+            # surface honest about what is actually in effect.
+            if has_fixed_tilt(tilt_only=tilt_only, tilt=tilt):
                 tilt_min = None
                 tilt_max = None
-            elif use_my:
+            if tilt_only or use_my:
                 position_max = None
 
             state = CustomPositionSensorState(

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -216,8 +216,11 @@ class CustomPositionSensorState:
     # same pre-inversion canonical space as ``position`` / ``tilt``.
     #
     # ``position_max`` is normalized off on the ``use_my`` path (hardware-pinned)
-    # and by ``tilt_only``; ``tilt_min`` / ``tilt_max`` are normalized off by
-    # ``tilt_only`` (a FIXED tilt claim wins over bounds on the same axis).
+    # and by ``tilt_only``; ``tilt_min`` / ``tilt_max`` are normalized off only
+    # when the slot names an actual fixed slat angle (``has_fixed_tilt``) — a
+    # real FIXED tilt claim wins over bounds on the same axis. A bare
+    # ``tilt_only`` flag with no configured slat angle is a vacuous claim and
+    # leaves ``tilt_min`` / ``tilt_max`` intact (issue #1215).
     position_max: int | None = None
     tilt_min: int | None = None
     tilt_max: int | None = None

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -124,6 +124,24 @@ def derive_axis_mode(
     return AxisConstraintMode.NONE
 
 
+def has_fixed_tilt(*, tilt_only: bool, tilt: int | None) -> bool:
+    """Whether a slot's ``tilt_only`` flag names an actual FIXED tilt claim.
+
+    ``tilt_only`` conflates two different claims: it *always* disclaims the
+    position axis (issue #514 — see :attr:`CustomPositionSensorState.position_mode`,
+    which keys on the bare flag and is unaffected by this predicate), but it
+    only outranks ``tilt_min``/``tilt_max`` bounds on the tilt axis when it
+    also names a slat angle. ``tilt_only=True`` with ``tilt=None`` is a
+    *vacuous* FIXED claim — before issue #1215 that vacuous claim still won
+    the precedence, silently discarding a configured ``tilt_min``/``tilt_max``
+    and leaving the slot completely inert. Callers that need the FIXED-vs-
+    bounds precedence (:attr:`CustomPositionSensorState.tilt_mode`, the
+    snapshot-builder tilt-bound wipe, and the config-summary rendering
+    branch) must test this predicate, not the bare ``tilt_only`` flag.
+    """
+    return tilt_only and tilt is not None
+
+
 @dataclass(frozen=True, slots=True)
 class CustomPositionSensorState:
     """Per-slot trigger reading carried in the pipeline snapshot.
@@ -230,6 +248,10 @@ class CustomPositionSensorState:
 
         ``tilt_only`` wins the whole slot: it fixes the slat angle and lets the
         position pipeline drive the carriage, so it claims nothing here.
+        Deliberately keyed on the bare flag, unlike :attr:`tilt_mode` (issue
+        #1215) — a tilt-only slot disclaims the position axis whether or not
+        it also names a slat angle, so this must NOT route through
+        :func:`has_fixed_tilt`.
         """
         if self.tilt_only:
             return AxisConstraintMode.NONE
@@ -243,17 +265,16 @@ class CustomPositionSensorState:
     def tilt_mode(self) -> AxisConstraintMode:
         """This slot's derived claim on the tilt axis (issue #943).
 
-        ``tilt_only`` is an exact (``FIXED``) tilt claim and wins over the
-        bounds — mirroring the precedence it already has over ``min_mode`` /
-        ``use_my``. A tilt-only slot with no configured slat angle claims
-        nothing (pre-#943 behavior, preserved).
+        A real FIXED tilt claim (``tilt_only`` *with* a configured slat
+        angle) wins over the bounds — mirroring the precedence it already has
+        over ``min_mode`` / ``use_my``. A tilt-only slot with no configured
+        slat angle makes no FIXED claim (issue #1215): it falls through to
+        the same bound derivation as any other slot, so a constraint-only
+        "tilt_only + tilt_min" slot still emits its floor instead of going
+        silently inert.
         """
-        if self.tilt_only:
-            return (
-                AxisConstraintMode.FIXED
-                if self.tilt is not None
-                else AxisConstraintMode.NONE
-            )
+        if has_fixed_tilt(tilt_only=self.tilt_only, tilt=self.tilt):
+            return AxisConstraintMode.FIXED
         return derive_axis_mode(fixed=None, low=self.tilt_min, high=self.tilt_max)
 
     @property

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -90,7 +90,9 @@
     "custom_and_no_sensors": "⚠️ {label}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
     "group_empty": "⚠️ Diese Gruppe hat keine Mitglieder – sie wird nichts steuern.",
     "forecast_source_no_weather_entity": "⚠️ Außentemperaturquelle basiert auf Vorhersage, aber es ist keine Wetter-Entität konfiguriert — die Vorhersage wird stillschweigend auf den Live-Messwert zurückfallen. Konfigurieren Sie eine Wetter-Entität unter Wetter, Licht & Wolken.",
-    "travel_time_unmeasurable": "⚠️ {entities} melden einen angenommenen Zustand, daher kann ihre Laufzeit nicht gemessen werden und keine wurde eingegeben — Dashboards zeigen keine Bewegung. Geben Sie eine Zeit unter Kalibrierung → Laufzeit ein."
+    "travel_time_unmeasurable": "⚠️ {entities} melden einen angenommenen Zustand, daher kann ihre Laufzeit nicht gemessen werden und keine wurde eingegeben — Dashboards zeigen keine Bewegung. Geben Sie eine Zeit unter Kalibrierung → Laufzeit ein.",
+    "custom_tilt_only_bounds_discarded": "⚠️ {label}: Lamelle auf {slat}% fixiert — die konfigurierten Neigungsgrenzen werden für diesen Slot ignoriert.",
+    "custom_tilt_only_no_effect": "⚠️ {label}: Nur Neigung ist aktiviert, ohne Lamellenwinkel und ohne Neigungsgrenzen — dieser Slot hat keine Auswirkung."
   },
   "motion": {
     "action_hold": "Behänge halten aktuelle Position (zurück zum Standard, wenn Sonne den Sonnen-Akzeptanzwinkel verlässt)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -81,6 +81,8 @@
   "warnings": {
     "custom_position_bound_conflict": "⚠️ {label}: the maximum ({max}%) is below the minimum ({min}%) — the minimum wins and the maximum is ignored.",
     "custom_tilt_only_conflict": "⚠️ {label}: tilt only is on — Use as minimum / Use My position are ignored for this slot.",
+    "custom_tilt_only_bounds_discarded": "⚠️ {label}: slat fixed at {slat}% — the configured tilt bounds are ignored for this slot.",
+    "custom_tilt_only_no_effect": "⚠️ {label}: tilt only is on with no slat angle and no tilt bounds configured — this slot has no effect.",
     "motion_hold_no_sensors": "⚠️ hold_position mode is set but no occupancy sources are configured — the setting has no effect until an occupancy source is added",
     "cloudy_pos_ignored": "⚠️ Cloudy position ({pos}%) configured but cloud suppression is disabled — value will be ignored.",
     "sun_track_min_below_floor": "⚠️ Sun-tracking min {sun_min}% < min position {min_pos}% — always-on floor dominates; sun-tracking floor will be raised to {min_pos}%.",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -90,7 +90,9 @@
     "custom_and_no_sensors": "⚠️ {label} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
     "group_empty": "⚠️ Ce groupe n'a pas de membres — il ne commandera rien.",
     "forecast_source_no_weather_entity": "⚠️ La source de température extérieure est basée sur les prévisions mais aucune entité météo n'est configurée — les prévisions vont silencieusement revenir au relevé en direct. Configurez une entité météo dans Météo, lumière & nuages.",
-    "travel_time_unmeasurable": "⚠️ {entities} signalent un état supposé, donc leur temps de course ne peut pas être mesuré et aucun n'a été entré — les tableaux de bord ne les montreront pas en mouvement. Entrez une durée sous Étalonnage → Temps de course."
+    "travel_time_unmeasurable": "⚠️ {entities} signalent un état supposé, donc leur temps de course ne peut pas être mesuré et aucun n'a été entré — les tableaux de bord ne les montreront pas en mouvement. Entrez une durée sous Étalonnage → Temps de course.",
+    "custom_tilt_only_bounds_discarded": "⚠️ {label} : lamelle fixée à {slat}% — les limites d'inclinaison configurées sont ignorées pour cet emplacement.",
+    "custom_tilt_only_no_effect": "⚠️ {label} : inclinaison seulement est activé sans angle de lamelle et sans limite d'inclinaison configurée — cet emplacement n'a aucun effet."
   },
   "motion": {
     "action_hold": "les stores maintiennent la position actuelle (retournent à la position par défaut quand le soleil quitte l'angle d'ouverture solaire)",

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -2875,7 +2875,8 @@ def test_custom_position_tilt_only_without_fixed_tilt_no_phantom_minimum():
     into the bound-rendering branch must not expose it to a phantom
     '(as minimum)' fragment, nor a phantom position target. The runtime
     normalizes min_mode off for ANY tilt_only slot regardless of whether a
-    slat angle is configured (snapshot_builder.py:617-619), and
+    slat angle is configured (snapshot_builder.py's tilt_only mutual-
+    exclusion normalization, keyed on the bare flag), and
     ``position_mode`` is NONE for every tilt_only slot too (types.py's
     ``position_mode`` keys on the bare flag) — so a stored
     ``custom_position_N`` must not render as a target the handler never
@@ -2916,6 +2917,98 @@ def test_custom_position_tilt_only_without_fixed_tilt_no_phantom_ceiling():
     custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
     assert "(at most 60%)" not in custom_line
     assert "at least 50%" in custom_line
+
+
+def test_custom_position_use_my_no_phantom_ceiling():
+    """Issue #1215 round-2 audit finding 1: a ``use_my`` slot (no
+    ``tilt_only``) with no stored position must not render a phantom
+    position ceiling either. ``snapshot_builder.py`` wipes ``position_max``
+    on the ``use_my`` path the same way it does for ``tilt_only`` (``if
+    tilt_only or use_my: position_max = None``), so a stored
+    ``custom_position_position_max_N`` must not surface as '(at most N%)'
+    when only ``use_my`` is set.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.door",
+        "custom_position_priority_1": 77,
+        "custom_position_use_my_1": True,
+        "custom_position_position_max_1": 60,
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
+    assert "(at most 60%)" not in custom_line
+
+
+def test_custom_position_tilt_only_with_fixed_tilt_warns_bounds_discarded():
+    """Issue #1215 round-2 audit finding 2: a REAL fixed tilt (``tilt_only``
+    + a configured slat angle) still deliberately outranks ``tilt_min`` /
+    ``tilt_max`` on the same slot — the #514 precedence this fix preserves —
+    but nothing told the user their configured bounds are being discarded.
+    Warn.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.glare",
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_1": 30,
+        "custom_position_tilt_only_1": True,
+        "custom_position_tilt_min_1": 50,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    warn_line = next(ln for ln in summary.splitlines() if "⚠️" in ln and "30%" in ln)
+    assert "ignored" in warn_line.lower()
+
+
+def test_custom_position_tilt_only_no_bounds_no_discard_warning():
+    """No ``tilt_min``/``tilt_max`` configured alongside a real fixed tilt ->
+    no 'bounds discarded' warning — there is nothing to discard.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.glare",
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_1": 30,
+        "custom_position_tilt_only_1": True,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    assert "ignored for this slot" not in summary.lower()
+
+
+def test_custom_position_tilt_only_fully_inert_warns_no_effect():
+    """Issue #1215 round-2 audit finding 6: a tilt_only slot with no slat
+    angle AND no tilt bounds has ``position_mode == NONE`` and
+    ``tilt_mode == NONE`` — it does nothing at all. Warn so the user isn't
+    left wondering why nothing moves.
+
+    ``custom_position_position_max_1`` is set purely so the slot passes
+    ``custom_position_slot_configured`` (a trigger alone needs at least one
+    claim key to participate at all) — ``tilt_only`` nulls it right back out
+    regardless, per its own unconditional position-axis disclaim, which is
+    exactly the inert combination this warning exists to catch.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.door",
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_only_1": True,
+        "custom_position_position_max_1": 60,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    warn_line = next(
+        ln for ln in summary.splitlines() if "⚠️" in ln and "no effect" in ln.lower()
+    )
+    assert "Custom #1" in warn_line or "#1" in warn_line
+
+
+def test_custom_position_tilt_only_with_bound_no_no_effect_warning():
+    """A tilt_only slot WITH a configured tilt bound is not inert — no
+    'no effect' warning fires for it.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.door",
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_only_1": True,
+        "custom_position_tilt_min_1": 50,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    assert "no effect" not in summary.lower()
 
 
 def test_weather_state_list_in_cloud_line():

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -2873,11 +2873,14 @@ def test_custom_position_tilt_only_without_fixed_tilt_renders_bound():
 def test_custom_position_tilt_only_without_fixed_tilt_no_phantom_minimum():
     """Issue #1215 residual risk: routing a tilt_only-without-fixed-tilt slot
     into the bound-rendering branch must not expose it to a phantom
-    '(as minimum)' fragment. The runtime normalizes min_mode off for ANY
-    tilt_only slot regardless of whether a slat angle is configured
-    (snapshot_builder.py:617-619), so the summary must match — while the
-    mutual-exclusion ⚠️ warning still fires, since reporting the conflict is
-    its job.
+    '(as minimum)' fragment, nor a phantom position target. The runtime
+    normalizes min_mode off for ANY tilt_only slot regardless of whether a
+    slat angle is configured (snapshot_builder.py:617-619), and
+    ``position_mode`` is NONE for every tilt_only slot too (types.py's
+    ``position_mode`` keys on the bare flag) — so a stored
+    ``custom_position_N`` must not render as a target the handler never
+    claims. The mutual-exclusion ⚠️ warning still fires, since reporting the
+    conflict is its job.
     """
     cfg = {
         "custom_position_sensor_1": "binary_sensor.door",
@@ -2890,7 +2893,29 @@ def test_custom_position_tilt_only_without_fixed_tilt_no_phantom_minimum():
     summary = _build_config_summary(cfg, CoverType.VENETIAN)
     custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
     assert "(as minimum)" not in custom_line
+    assert "→ 80%" not in custom_line
+    assert "the calculated position" in custom_line
     assert "⚠️" in summary
+
+
+def test_custom_position_tilt_only_without_fixed_tilt_no_phantom_ceiling():
+    """Issue #1215 finding 2: a tilt_only slot with no fixed slat angle must
+    not render a phantom position ceiling either. snapshot_builder.py wipes
+    ``position_max`` for EVERY tilt_only slot (bare flag, regardless of a
+    fixed tilt), so a stored ``custom_position_position_max_N`` must not
+    surface as '(at most N%)' — the handler makes no position claim to cap.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.door",
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_only_1": True,
+        "custom_position_tilt_min_1": 50,
+        "custom_position_position_max_1": 60,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
+    assert "(at most 60%)" not in custom_line
+    assert "at least 50%" in custom_line
 
 
 def test_weather_state_list_in_cloud_line():

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -2853,6 +2853,46 @@ def test_custom_position_tilt_only_no_warning_when_alone():
     assert warning_lines == []
 
 
+def test_custom_position_tilt_only_without_fixed_tilt_renders_bound():
+    """Issue #1215: tilt_only + tilt_min with NO fixed slat angle must render
+    the actual configured bound, not the phantom 'slat fixed at 0%' claim —
+    nothing is fixed at 0% and the slot is not inert.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.door",
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_only_1": True,
+        "custom_position_tilt_min_1": 50,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
+    assert "at least 50%" in custom_line
+    assert "slat fixed at 0%" not in custom_line
+
+
+def test_custom_position_tilt_only_without_fixed_tilt_no_phantom_minimum():
+    """Issue #1215 residual risk: routing a tilt_only-without-fixed-tilt slot
+    into the bound-rendering branch must not expose it to a phantom
+    '(as minimum)' fragment. The runtime normalizes min_mode off for ANY
+    tilt_only slot regardless of whether a slat angle is configured
+    (snapshot_builder.py:617-619), so the summary must match — while the
+    mutual-exclusion ⚠️ warning still fires, since reporting the conflict is
+    its job.
+    """
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.door",
+        "custom_position_1": 80,
+        "custom_position_priority_1": 77,
+        "custom_position_tilt_only_1": True,
+        "custom_position_tilt_min_1": 50,
+        "custom_position_min_mode_1": True,
+    }
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
+    assert "(as minimum)" not in custom_line
+    assert "⚠️" in summary
+
+
 def test_weather_state_list_in_cloud_line():
     """CONF_WEATHER_STATE list renders as 'weather in {state, state}' on the cloud line."""
     from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.cover_types.venetian import VenetianPolicy
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
 
@@ -809,6 +809,117 @@ class TestEngineTiltBounds:
         _, low = self._resolve(monkeypatch, 10, tilt_low=40, tilt_high=80)
         _, high = self._resolve(monkeypatch, 95, tilt_low=40, tilt_high=80)
         assert (low.tilt, high.tilt) == (40, 80)
+
+
+class TestTiltBoundFromTiltOnlySlotWithoutFixedTilt:
+    """issue #1215: the reporter's exact configuration, end-to-end.
+
+    A custom-position slot is ``tilt_only=True`` with NO fixed slat angle and
+    a ``tilt_min`` of 50 — the exact stored options from the reporter's
+    diagnostics. Solar wins the pipeline with ``tilt=None`` (a venetian
+    resolves its slat angle only after the pipeline runs, in
+    ``post_pipeline_resolve``); the bound must still be carried onto the
+    ``PipelineResult`` and clamp whatever the venetian engine computes.
+    """
+
+    @staticmethod
+    def _pipeline_result():
+        """Run the real registry — SolarHandler + the reporter's slot."""
+        from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+            CustomPositionHandler,
+        )
+        from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
+            DefaultHandler,
+        )
+        from custom_components.adaptive_cover_pro.pipeline.handlers.solar import (
+            SolarHandler,
+        )
+        from custom_components.adaptive_cover_pro.pipeline.registry import (
+            PipelineRegistry,
+        )
+        from custom_components.adaptive_cover_pro.pipeline.types import (
+            CustomPositionSensorState,
+        )
+        from tests.test_pipeline.conftest import make_snapshot
+
+        state = CustomPositionSensorState(
+            entity_ids=("binary_sensor.slot1",),
+            is_on=True,
+            position=None,
+            priority=77,
+            min_mode=False,
+            use_my=False,
+            tilt=None,
+            tilt_only=True,
+            slot=1,
+            active_entity_ids=("binary_sensor.slot1",),
+            tilt_min=50,
+        )
+        registry = PipelineRegistry(
+            [
+                SolarHandler(),
+                DefaultHandler(),
+                CustomPositionHandler(slot=1, position=None, priority=77, tilt=None),
+            ]
+        )
+        snap = make_snapshot(
+            custom_position_sensors=[state],
+            default_position=0,
+            direct_sun_valid=True,
+        )
+        result = registry.evaluate(snap)
+        assert result.control_method == ControlMethod.SOLAR
+        assert result.tilt is None
+        # Nothing resolved a tilt yet, so the bound rides the result instead
+        # of being clamped in-pipeline (registry.py:1072-1078) — this is the
+        # carry the venetian engine consumes below.
+        assert (result.tilt_low, result.tilt_high) == (50, None)
+        return result
+
+    def test_tilt_bound_from_tilt_only_slot_clamps_engine_tilt(
+        self, monkeypatch
+    ) -> None:
+        """The reporter's exact scenario: engine resolves 46 → clamped to 50."""
+        pipeline_result = self._pipeline_result()
+        policy = _make_policy()
+        monkeypatch.setattr(
+            VenetianPolicy,
+            "_compose_tilt",
+            lambda self, *a, **kw: (46, MagicMock()),
+        )
+        monkeypatch.setattr(
+            VenetianPolicy, "_engine_tilt_suppressed", lambda self, r, c: False
+        )
+        resolved = policy.post_pipeline_resolve(pipeline_result, **_solar_kwargs())
+        assert resolved.tilt == 50
+        # Distinguish the applied clamp (REGISTRY_TILT_CLAMPED, matched=True)
+        # from the earlier "bound carried, nothing to clamp yet" step the
+        # registry also files under handler="tilt_clamp" (registry.py:1079-1093).
+        assert any(
+            s.reason_payload is not None
+            and s.reason_payload.code == ReasonCode.REGISTRY_TILT_CLAMPED
+            for s in resolved.decision_trace
+        )
+
+    def test_engine_tilt_above_bound_passes_through(self, monkeypatch) -> None:
+        """The reporter's acceptance pair: a calculated 75% stays 75%."""
+        pipeline_result = self._pipeline_result()
+        policy = _make_policy()
+        monkeypatch.setattr(
+            VenetianPolicy,
+            "_compose_tilt",
+            lambda self, *a, **kw: (75, MagicMock()),
+        )
+        monkeypatch.setattr(
+            VenetianPolicy, "_engine_tilt_suppressed", lambda self, r, c: False
+        )
+        resolved = policy.post_pipeline_resolve(pipeline_result, **_solar_kwargs())
+        assert resolved.tilt == 75
+        assert not any(
+            s.reason_payload is not None
+            and s.reason_payload.code == ReasonCode.REGISTRY_TILT_CLAMPED
+            for s in resolved.decision_trace
+        )
 
 
 class TestPerCoverHoldDispatchPremise:

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -11,7 +11,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.cover_types.venetian import VenetianPolicy
-from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
+from custom_components.adaptive_cover_pro.const import (
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+    ControlMethod,
+    ReasonCode,
+)
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
 
@@ -846,7 +850,7 @@ class TestTiltBoundFromTiltOnlySlotWithoutFixedTilt:
             entity_ids=("binary_sensor.slot1",),
             is_on=True,
             position=None,
-            priority=77,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             min_mode=False,
             use_my=False,
             tilt=None,
@@ -859,7 +863,12 @@ class TestTiltBoundFromTiltOnlySlotWithoutFixedTilt:
             [
                 SolarHandler(),
                 DefaultHandler(),
-                CustomPositionHandler(slot=1, position=None, priority=77, tilt=None),
+                CustomPositionHandler(
+                    slot=1,
+                    position=None,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+                    tilt=None,
+                ),
             ]
         )
         snap = make_snapshot(

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -330,6 +330,17 @@ class TestTiltBounds:
         res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=20))
         assert (res.tilt_low, res.tilt_high) == (None, None)
 
+    def test_tilt_only_without_fixed_tilt_still_clamps_winner_tilt(self) -> None:
+        """Issue #1215: tilt_only + tilt_min on the SAME slot, with no fixed
+        slat angle, must clamp a tilt the winner already set — exactly like a
+        plain tilt_min slot (``test_tilt_min_raises_winner_tilt`` above). A
+        vacuous ``tilt_only`` FIXED claim must not swallow the bound.
+        """
+        res = _evaluate(
+            [_slot(1, tilt_only=True, tilt_min=50)], winner=_StubWinner(50, tilt=46)
+        )
+        assert res.tilt == 50
+
 
 class TestTiltOnlyOverlayThenClamp:
     """FIXED fills when unset; bounds then clamp the filled value."""

--- a/tests/test_pipeline/test_axis_constraints.py
+++ b/tests/test_pipeline/test_axis_constraints.py
@@ -375,6 +375,41 @@ class TestGatherTiltFixedParity:
         snap = _snapshot(sensors=[_slot(1, position=30, tilt=50, tilt_only=True)])
         assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
 
+    def test_tilt_only_without_fixed_tilt_still_emits_tilt_bound(self) -> None:
+        """Issue #1215: tilt_only + tilt_min with NO fixed slat angle must
+        still emit a tilt bound, not vanish. ``tilt_only`` alone is a vacuous
+        FIXED claim when no slat angle is configured — it must fall through
+        to the tilt_min/tilt_max derivation instead of suppressing it.
+        """
+        snap = _snapshot(sensors=[_slot(1, tilt=None, tilt_only=True, tilt_min=50)])
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)
+        assert len(cs) == 1
+        assert cs[0].axis == AXIS_NAME_TILT
+        assert cs[0].kind is AxisConstraintMode.MIN
+        assert cs[0].low == 50
+        assert cs[0].high is None
+        assert cs[0].slot == 1
+
+    def test_tilt_only_without_fixed_tilt_makes_no_position_claim(self) -> None:
+        """Issue #1215: the tilt-bound fix must not leak onto the position
+        axis — tilt_only still disclaims position with no slat angle set.
+        """
+        snap = _snapshot(sensors=[_slot(1, tilt=None, tilt_only=True, tilt_min=50)])
+        snap_sensor = snap.custom_position_sensors[0]
+        assert snap_sensor.position_mode is AxisConstraintMode.NONE
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
+
+    def test_tilt_only_with_fixed_tilt_still_outranks_bounds(self) -> None:
+        """Issue #1215 regression guard: a REAL fixed tilt must still outrank
+        tilt_min/tilt_max on the same slot — the #514 precedence is preserved.
+        """
+        snap = _snapshot(sensors=[_slot(1, tilt=20, tilt_only=True, tilt_min=50)])
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)
+        assert len(cs) == 1
+        assert cs[0].kind is AxisConstraintMode.FIXED
+        assert cs[0].low == 20
+        assert cs[0].high == 20
+
     def test_tilt_fixed_carries_slot_metadata(self) -> None:
         """Source/label/slot mirror TiltAxisContribution."""
         snap = _snapshot(

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -1371,6 +1371,53 @@ def test_tilt_only_wins_over_tilt_bounds():
     assert state.tilt_max is None
 
 
+@pytest.mark.unit
+def test_tilt_only_without_fixed_tilt_preserves_tilt_bounds():
+    """Issue #1215: tilt_only + tilt_min with NO fixed slat angle must NOT be
+    wiped. ``tilt_only`` alone (no ``tilt``) is a vacuous FIXED claim — it
+    must not suppress the tilt_min the slot was actually configured for.
+    """
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {keys["tilt_only"]: True, keys["tilt_min"]: 50},
+    )
+    assert state.tilt_min == 50
+    assert state.tilt_mode is AxisConstraintMode.MIN
+
+
+@pytest.mark.unit
+def test_tilt_only_with_fixed_tilt_still_wipes_tilt_bounds():
+    """Issue #1215 regression guard: a REAL fixed tilt still wins and wipes
+    the stored bound — the #514 precedence is preserved unchanged.
+    """
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {keys["tilt"]: 20, keys["tilt_only"]: True, keys["tilt_min"]: 50},
+    )
+    assert state.tilt_min is None
+    assert state.tilt_mode is AxisConstraintMode.FIXED
+
+
+@pytest.mark.unit
+def test_tilt_only_still_wipes_position_max_without_fixed_tilt():
+    """Issue #1215: the position-axis disclaimer stays keyed on the bare
+    ``tilt_only`` flag regardless of whether a slat angle is configured — a
+    tilt-only slot always disclaims the position axis (issue #514).
+    """
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {
+            keys["tilt_only"]: True,
+            keys["tilt_min"]: 50,
+            keys["position_max"]: 60,
+        },
+    )
+    assert state.position_max is None
+
+
 # ---------------------------------------------------------------------------
 # acp self-reference namespace in custom-position slot templates (issue #1159)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A Custom Position slot with `Tilt only` enabled, **no fixed slat angle**, and a `Minimum tilt` silently discarded the bound and went completely inert: it claimed no position, emitted no constraint, and never clamped the solar tilt.

`tilt_only` conflates two claims. It always disclaims the position axis, but it only outranks `tilt_min`/`tilt_max` when it also names a slat angle. With `tilt is None` that FIXED claim is vacuous, so the bounds were thrown away in favour of nothing, at two independent sites: the `tilt_mode` derivation in `pipeline/types.py` and the normalization wipe in `pipeline/snapshot_builder.py`. Everything downstream (`gather_axis_constraints` -> `compose_bounds` -> the registry gate -> `VenetianPolicy.post_pipeline_resolve`'s `clamp_to_bounds`) was already correct: it just never received a constraint. The config summary rendered a phantom "slat fixed at 0%" for the same configuration.

This keys the FIXED-tilt precedence on an actual fixed tilt via one shared `has_fixed_tilt()` predicate, delegated to from all three sites. The position-axis disclaimer deliberately stays on the bare flag. The #514 precedence (a real fixed slat angle outranks bounds) is preserved exactly, and the new path emits a `MIN` and never a `FIXED`, so the `_pin_tilt_only_carriage` guards from #1157 are behaviourally untouched. Existing stored configs are fixed with no user action, no new option, and no migration.

Two follow-on commits: the config summary no longer claims a position target or ceiling for tilt-only slots (nor a ceiling for My slots, which the snapshot builder wipes the same way), and new warnings fire when a real fixed slat angle discards configured tilt bounds or when a tilt-only slot has no effect at all. The two new summary strings are synced to DE and FR.

## Testing

- ✅ 12817 tests passing

Verified by a 240-combination sweep comparing `_build_config_summary` against `PipelineSnapshotBuilder.read_custom_position_sensors` across every slot claim/flag dimension: 0 mismatches.

## Related Issues

Refs #1215