### PR TITLE
fix: give default-position handlers their own sunset tilt (#1214)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1869,9 +1869,12 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "blind_spot.elevation_above": "above {elev}° elevation",
     # --- Default fallback (0) ---
     "rules.default": "🌙 Default (no rule matches) → {default_pos}%",
-    "default.tilt": ("  ↳ Default tilt: {tilt}% (used when no handler wins control)"),
+    "default.tilt": (
+        "  ↳ Default tilt: {tilt}% (used whenever the position falls back to default)"
+    ),
     "default.sunset_tilt": (
-        "  ↳ Sunset tilt: {tilt}% (used when no handler wins control, during sunset)"
+        "  ↳ Sunset tilt: {tilt}% (used whenever the position falls back to default, "
+        "during sunset)"
     ),
     # --- Position limits ---
     "headers.position_limits": "**Position Limits**",

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -682,7 +682,7 @@ CONF_DAYTIME_GATE_TEMPLATE_MODE = "daytime_gate_template_mode"  # TemplateCombin
 # genuinely needs its own window takes it as a constructor argument.
 DEFAULT_CONDITION_GATE_GRACE_SECONDS = 120.0
 # Explicit tilt for venetian covers (0-100). None = use solar-computed tilt.
-CONF_DEFAULT_TILT = "default_tilt"  # tilt when no handler fires
+CONF_DEFAULT_TILT = "default_tilt"  # tilt when the position falls back to default
 CONF_SUNSET_TILT = (
     "sunset_tilt"  # tilt during sunset window (falls back to default_tilt)
 )

--- a/custom_components/adaptive_cover_pro/pipeline/__init__.py
+++ b/custom_components/adaptive_cover_pro/pipeline/__init__.py
@@ -8,6 +8,7 @@ from .handler import OverrideHandler
 from .helpers import (
     apply_snapshot_limits,
     compute_default_position,
+    compute_default_tilt,
     compute_raw_calculated_position,
     compute_solar_position,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "PipelineResult",
     "apply_snapshot_limits",
     "compute_default_position",
+    "compute_default_tilt",
     "compute_raw_calculated_position",
     "compute_solar_position",
 ]

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -476,10 +476,12 @@ class ClimateHandler(OverrideHandler):
       branch only carries the effective default/sunset tilt (issue #1214)
       when the matched rule RESOLVED its position from the default —
       TRACKING_SEASON_GATE and the NORMAL-table LOW_LIGHT branch (_default)
-      qualify; the TILT-table LOW_LIGHT branch (_solar) does not, and stays
-      untilted so a solar-tracked slat angle is never overwritten by the
-      configured default tilt. ClimateRule.resolves_default_position carries
-      that provenance out of the rule table — see its docstring.
+      qualify; the TILT-table LOW_LIGHT branch (_solar) does not. That still
+      holds when the sun is invalid and _solar falls back to
+      ctx.default_position — the branch stays labelled solar, not a
+      default-position resolution, so it stays untilted either way.
+      ClimateRule.resolves_default_position carries that provenance out of
+      the rule table — see its docstring.
     - SOLAR for glare control, in any season
     """
 

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -478,8 +478,8 @@ class ClimateHandler(OverrideHandler):
       TRACKING_SEASON_GATE and the NORMAL-table LOW_LIGHT branch (_default)
       qualify; the TILT-table LOW_LIGHT branch (_solar) does not. That still
       holds when the sun is invalid and _solar falls back to
-      ctx.default_position — the branch stays labelled solar, not a
-      default-position resolution, so it stays untilted either way.
+      ctx.default_position — the branch's position still comes from _solar,
+      not from a default-position resolution, so it stays untilted either way.
       ClimateRule.resolves_default_position carries that provenance out of
       the rule table — see its docstring.
     - SOLAR for glare control, in any season

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -463,10 +463,14 @@ class ClimateHandler(OverrideHandler):
     - EXTREME_HEAT for the all-day heat hold, DEFAULT for the season gate
     - DEFAULT for the LOW_LIGHT branch. This labels the branch, not the
       position: the rule tables pick that with _default or _solar, so DEFAULT
-      is not a promise the cover sits at its default position. Both DEFAULT
-      branches (season gate + LOW_LIGHT) also carry the effective
-      default/sunset tilt (issue #1214), since they answer with the
-      effective default position.
+      is not a promise the cover sits at its default position. A DEFAULT
+      branch only carries the effective default/sunset tilt (issue #1214)
+      when its position ACTUALLY equals the effective default —
+      TRACKING_SEASON_GATE and the NORMAL-table LOW_LIGHT branch (_default)
+      qualify; the TILT-table LOW_LIGHT branch (_solar) does not, and stays
+      untilted so a solar-tracked slat angle is never overwritten by the
+      configured default tilt. compute_default_tilt's position gate makes
+      this automatic — see its docstring.
     - SOLAR for glare control, in any season
     """
 
@@ -569,13 +573,22 @@ class ClimateHandler(OverrideHandler):
             method = ControlMethod.SOLAR
             season_code = ReasonCode.FRAGMENT_SEASON_GLARE
 
-        # DEFAULT-labelled branches (TRACKING_SEASON_GATE, LOW_LIGHT) return
-        # the effective default position, so they must also carry the
-        # effective default/sunset tilt — otherwise a venetian's sunset_tilt
-        # is unreachable whenever climate outranks DefaultHandler (issue
-        # #1214). Every other branch leaves tilt unset, same as before.
+        # A DEFAULT-labelled branch carries the effective default/sunset tilt
+        # only when its own `position` is genuinely the effective default
+        # (issue #1214) — the ControlMethod.DEFAULT label alone is not that
+        # promise (see the class docstring above). Gating on `method` first
+        # keeps this call off every SOLAR/WINTER/SUMMER/EXTREME_HEAT branch,
+        # so a genuinely solar- or climate-tracked tilt from the venetian
+        # engine is never at risk of being overwritten by a handler-supplied
+        # tilt (post_pipeline_resolve honors a non-None handler tilt
+        # unconditionally). Within the DEFAULT label, compute_default_tilt's
+        # position gate then tells TRACKING_SEASON_GATE / NORMAL-table
+        # LOW_LIGHT (both `_default`) apart from TILT-table LOW_LIGHT
+        # (`_solar`) — only the former two qualify.
         tilt = (
-            compute_default_tilt(snapshot) if method is ControlMethod.DEFAULT else None
+            compute_default_tilt(snapshot, position=position)
+            if method is ControlMethod.DEFAULT
+            else None
         )
 
         return PipelineResult(

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -33,6 +33,7 @@ from ...reason_i18n import Reason, _REASON_TEMPLATES_EN
 from ..handler import OverrideHandler
 from ..helpers import (
     apply_snapshot_limits,
+    compute_default_tilt,
     compute_raw_calculated_position,
     compute_solar_position,
 )
@@ -462,7 +463,10 @@ class ClimateHandler(OverrideHandler):
     - EXTREME_HEAT for the all-day heat hold, DEFAULT for the season gate
     - DEFAULT for the LOW_LIGHT branch. This labels the branch, not the
       position: the rule tables pick that with _default or _solar, so DEFAULT
-      is not a promise the cover sits at its default position
+      is not a promise the cover sits at its default position. Both DEFAULT
+      branches (season gate + LOW_LIGHT) also carry the effective
+      default/sunset tilt (issue #1214), since they answer with the
+      effective default position.
     - SOLAR for glare control, in any season
     """
 
@@ -565,9 +569,19 @@ class ClimateHandler(OverrideHandler):
             method = ControlMethod.SOLAR
             season_code = ReasonCode.FRAGMENT_SEASON_GLARE
 
+        # DEFAULT-labelled branches (TRACKING_SEASON_GATE, LOW_LIGHT) return
+        # the effective default position, so they must also carry the
+        # effective default/sunset tilt — otherwise a venetian's sunset_tilt
+        # is unreachable whenever climate outranks DefaultHandler (issue
+        # #1214). Every other branch leaves tilt unset, same as before.
+        tilt = (
+            compute_default_tilt(snapshot) if method is ControlMethod.DEFAULT else None
+        )
+
         return PipelineResult(
             position=position,
             control_method=method,
+            tilt=tilt,
             reason_payload=Reason(
                 ReasonCode.CLIMATE_ACTIVE,
                 {"season": Reason(season_code), "position": position},

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -45,7 +45,7 @@ from .climate_modes import (
     TILT_WITHOUT_PRESENCE,
     ClimateContext,
     ClimateRule,
-    evaluate_rules,
+    match_rule,
 )
 
 # ---------------------------------------------------------------------------
@@ -182,6 +182,13 @@ class ClimateCoverState:
     snapshot: PipelineSnapshot
     climate_data: ClimateCoverData
     climate_strategy: ClimateStrategy | None = field(default=None, init=False)
+    # Whether the matched rule resolved its position FROM the cover's
+    # configured default (``climate_modes._default``) rather than from solar
+    # tracking, a climate hold, or a configured override. Recorded by ``_run``
+    # at the moment the rule matches — i.e. BEFORE ``get_state`` clamps the
+    # answer — so a min/max limit that moves the value cannot disqualify it
+    # (issue #1214). Stays False until a table has run.
+    position_from_default: bool = field(default=False, init=False)
 
     @property
     def cover(self):
@@ -269,10 +276,12 @@ class ClimateCoverState:
         )
 
     def _run(self, rules: tuple[ClimateRule, ...], *, tilt: bool) -> int | None:
-        """Evaluate a rule table, record the chosen strategy, return its position."""
-        strategy, position = evaluate_rules(rules, self._build_context(tilt=tilt))
-        self.climate_strategy = strategy
-        return position
+        """Match a rule table, record strategy + provenance, return its position."""
+        ctx = self._build_context(tilt=tilt)
+        rule = match_rule(rules, ctx)
+        self.climate_strategy = rule.strategy
+        self.position_from_default = rule.resolves_default_position
+        return rule.position(ctx)
 
     def normal_with_presence(self) -> int | None:
         """Climate strategy for normal covers with occupants present.
@@ -465,12 +474,12 @@ class ClimateHandler(OverrideHandler):
       position: the rule tables pick that with _default or _solar, so DEFAULT
       is not a promise the cover sits at its default position. A DEFAULT
       branch only carries the effective default/sunset tilt (issue #1214)
-      when its position ACTUALLY equals the effective default —
+      when the matched rule RESOLVED its position from the default —
       TRACKING_SEASON_GATE and the NORMAL-table LOW_LIGHT branch (_default)
       qualify; the TILT-table LOW_LIGHT branch (_solar) does not, and stays
       untilted so a solar-tracked slat angle is never overwritten by the
-      configured default tilt. compute_default_tilt's position gate makes
-      this automatic — see its docstring.
+      configured default tilt. ClimateRule.resolves_default_position carries
+      that provenance out of the rule table — see its docstring.
     - SOLAR for glare control, in any season
     """
 
@@ -573,21 +582,27 @@ class ClimateHandler(OverrideHandler):
             method = ControlMethod.SOLAR
             season_code = ReasonCode.FRAGMENT_SEASON_GLARE
 
-        # A DEFAULT-labelled branch carries the effective default/sunset tilt
-        # only when its own `position` is genuinely the effective default
-        # (issue #1214) — the ControlMethod.DEFAULT label alone is not that
-        # promise (see the class docstring above). Gating on `method` first
-        # keeps this call off every SOLAR/WINTER/SUMMER/EXTREME_HEAT branch,
-        # so a genuinely solar- or climate-tracked tilt from the venetian
-        # engine is never at risk of being overwritten by a handler-supplied
-        # tilt (post_pipeline_resolve honors a non-None handler tilt
-        # unconditionally). Within the DEFAULT label, compute_default_tilt's
-        # position gate then tells TRACKING_SEASON_GATE / NORMAL-table
-        # LOW_LIGHT (both `_default`) apart from TILT-table LOW_LIGHT
-        # (`_solar`) — only the former two qualify.
+        # Two gates, two different jobs (issue #1214):
+        #
+        # `method is ControlMethod.DEFAULT` is the SAFETY gate. It keeps this
+        # call off every SOLAR/WINTER/SUMMER/EXTREME_HEAT branch, because
+        # `VenetianPolicy.post_pipeline_resolve` honors a non-None handler
+        # tilt unconditionally — a tilt on a SOLAR branch would silently
+        # switch the geometry engine's slat angle off.
+        #
+        # `position_from_default` is the CORRECTNESS gate. Within the DEFAULT
+        # label it separates the branches that resolved their position from
+        # the configured default (`climate_modes._default`:
+        # TRACKING_SEASON_GATE and the NORMAL-table LOW_LIGHT) from the one
+        # that resolved it from solar tracking (`_solar`: the TILT-table
+        # LOW_LIGHT). It is provenance, recorded when the rule matched, not a
+        # comparison against `compute_default_position` — so the limit clamp
+        # `get_state` applies afterwards (and the sunset bypass that clamp
+        # does NOT share, #128) cannot strip the tilt off a genuine default.
         tilt = (
-            compute_default_tilt(snapshot, position=position)
+            compute_default_tilt(snapshot)
             if method is ControlMethod.DEFAULT
+            and climate_cover_state.position_from_default
             else None
         )
 

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
@@ -201,18 +201,59 @@ class ClimateRule:
     strategy: ClimateStrategy
     position: Callable[[ClimateContext], int | None]
 
+    @property
+    def resolves_default_position(self) -> bool:
+        """Whether this branch answers with the cover's configured DEFAULT position.
+
+        Provenance, not value (issue #1214). The flag keys on the *identity* of
+        the rule's position function, which makes it right in both directions
+        that a value comparison gets wrong:
+
+        * It stays True after ``ClimateCoverState.get_state`` runs the answer
+          through ``apply_snapshot_limits`` — a ``min_position`` floor moving
+          0 % to 20 % does not turn the default position into something else,
+          and the sunset carve-out (#128) means the clamped answer routinely
+          differs from ``compute_default_position``.
+        * It stays False for a branch that merely *lands on* the same number:
+          ``_solar`` on a cover whose tracked position happens to equal the
+          default is still solar tracking.
+
+        ``ClimateHandler`` reads this to decide whether a
+        ``ControlMethod.DEFAULT`` winner has earned the effective
+        default/sunset tilt. ``_default`` is the only position function that
+        answers with ``ctx.default_position``; every other one derives its
+        value from geometry, a climate hold, or a configured override.
+        """
+        return self.position is _default
+
+
+def match_rule(rules: tuple[ClimateRule, ...], ctx: ClimateContext) -> ClimateRule:
+    """Return the first rule whose predicate holds — the evaluator's primitive.
+
+    Every table ends with an always-true catch-all, so a match is guaranteed.
+    Callers that need the matched rule ITSELF (for its ``strategy`` *and* its
+    ``resolves_default_position`` provenance) use this;
+    :func:`evaluate_rules` is the adapter that also applies the position
+    function.
+    """
+    for rule in rules:
+        if rule.predicate(ctx):
+            return rule
+    raise RuntimeError("climate rule table exhausted without a catch-all")
+
 
 def evaluate_rules(
     rules: tuple[ClimateRule, ...], ctx: ClimateContext
 ) -> tuple[ClimateStrategy, int | None]:
     """Return (strategy, position) for the first matching rule.
 
-    Every table ends with an always-true catch-all, so a match is guaranteed.
+    The value-level view of :func:`match_rule`, for callers that need nothing
+    but the outcome. ``ClimateCoverState._run`` goes through ``match_rule``
+    instead because it also has to record the branch's
+    ``resolves_default_position`` provenance (issue #1214).
     """
-    for rule in rules:
-        if rule.predicate(ctx):
-            return rule.strategy, rule.position(ctx)
-    raise RuntimeError("climate rule table exhausted without a catch-all")
+    rule = match_rule(rules, ctx)
+    return rule.strategy, rule.position(ctx)
 
 
 _ALWAYS: Callable[[ClimateContext], bool] = lambda _ctx: True  # noqa: E731

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
@@ -220,8 +220,8 @@ class ClimateRule:
 
         ``ClimateHandler`` reads this to decide whether a
         ``ControlMethod.DEFAULT`` winner has earned the effective
-        default/sunset tilt. ``_default`` is the rule whose position is
-        *always* ``ctx.default_position``, by construction. ``_solar`` can
+        default/sunset tilt. ``_default`` is the position function whose
+        answer is *always* ``ctx.default_position``. ``_solar`` can
         return that same value too — it falls back to
         ``ctx.default_position`` whenever ``direct_sun_valid`` is False —
         but that fallback is still solar tracking, not a default-position

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
@@ -5,7 +5,7 @@ same season-condition expressions (low-light, winter-insulation, winter-heating,
 summer) in slightly different orders. This module factors the shared predicate
 vocabulary into one place (`ClimateContext` properties) and expresses each router
 as an ordered list of `ClimateRule`s evaluated first-match-wins. `ClimateCoverState`
-builds a context and delegates to `evaluate_rules`, preserving the exact branch
+builds a context and delegates to `match_rule`, preserving the exact branch
 order, `ClimateStrategy` labels, and position outputs of the original code.
 """
 
@@ -220,9 +220,13 @@ class ClimateRule:
 
         ``ClimateHandler`` reads this to decide whether a
         ``ControlMethod.DEFAULT`` winner has earned the effective
-        default/sunset tilt. ``_default`` is the only position function that
-        answers with ``ctx.default_position``; every other one derives its
-        value from geometry, a climate hold, or a configured override.
+        default/sunset tilt. ``_default`` is the rule whose position is
+        *always* ``ctx.default_position``, by construction. ``_solar`` can
+        return that same value too — it falls back to
+        ``ctx.default_position`` whenever ``direct_sun_valid`` is False —
+        but that fallback is still solar tracking, not a default-position
+        resolution, so identity (not the resulting number) is what keeps it
+        out.
         """
         return self.position is _default
 

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -80,11 +80,14 @@ class CloudSuppressionHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.CLOUD,
-            # This handler always answers with either the effective default
-            # position or a configured cloudy_position — never a solar-tracked
-            # one — so it always carries the effective default/sunset tilt too
-            # (issue #1214), the same one DefaultHandler would have supplied.
-            tilt=compute_default_tilt(snapshot),
+            # This handler carries the effective default/sunset tilt only on
+            # the sunset and no-cloudy_position branches, where `position` IS
+            # the effective default (issue #1214 finding 1). The
+            # cloudy_position branch answers with a configured override, not
+            # the default — compute_default_tilt's position gate returns
+            # None there rather than stamping the default tilt onto an
+            # unrelated position.
+            tilt=compute_default_tilt(snapshot, position=position),
             reason_payload=Reason(
                 ReasonCode.CLOUD_SUPPRESSION,
                 {

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -66,28 +66,33 @@ class CloudSuppressionHandler(OverrideHandler):
         if not triggers:
             triggers.append(Reason(ReasonCode.FRAGMENT_TRIGGER_SMOOTHING_HOLD))
 
+        # Each branch states its own tilt (issue #1214). The two that resolve
+        # the position from the effective default pair it with the effective
+        # default/sunset tilt; the cloudy_position branch answers with a
+        # configured override, so the slats hold their current angle — the
+        # #1153 rule for hold-type winners. Provenance, not value: a
+        # cloudy_position that happens to equal the default position (0 %
+        # alongside a venetian's default_percentage of 0 %, the #1214
+        # reporter's own config) is still an override.
         cloudy = snapshot.climate_options.cloudy_position
+        tilt: int | None
         if snapshot.is_sunset_active:
             position = compute_default_position(snapshot)
             pos_label = Reason(ReasonCode.FRAGMENT_SUNSET_POSITION)
+            tilt = compute_default_tilt(snapshot)
         elif cloudy is not None:
             position = apply_snapshot_limits(snapshot, cloudy, sun_valid=False)
             pos_label = Reason(ReasonCode.FRAGMENT_CLOUDY_POSITION)
+            tilt = None
         else:
             position = compute_default_position(snapshot)
             pos_label = Reason(ReasonCode.FRAGMENT_DEFAULT_POSITION)
+            tilt = compute_default_tilt(snapshot)
 
         return PipelineResult(
             position=position,
             control_method=ControlMethod.CLOUD,
-            # This handler carries the effective default/sunset tilt only on
-            # the sunset and no-cloudy_position branches, where `position` IS
-            # the effective default (issue #1214 finding 1). The
-            # cloudy_position branch answers with a configured override, not
-            # the default — compute_default_tilt's position gate returns
-            # None there rather than stamping the default tilt onto an
-            # unrelated position.
-            tilt=compute_default_tilt(snapshot, position=position),
+            tilt=tilt,
             reason_payload=Reason(
                 ReasonCode.CLOUD_SUPPRESSION,
                 {

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -8,6 +8,7 @@ from ..handler import OverrideHandler
 from ..helpers import (
     apply_snapshot_limits,
     compute_default_position,
+    compute_default_tilt,
     compute_raw_calculated_position,
 )
 from ..types import PipelineResult, PipelineSnapshot
@@ -79,6 +80,11 @@ class CloudSuppressionHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.CLOUD,
+            # This handler always answers with either the effective default
+            # position or a configured cloudy_position — never a solar-tracked
+            # one — so it always carries the effective default/sunset tilt too
+            # (issue #1214), the same one DefaultHandler would have supplied.
+            tilt=compute_default_tilt(snapshot),
             reason_payload=Reason(
                 ReasonCode.CLOUD_SUPPRESSION,
                 {

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/default.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/default.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from ...const import ControlMethod, ReasonCode
-from ...position_utils import PositionConverter
 from ...reason_i18n import Reason
 from ..handler import OverrideHandler
-from ..helpers import compute_default_position
+from ..helpers import compute_default_position, compute_default_tilt
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -26,31 +25,10 @@ class DefaultHandler(OverrideHandler):
         position = compute_default_position(snapshot)
         # Resolve tilt: sunset_tilt takes precedence during the sunset window,
         # then fall back to default_tilt. None means the venetian policy will
-        # use solar-computed tilt instead.
-        # Sunset tilt (and its default_tilt fallback) is a deliberate carve-out
-        # and stays UNclamped, mirroring the sunset *position* bypass (#128).
-        # Only the non-sunset default_tilt honors the global min_tilt/max_tilt
-        # clamp (#503) — exactly as default *position* is clamped. tilt is None
-        # for non-venetian covers, so the clamp is a natural no-op there (no
-        # cover-type string branch needed).
-        tilt: int | None
-        if snapshot.is_sunset_active:
-            tilt = (
-                snapshot.sunset_tilt
-                if snapshot.sunset_tilt is not None
-                else snapshot.default_tilt
-            )
-        else:
-            tilt = snapshot.default_tilt
-            if tilt is not None:
-                tilt = PositionConverter.apply_tilt_limits(
-                    tilt,
-                    snapshot.min_tilt,
-                    snapshot.max_tilt,
-                    snapshot.min_tilt_sun_only,
-                    snapshot.max_tilt_sun_only,
-                    sun_valid=False,
-                )
+        # use solar-computed tilt instead. See compute_default_tilt for the
+        # #503 clamp / #128 carve-out this delegates to (issue #1214: shared
+        # with every other handler that answers with the default position).
+        tilt = compute_default_tilt(snapshot)
         # "Use My at sunset" path: route through the cover's hardware-stored My preset
         # when the sunset window is active and the user has opted in.
         if (

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/default.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/default.py
@@ -27,7 +27,11 @@ class DefaultHandler(OverrideHandler):
         # then fall back to default_tilt. None means the venetian policy will
         # use solar-computed tilt instead. See compute_default_tilt for the
         # #503 clamp / #128 carve-out this delegates to (issue #1214: shared
-        # with every other handler that answers with the default position).
+        # with every other handler branch that resolves from the default
+        # position). Resolved once, above the branch split, because BOTH of
+        # this handler's branches are the default by construction — "Use My
+        # at sunset" substitutes the hardware preset for the *position* only
+        # and still owes the configured sunset tilt.
         tilt = compute_default_tilt(snapshot)
         # "Use My at sunset" path: route through the cover's hardware-stored My preset
         # when the sunset window is active and the user has opted in.

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -75,15 +75,13 @@ class MotionTimeoutHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.MOTION,
-            # This return-to-default branch answers with the effective default
-            # position, so it also carries the effective default/sunset tilt
-            # (issue #1214) — the same one DefaultHandler would have supplied.
-            # The position gate is a no-op here (this branch's `position` IS
-            # compute_default_position(snapshot)) but is passed anyway to keep
-            # every handler using the same "earn the tilt by position, not by
-            # label" invariant. The hold_position branch above deliberately
-            # stays untilted.
-            tilt=compute_default_tilt(snapshot, position=position),
+            # This return-to-default branch resolves its position from the
+            # effective default, so it also carries the effective
+            # default/sunset tilt (issue #1214) — the same one DefaultHandler
+            # would have supplied. The hold_position branch above resolves
+            # from the cover's own current position and deliberately stays
+            # untilted (skip_command, #1153 hold semantics).
+            tilt=compute_default_tilt(snapshot),
             reason_payload=Reason(
                 ReasonCode.OCCUPANCY_LABEL,
                 {"pos_label": pos_label, "position": position},

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -6,7 +6,11 @@ from ...const import ControlMethod, ReasonCode
 from ...position_utils import flip_if
 from ...reason_i18n import Reason
 from ..handler import OverrideHandler
-from ..helpers import compute_default_position, compute_raw_calculated_position
+from ..helpers import (
+    compute_default_position,
+    compute_default_tilt,
+    compute_raw_calculated_position,
+)
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -71,6 +75,11 @@ class MotionTimeoutHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.MOTION,
+            # This return-to-default branch answers with the effective default
+            # position, so it also carries the effective default/sunset tilt
+            # (issue #1214) — the same one DefaultHandler would have supplied.
+            # The hold_position branch above deliberately stays untilted.
+            tilt=compute_default_tilt(snapshot),
             reason_payload=Reason(
                 ReasonCode.OCCUPANCY_LABEL,
                 {"pos_label": pos_label, "position": position},

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -78,8 +78,12 @@ class MotionTimeoutHandler(OverrideHandler):
             # This return-to-default branch answers with the effective default
             # position, so it also carries the effective default/sunset tilt
             # (issue #1214) — the same one DefaultHandler would have supplied.
-            # The hold_position branch above deliberately stays untilted.
-            tilt=compute_default_tilt(snapshot),
+            # The position gate is a no-op here (this branch's `position` IS
+            # compute_default_position(snapshot)) but is passed anyway to keep
+            # every handler using the same "earn the tilt by position, not by
+            # label" invariant. The hold_position branch above deliberately
+            # stays untilted.
+            tilt=compute_default_tilt(snapshot, position=position),
             reason_payload=Reason(
                 ReasonCode.OCCUPANCY_LABEL,
                 {"pos_label": pos_label, "position": position},

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -439,7 +439,9 @@ def compute_default_position(snapshot: PipelineSnapshot) -> int:
     )
 
 
-def compute_default_tilt(snapshot: PipelineSnapshot) -> int | None:
+def compute_default_tilt(
+    snapshot: PipelineSnapshot, *, position: int | None = None
+) -> int | None:
     """Effective default/sunset tilt for the live pipeline (issue #1214).
 
     Single source of truth for resolving ``sunset_tilt``/``default_tilt`` —
@@ -448,6 +450,28 @@ def compute_default_tilt(snapshot: PipelineSnapshot) -> int | None:
     supply the *effective default tilt* that pairs with it, without any of
     them needing to know each other's tilt (issue #1153's ``_MERGEABLE`` seam
     stays closed — each handler states its own tilt as the winner).
+
+    ``position`` is the caller's OWN resolved position for the branch it is
+    calling from. When given, the tilt is only returned if ``position``
+    equals ``compute_default_position(snapshot)`` — i.e. the caller is
+    genuinely AT the effective default position, not merely sharing a
+    control-method label with a handler that is. This is the gate that keeps
+    the tilt off a ``CloudSuppressionHandler`` ``cloudy_position`` branch
+    (issue #1214 finding 1 — that position is a configured override, not the
+    default) and off a tilt-primary ``ClimateHandler`` LOW_LIGHT branch that
+    resolved via ``_solar`` rather than ``_default`` (issue #1214 finding 2 —
+    ``ControlMethod.DEFAULT`` labels the branch, not the position; see the
+    class docstring on ``ClimateHandler``). A coincidental match — e.g. a
+    ``cloudy_position`` or solar-tracked position that happens to equal the
+    default — is treated as a real match: the cover genuinely is sitting at
+    the default position, so pairing it with the default tilt is correct.
+
+    Omit ``position`` (the default, ``None``) to skip the gate entirely —
+    for a caller that is unconditionally at the default position by
+    construction, such as ``DefaultHandler``, which stays at its default
+    even on its "Use My at sunset" branch that substitutes a different
+    *position* value but still means "the default handler won, use its
+    tilt."
 
     Sunset tilt (and its default_tilt fallback) is a deliberate carve-out and
     stays UNclamped, mirroring the sunset *position* bypass (#128). Only the
@@ -458,11 +482,16 @@ def compute_default_tilt(snapshot: PipelineSnapshot) -> int | None:
 
     Args:
         snapshot: Current pipeline snapshot.
+        position: The calling handler's own resolved position, or None to
+            skip the position-match gate (see above).
 
     Returns:
-        Effective default/sunset tilt, or None when neither is configured.
+        Effective default/sunset tilt, or None when neither is configured,
+        or when ``position`` does not match the effective default position.
 
     """
+    if position is not None and position != compute_default_position(snapshot):
+        return None
     tilt: int | None
     if snapshot.is_sunset_active:
         tilt = (

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -6,6 +6,7 @@ patterns across pipeline handlers:
 - ``apply_snapshot_limits``    — apply position limits using config from the snapshot
 - ``compute_solar_position``   — calculate_raw_percentage() + floor-at-1 + limits
 - ``compute_default_position`` — default_position + limits (sun not in FOV)
+- ``compute_default_tilt``     — sunset_tilt/default_tilt + the #503 tilt clamp
 
 Floor-mode composition (the former ``apply_minimum_mode`` semantic) now
 lives in :mod:`pipeline.floors` and runs as a post-decision pass in the
@@ -439,39 +440,40 @@ def compute_default_position(snapshot: PipelineSnapshot) -> int:
     )
 
 
-def compute_default_tilt(
-    snapshot: PipelineSnapshot, *, position: int | None = None
-) -> int | None:
+def compute_default_tilt(snapshot: PipelineSnapshot) -> int | None:
     """Effective default/sunset tilt for the live pipeline (issue #1214).
 
     Single source of truth for resolving ``sunset_tilt``/``default_tilt`` —
-    extracted from ``DefaultHandler`` so every handler that answers with the
-    *effective default position* (``compute_default_position``) can also
-    supply the *effective default tilt* that pairs with it, without any of
-    them needing to know each other's tilt (issue #1153's ``_MERGEABLE`` seam
-    stays closed — each handler states its own tilt as the winner).
+    extracted from ``DefaultHandler`` so every handler branch that resolves
+    its position *from* the default position can also supply the default tilt
+    that pairs with it, without any of them needing to know each other's tilt
+    (issue #1153's ``_MERGEABLE`` seam stays closed — each handler states its
+    own tilt as the winner).
 
-    ``position`` is the caller's OWN resolved position for the branch it is
-    calling from. When given, the tilt is only returned if ``position``
-    equals ``compute_default_position(snapshot)`` — i.e. the caller is
-    genuinely AT the effective default position, not merely sharing a
-    control-method label with a handler that is. This is the gate that keeps
-    the tilt off a ``CloudSuppressionHandler`` ``cloudy_position`` branch
-    (issue #1214 finding 1 — that position is a configured override, not the
-    default) and off a tilt-primary ``ClimateHandler`` LOW_LIGHT branch that
-    resolved via ``_solar`` rather than ``_default`` (issue #1214 finding 2 —
-    ``ControlMethod.DEFAULT`` labels the branch, not the position; see the
-    class docstring on ``ClimateHandler``). A coincidental match — e.g. a
-    ``cloudy_position`` or solar-tracked position that happens to equal the
-    default — is treated as a real match: the cover genuinely is sitting at
-    the default position, so pairing it with the default tilt is correct.
+    **Deciding whether a branch qualifies is the caller's job, not this
+    helper's.** A handler knows structurally which of its own branches it
+    took and whether that branch resolved from the default; it calls this on
+    those branches and passes ``tilt=None`` on the others. That is not a
+    duplication of policy — the shared part (sunset precedence, the #503
+    clamp, the #128 carve-out) lives here, and each handler owning its own
+    output is exactly the #1153 principle. Concretely:
 
-    Omit ``position`` (the default, ``None``) to skip the gate entirely —
-    for a caller that is unconditionally at the default position by
-    construction, such as ``DefaultHandler``, which stays at its default
-    even on its "Use My at sunset" branch that substitutes a different
-    *position* value but still means "the default handler won, use its
-    tilt."
+    * ``DefaultHandler`` — every branch, including "Use My at sunset", which
+      substitutes the *position* only.
+    * ``CloudSuppressionHandler`` — the sunset and no-``cloudy_position``
+      branches; the ``cloudy_position`` branch is a configured override and
+      stays untilted.
+    * ``MotionTimeoutHandler`` — the return-to-default branch; the
+      ``hold_position`` branch stays untilted.
+    * ``ClimateHandler`` — the ``ControlMethod.DEFAULT`` branches whose
+      matched rule reports ``ClimateRule.resolves_default_position``.
+
+    Note that qualification is about PROVENANCE, never about whether the
+    branch's number happens to equal ``compute_default_position(snapshot)``.
+    A limit clamp can move a genuine default answer away from that value
+    (``min_position`` versus the sunset bypass, #128), and a configured
+    override can coincide with it — so a value comparison is wrong in both
+    directions.
 
     Sunset tilt (and its default_tilt fallback) is a deliberate carve-out and
     stays UNclamped, mirroring the sunset *position* bypass (#128). Only the
@@ -482,16 +484,11 @@ def compute_default_tilt(
 
     Args:
         snapshot: Current pipeline snapshot.
-        position: The calling handler's own resolved position, or None to
-            skip the position-match gate (see above).
 
     Returns:
-        Effective default/sunset tilt, or None when neither is configured,
-        or when ``position`` does not match the effective default position.
+        Effective default/sunset tilt, or None when neither is configured.
 
     """
-    if position is not None and position != compute_default_position(snapshot):
-        return None
     tilt: int | None
     if snapshot.is_sunset_active:
         tilt = (

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -437,3 +437,48 @@ def compute_default_position(snapshot: PipelineSnapshot) -> int:
         snapshot.config,
         is_sunset_active=snapshot.is_sunset_active,
     )
+
+
+def compute_default_tilt(snapshot: PipelineSnapshot) -> int | None:
+    """Effective default/sunset tilt for the live pipeline (issue #1214).
+
+    Single source of truth for resolving ``sunset_tilt``/``default_tilt`` —
+    extracted from ``DefaultHandler`` so every handler that answers with the
+    *effective default position* (``compute_default_position``) can also
+    supply the *effective default tilt* that pairs with it, without any of
+    them needing to know each other's tilt (issue #1153's ``_MERGEABLE`` seam
+    stays closed — each handler states its own tilt as the winner).
+
+    Sunset tilt (and its default_tilt fallback) is a deliberate carve-out and
+    stays UNclamped, mirroring the sunset *position* bypass (#128). Only the
+    non-sunset default_tilt honors the global min_tilt/max_tilt clamp (#503)
+    — exactly as default *position* is clamped. Returns None for cover types
+    that never configure a tilt (default_tilt/sunset_tilt both None), which
+    is a natural no-op — no cover-type string branch needed.
+
+    Args:
+        snapshot: Current pipeline snapshot.
+
+    Returns:
+        Effective default/sunset tilt, or None when neither is configured.
+
+    """
+    tilt: int | None
+    if snapshot.is_sunset_active:
+        tilt = (
+            snapshot.sunset_tilt
+            if snapshot.sunset_tilt is not None
+            else snapshot.default_tilt
+        )
+    else:
+        tilt = snapshot.default_tilt
+        if tilt is not None:
+            tilt = PositionConverter.apply_tilt_limits(
+                tilt,
+                snapshot.min_tilt,
+                snapshot.max_tilt,
+                snapshot.min_tilt_sun_only,
+                snapshot.max_tilt_sun_only,
+                sun_valid=False,
+            )
+    return tilt

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -393,17 +393,17 @@ class PipelineSnapshot:
     sunset_use_my: bool = False
 
     # Explicit tilt for venetian covers. None = use solar-computed tilt.
-    default_tilt: int | None = None  # tilt when no active handler fires
+    default_tilt: int | None = None  # tilt when the position falls back to default
     sunset_tilt: int | None = (
         None  # tilt during sunset window; falls back to default_tilt
     )
 
-    # Global tilt clamps (issue #503). The DefaultHandler clamps its non-sunset
-    # default_tilt to [min_tilt, max_tilt]; sunset_tilt and custom-position tilt
-    # are deliberate carve-outs and are never clamped. The *_sun_only toggles
-    # mirror enable_min/max_position: False (default) = always enforce, True =
-    # only during sun tracking. Defaults are no-ops (0 / 100 / False) so
-    # snapshots that don't set them behave exactly as before.
+    # Global tilt clamps (issue #503). compute_default_tilt (pipeline/helpers.py)
+    # clamps the non-sunset default_tilt to [min_tilt, max_tilt]; sunset_tilt and
+    # custom-position tilt are deliberate carve-outs and are never clamped. The
+    # *_sun_only toggles mirror enable_min/max_position: False (default) = always
+    # enforce, True = only during sun tracking. Defaults are no-ops (0 / 100 /
+    # False) so snapshots that don't set them behave exactly as before.
     min_tilt: int = 0
     max_tilt: int = 100
     min_tilt_sun_only: bool = False

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -196,8 +196,8 @@
     "elevation_above": "ab {elev}° Höhe"
   },
   "default": {
-    "tilt": "  ↳ Standard-Neigung: {tilt}% (gilt, wenn kein Handler die Kontrolle übernimmt)",
-    "sunset_tilt": "  ↳ Sonnenuntergangsneigung: {tilt}% (gilt bei Sonnenuntergang, wenn kein Handler die Kontrolle übernimmt)"
+    "tilt": "  ↳ Standard-Neigung: {tilt}% (angewendet, wenn die Beschattung auf ihre Standardposition zurückfällt)",
+    "sunset_tilt": "  ↳ Sonnenuntergangs-Neigung: {tilt}% (angewendet, wenn die Beschattung auf ihre Standardposition zurückfällt, beim Sonnenuntergang)"
   },
   "limits": {
     "range": "Bereich: {lo}–{hi}{qualifier}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -196,8 +196,8 @@
     "elevation_above": "above {elev}° elevation"
   },
   "default": {
-    "tilt": "  ↳ Default tilt: {tilt}% (used when no handler wins control)",
-    "sunset_tilt": "  ↳ Sunset tilt: {tilt}% (used when no handler wins control, during sunset)"
+    "tilt": "  ↳ Default tilt: {tilt}% (used whenever the position falls back to default)",
+    "sunset_tilt": "  ↳ Sunset tilt: {tilt}% (used whenever the position falls back to default, during sunset)"
   },
   "limits": {
     "range": "Range: {lo}–{hi}{qualifier}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -196,8 +196,8 @@
     "elevation_above": "au-dessus de {elev}° élévation"
   },
   "default": {
-    "tilt": "  ↳ Inclinaison par défaut : {tilt}% (utilisée quand aucun gestionnaire ne prend le contrôle)",
-    "sunset_tilt": "  ↳ Inclinaison coucher : {tilt}% (utilisée au coucher du soleil, quand aucun gestionnaire ne prend le contrôle)"
+    "tilt": "  ↳ Inclinaison par défaut : {tilt}% (utilisée chaque fois que la position revient par défaut)",
+    "sunset_tilt": "  ↳ Inclinaison coucher : {tilt}% (utilisée chaque fois que la position revient par défaut, au coucher du soleil)"
   },
   "limits": {
     "range": "Plage : {lo}–{hi}{qualifier}",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1051,7 +1051,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Standard- & Sonnenuntergangs-Neigung",
-        "description": "Standard-Lamellenneigung, die nur gilt, wenn kein anderer Handler die Kontrolle übernimmt – derselbe Fallback wie die Standardposition. Gewinnt ein Custom-Position-Slot, übernimmt dessen eigene Neigung; gewinnt die Sonnenverfolgung, übernimmt die automatische Sonnenberechnung; jeder andere Handler lässt die Lamellen ihren aktuellen Winkel beibehalten.",
+        "description": "Standard-Lamellenneigung, die angewendet wird, wenn die Beschattung auf ihre Standardposition zurückfällt – nicht nur wenn kein anderer Handler die Kontrolle übernimmt, sondern auch wenn Klimamodus (wenig Licht/Nebensaison), Wolkenunterdrückung oder Motion-Timeout dort die Position halten. Wenn ein Custom-Position-Slot gewinnt, übernimmt dessen eigene Neigung; wenn die Sonnenverfolgung gewinnt, übernimmt die automatische Sonnenberechnung; jeder andere Handler lässt die Lamellen ihren aktuellen Winkel beibehalten.",
         "data": {
           "default_tilt": "Standard-Neigung",
           "sunset_tilt": "Sonnenuntergangs-Neigung"

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1103,7 +1103,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Default & Sunset Tilt",
-        "description": "Slat-tilt defaults applied only when no other handler wins control — the same fallback as Default Position. When a custom-position slot wins, its own Tilt takes over; when solar tracking wins, the automatic solar calculation takes over; any other handler leaves the slats holding their current angle.",
+        "description": "Slat-tilt defaults applied whenever the cover falls back to its default position — not just when no handler wins, but also when climate (low-light/off-season), cloud suppression, or motion timeout hold there. When a custom-position slot wins, its own Tilt takes over; when solar tracking wins, the automatic solar calculation takes over; any other handler leaves the slats holding their current angle.",
         "data": {
           "default_tilt": "Default Tilt",
           "sunset_tilt": "Sunset Tilt"

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1051,7 +1051,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Inclinaison par Défaut et Coucher du Soleil",
-        "description": "Inclinaison des lamelles par défaut appliquée uniquement lorsqu'aucun autre gestionnaire ne prend le contrôle — le même repli que la Position par défaut. Quand un emplacement de position personnalisée gagne, sa propre inclinaison prend le relais ; quand le suivi solaire gagne, le calcul solaire automatique prend le relais ; tout autre gestionnaire laisse les lamelles conserver leur angle actuel.",
+        "description": "Inclinaison des lamelles par défaut appliquée chaque fois que la protection revient à sa position par défaut — non seulement quand aucun gestionnaire ne prend le contrôle, mais aussi quand le mode climatique (faible luminosité/hors saison), la suppression des nuages, ou le délai d'inactivité s'y maintiennent. Quand un emplacement de position personnalisée gagne, sa propre Inclinaison prend le relais ; quand le suivi solaire gagne, le calcul solaire automatique prend le relais ; tout autre gestionnaire laisse les lamelles conserver leur angle actuel.",
         "data": {
           "default_tilt": "Inclinaison par Défaut",
           "sunset_tilt": "Inclinaison Coucher du Soleil"

--- a/tests/test_climate_modes.py
+++ b/tests/test_climate_modes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -16,7 +17,9 @@ from custom_components.adaptive_cover_pro.pipeline.handlers.climate_modes import
     _TOP_OVERRIDES,
     ClimateContext,
     ClimateRule,
+    _default,
     evaluate_rules,
+    match_rule,
 )
 
 ALL_TABLES = [
@@ -103,6 +106,126 @@ def test_evaluate_rules_raises_without_catch_all():
 @pytest.mark.parametrize("table", ALL_TABLES)
 def test_every_table_ends_with_catch_all(table):
     assert table[-1].predicate(_ctx()) is True
+
+
+# --- position provenance: which branch resolved FROM the default (#1214) --
+
+
+def test_match_rule_returns_the_first_matching_rule():
+    """``match_rule`` is the primitive ``evaluate_rules`` adapts."""
+    rules = (
+        ClimateRule(lambda c: False, ClimateStrategy.WINTER_HEATING, _default),
+        ClimateRule(lambda c: True, ClimateStrategy.LOW_LIGHT, lambda c: 2),
+    )
+    assert match_rule(rules, _ctx()).strategy is ClimateStrategy.LOW_LIGHT
+
+
+def test_match_rule_raises_without_catch_all():
+    rules = (ClimateRule(lambda c: False, ClimateStrategy.LOW_LIGHT, _default),)
+    with pytest.raises(RuntimeError):
+        match_rule(rules, _ctx())
+
+
+def test_resolves_default_position_keys_on_the_position_fn_not_its_value():
+    """Provenance, not value equality.
+
+    A rule that merely *returns* the default position's number is not
+    resolving from the default. Issue #1214 round 1 compared values and got
+    it wrong in both directions — false negatives once a limit clamp moved
+    the answer, false positives when a configured override happened to
+    coincide with the default.
+    """
+    coincidence = ClimateRule(
+        lambda c: True, ClimateStrategy.LOW_LIGHT, lambda c: c.default_position
+    )
+    assert coincidence.position(_ctx(default_position=42)) == 42
+    assert coincidence.resolves_default_position is False
+
+    assert (
+        ClimateRule(
+            lambda c: True, ClimateStrategy.LOW_LIGHT, _default
+        ).resolves_default_position
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    ("table", "ctx", "strategy", "from_default"),
+    [
+        # NORMAL tables answer LOW_LIGHT with _default — these earn the tilt.
+        (NORMAL_WITH_PRESENCE, _ctx(lux=True), ClimateStrategy.LOW_LIGHT, True),
+        (
+            NORMAL_WITHOUT_PRESENCE,
+            _ctx(valid=True, lux=True),
+            ClimateStrategy.LOW_LIGHT,
+            True,
+        ),
+        (
+            NORMAL_WITHOUT_PRESENCE,
+            _ctx(valid=False),
+            ClimateStrategy.LOW_LIGHT,
+            True,
+        ),
+        # The season-scope gate answers with _default in every table that has one.
+        (
+            NORMAL_WITH_PRESENCE,
+            replace(_ctx(), tracking_seasons=frozenset()),
+            ClimateStrategy.TRACKING_SEASON_GATE,
+            True,
+        ),
+        (
+            TILT_WITH_PRESENCE,
+            replace(_ctx(), tracking_seasons=frozenset()),
+            ClimateStrategy.TRACKING_SEASON_GATE,
+            True,
+        ),
+        (
+            TILT_WITHOUT_PRESENCE,
+            replace(_ctx(valid=True), tracking_seasons=frozenset()),
+            ClimateStrategy.TRACKING_SEASON_GATE,
+            True,
+        ),
+        # TILT tables answer LOW_LIGHT with _solar — same DEFAULT label, a
+        # solar-tracked position, so no default tilt.
+        (TILT_WITH_PRESENCE, _ctx(lux=True), ClimateStrategy.LOW_LIGHT, False),
+        (
+            TILT_WITHOUT_PRESENCE,
+            _ctx(valid=True, lux=True),
+            ClimateStrategy.LOW_LIGHT,
+            False,
+        ),
+        # Every non-default branch stays False.
+        (
+            NORMAL_WITH_PRESENCE,
+            _ctx(is_winter=True, valid=True),
+            ClimateStrategy.WINTER_HEATING,
+            False,
+        ),
+        (
+            NORMAL_WITH_PRESENCE,
+            _ctx(is_winter=True, valid=False, winter_close_insulation=True),
+            ClimateStrategy.WINTER_INSULATION,
+            False,
+        ),
+        (NORMAL_WITH_PRESENCE, _ctx(), ClimateStrategy.GLARE_CONTROL, False),
+        (
+            NORMAL_WITH_PRESENCE,
+            _ctx(is_extreme_heat=True),
+            ClimateStrategy.EXTREME_HEAT,
+            False,
+        ),
+    ],
+)
+def test_table_branch_position_provenance(table, ctx, strategy, from_default):
+    """Pin which branch of each table resolves from the configured default.
+
+    ``ClimateHandler`` reads exactly this to decide whether a
+    ``ControlMethod.DEFAULT`` winner has earned the effective default/sunset
+    tilt (issue #1214).
+    """
+    rule = match_rule(table, ctx)
+    assert rule.strategy is strategy
+    assert rule.resolves_default_position is from_default
 
 
 # --- shared top-override band (issue #766 seam) ---------------------------

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -316,6 +316,74 @@ class TestPostPipelineResolveTiltOnlyMode:
         assert "venetian_mode" not in handler_names
 
 
+class TestIssue1214DefaultTiltEndpointHandoff:
+    """Issue #1214: a DEFAULT winner now carrying the effective default/sunset
+    tilt (climate LOW_LIGHT, cloud suppression, or motion return-to-default)
+    must flow through the same handler-tilt honor path as any other explicit
+    tilt -- staying exempt from the tilt-only carriage pin (#1153 round-2
+    finding 2) -- and, when that pairs position=0 with tilt=0, correctly trip
+    the #755 full-mechanical-endpoint flag rather than being silently
+    absorbed. This is the reporter's own SomfyIO/#985 hardware family, so the
+    endpoint decision here matters: it must be the intended #755 "force
+    close_cover" behaviour, not a spurious re-fire.
+    """
+
+    def test_default_winner_with_tilt_takes_handler_tilt_branch(self):
+        """DEFAULT + tilt=0 honors the handler tilt and stays exempt from the
+        tilt-only carriage pin -- the DEFAULT exemption (#1153 round-2 finding
+        2) must still hold now that DEFAULT winners routinely carry a tilt.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        result = PipelineResult(
+            position=0,
+            tilt=0,
+            control_method=ControlMethod.DEFAULT,
+            reason="climate low-light — sunset tilt",
+        )
+        resolved = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+
+        handler_names = [s.handler for s in resolved.decision_trace]
+        assert "venetian_handler_tilt" in handler_names
+        assert "venetian_mode" not in handler_names
+        assert resolved.tilt == 0
+        assert resolved.position == 0
+
+    def test_default_winner_at_0_0_sets_full_endpoint_target(self):
+        """The 0/0 pairing this fix now lets a DEFAULT winner reach is exactly
+        the state issue #755 designed the endpoint flag for.
+        """
+        policy = _make_policy()
+        result = PipelineResult(
+            position=0, tilt=0, control_method=ControlMethod.DEFAULT, reason="test"
+        )
+        resolved = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+
+        overrides = policy.position_context_overrides(resolved)
+        assert overrides["tilt"] == 0
+        assert overrides["full_endpoint_target"] is True
+
+    @pytest.mark.parametrize("method", [ControlMethod.CLOUD, ControlMethod.MOTION])
+    def test_cloud_and_motion_winners_at_position_0_nonzero_tilt_do_not_force_endpoint(
+        self, method
+    ):
+        """A CLOUD/MOTION winner at position=0 with a non-zero default_tilt
+        (e.g. default_tilt=50, not sunset) is NOT a mechanical stop -- the
+        endpoint flag must stay clear, exactly as #755 intends.
+        """
+        policy = _make_policy()
+        result = PipelineResult(
+            position=0, tilt=50, control_method=method, reason="test"
+        )
+        resolved = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+
+        overrides = policy.position_context_overrides(resolved)
+        assert overrides["tilt"] == 50
+        assert overrides.get("full_endpoint_target", False) is False
+
+
 class TestPostPipelineResolveCoverageSteps:
     """Movement minimization quantizes the slat tilt toward full coverage."""
 

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -3079,6 +3079,42 @@ async def test_apply_position_position_capable_assumed_state_still_same_position
     mock_hass.services.async_call.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_full_endpoint_zero_already_closed_skips_for_climate_default_winner(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #1214 regression guard: a climate/cloud/motion DEFAULT-branch
+    winner now supplies tilt=0 alongside position=0 (previously tilt was
+    always None for these handlers -- the bug this issue fixes). On a
+    venetian already mechanically closed, that newly-real 0/0 pairing must
+    NOT re-fire close_cover -- the same #985 "no spurious command for a
+    target already satisfied" guarantee the assumed_state guard above locks,
+    now exercised with the tilt this fix newly makes non-None.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=0, state="closed")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=0),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("close_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "climate",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=0),
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
 # --- is_target_unreached: A2 read-only "commanded but not reached" predicate ---
 # Issue #990. Read-only predicate the coordinator polls each cycle to raise the
 # cover_not_moving Repair. True iff a target is set, the cover has settled

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -936,6 +936,46 @@ class TestDefaultHandler:
         assert result is not None
         assert result.tilt == 80
 
+    # -- "Use My at sunset" keeps the sunset tilt (issue #1214) -------------
+
+    def test_sunset_use_my_branch_still_carries_sunset_tilt(self) -> None:
+        """The My-preset branch substitutes the POSITION only — the tilt stays.
+
+        ``DefaultHandler`` is the one handler that is at its default by
+        construction on every branch: "Use My at sunset" routes the position
+        through the cover's hardware My preset, but the slats still owe the
+        configured ``sunset_tilt``. Nothing locked this before (#1214 round-2
+        finding 3) — ``test_my_position.py`` and ``test_default_handler.py``
+        only assert ``position``/``use_my_position`` — so a later "make every
+        handler consistent" edit could have gated this branch and silently
+        dropped the sunset tilt with the whole suite still green.
+        """
+        snap = make_snapshot(
+            is_sunset_active=True,
+            sunset_use_my=True,
+            my_position_value=88,
+            sunset_tilt=0,
+            default_tilt=50,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.use_my_position is True
+        assert result.position == 88
+        assert result.tilt == 0
+
+    def test_sunset_use_my_branch_falls_back_to_default_tilt(self) -> None:
+        """Same branch, no sunset_tilt configured: the default_tilt fallback rides along."""
+        snap = make_snapshot(
+            is_sunset_active=True,
+            sunset_use_my=True,
+            my_position_value=88,
+            default_tilt=50,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.use_my_position is True
+        assert result.tilt == 50
+
 
 # ---------------------------------------------------------------------------
 # compute_default_tilt — the shared helper DefaultHandler delegates to

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -21,6 +21,7 @@ from custom_components.adaptive_cover_pro.pipeline.handlers.weather import (
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
+from custom_components.adaptive_cover_pro.pipeline.helpers import compute_default_tilt
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
     PipelineResult,
@@ -934,6 +935,47 @@ class TestDefaultHandler:
         result = self.handler.evaluate(snap)
         assert result is not None
         assert result.tilt == 80
+
+
+# ---------------------------------------------------------------------------
+# compute_default_tilt — the shared helper DefaultHandler delegates to
+# (issue #1214: extracted so higher-priority handlers that answer with the
+# effective default position can also carry the effective default tilt).
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDefaultTilt:
+    """Direct tests of pipeline.helpers.compute_default_tilt(snapshot)."""
+
+    def test_returns_none_when_neither_tilt_configured(self) -> None:
+        """No sunset_tilt, no default_tilt → None."""
+        snap = make_snapshot()
+        assert compute_default_tilt(snap) is None
+
+    def test_sunset_tilt_wins_when_sunset_active(self) -> None:
+        """sunset_tilt takes precedence during the sunset window."""
+        snap = make_snapshot(is_sunset_active=True, sunset_tilt=0, default_tilt=50)
+        assert compute_default_tilt(snap) == 0
+
+    def test_falls_back_to_default_tilt_when_sunset_tilt_is_none(self) -> None:
+        """sunset_tilt=None during sunset falls back to default_tilt."""
+        snap = make_snapshot(is_sunset_active=True, sunset_tilt=None, default_tilt=40)
+        assert compute_default_tilt(snap) == 40
+
+    def test_returns_default_tilt_when_not_sunset(self) -> None:
+        """Outside the sunset window, default_tilt applies (sunset_tilt ignored)."""
+        snap = make_snapshot(is_sunset_active=False, sunset_tilt=80, default_tilt=20)
+        assert compute_default_tilt(snap) == 20
+
+    def test_non_sunset_value_is_clamped_to_max_tilt(self) -> None:
+        """The non-sunset default_tilt honors the #503 min/max_tilt clamp."""
+        snap = make_snapshot(is_sunset_active=False, default_tilt=90, max_tilt=60)
+        assert compute_default_tilt(snap) == 60
+
+    def test_sunset_value_is_not_clamped(self) -> None:
+        """The sunset value is a deliberate #128 carve-out — never clamped."""
+        snap = make_snapshot(is_sunset_active=True, sunset_tilt=80, max_tilt=60)
+        assert compute_default_tilt(snap) == 80
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -19,6 +19,7 @@ import pytest
 from custom_components.adaptive_cover_pro.const import (
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_TRACKING_SEASONS,
+    ClimateStrategy,
     ControlMethod,
 )
 from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
@@ -37,6 +38,9 @@ from custom_components.adaptive_cover_pro.pipeline.handlers.motion_timeout impor
     MotionTimeoutHandler,
 )
 from custom_components.adaptive_cover_pro.pipeline.handlers.solar import SolarHandler
+from custom_components.adaptive_cover_pro.pipeline.helpers import (
+    compute_default_position,
+)
 from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
 from custom_components.adaptive_cover_pro.pipeline.types import (
     ClimateOptions,
@@ -453,17 +457,73 @@ class TestNonVenetianPolicyTiltPassthrough:
 # tilt (via compute_default_tilt), so _MERGEABLE stays untouched.
 
 
-def _low_light_climate_readings() -> ClimateReadings:
-    """Build readings that drive ClimateStrategy.LOW_LIGHT: presence, no sun, intermediate temp."""
+def _low_light_climate_readings(
+    *, inside_temperature: float = 22.0, is_sunny: bool = False
+) -> ClimateReadings:
+    """Build readings that drive ClimateStrategy.LOW_LIGHT: presence, no sun, intermediate temp.
+
+    ``inside_temperature`` drives the season predicates (``_climate_options``
+    uses temp_low 18 / temp_high 26 and temp_switch False, so this reading is
+    the one ``get_current_temperature`` resolves to). ``is_sunny=True`` turns
+    the low-light predicate off so a table's later branches become reachable.
+    """
     return ClimateReadings(
         outside_temperature=None,
-        inside_temperature=22.0,
+        inside_temperature=inside_temperature,
         is_presence=True,
-        is_sunny=False,
+        is_sunny=is_sunny,
         lux_below_threshold=False,
         irradiance_below_threshold=False,
         cloud_coverage_above_threshold=False,
     )
+
+
+def _make_limited_cover(
+    *,
+    direct_sun_valid: bool = False,
+    min_pos: int | None = None,
+    max_pos: int | None = None,
+    min_pos_sun_only: bool = False,
+    max_pos_sun_only: bool = False,
+    min_pos_sun_tracking: int | None = None,
+):
+    """Mock cover whose ``CoverConfig`` carries real min/max position limits.
+
+    ``make_snapshot`` sources ``snapshot.config`` from ``cover.config`` and the
+    conftest mock leaves every limit unset, so a limit-sensitive test has to
+    build its own. Mirrors ``conftest._make_mock_cover``'s spec list.
+    """
+    cover = MagicMock(
+        spec=[
+            "direct_sun_valid",
+            "calculate_percentage",
+            "calculate_raw_percentage",
+            "distance",
+            "gamma",
+            "config",
+            "valid",
+            "valid_elevation",
+            "is_sun_in_blind_spot",
+            "sunset_valid",
+            "calculate_position",
+            "control_state_reason",
+            "sun_data",
+        ]
+    )
+    cover.direct_sun_valid = direct_sun_valid
+    cover.valid = True
+    cover.calculate_percentage = MagicMock(return_value=50.0)
+    cover.calculate_raw_percentage = MagicMock(return_value=50.0)
+    cover.distance = 3.0
+    cover.gamma = 0.0
+    config = MagicMock()
+    config.min_pos = min_pos
+    config.max_pos = max_pos
+    config.min_pos_sun_only = min_pos_sun_only
+    config.max_pos_sun_only = max_pos_sun_only
+    config.min_pos_sun_tracking = min_pos_sun_tracking
+    cover.config = config
+    return cover
 
 
 def _climate_options(**overrides) -> ClimateOptions:
@@ -545,10 +605,12 @@ class TestDefaultTiltReachesClimateWinner:
         carries, but a solar-tracked position, not the effective default one.
         Pairing that with the configured default tilt would silently
         overwrite a genuine solar-tracked slat angle with a stale default.
-        The class docstring says exactly this; the fix is that the tilt is
-        gated on the ACTUAL position matching compute_default_position, not
-        on the DEFAULT label alone -- so this must stay untilted even though
-        default_tilt is configured and the branch is labelled DEFAULT.
+        The class docstring says exactly this; the tilt is gated on the
+        matched rule's PROVENANCE (``ClimateRule.resolves_default_position``,
+        False for ``_solar``), not on the DEFAULT label -- so this must stay
+        untilted even though default_tilt is configured and the branch is
+        labelled DEFAULT, and it stays untilted regardless of what number the
+        solar position happens to land on.
 
         default_tilt/sunset_tilt are only exposed via the UI for
         position-primary policies (VenetianPolicy, DayNightShadePolicy), but
@@ -579,6 +641,92 @@ class TestDefaultTiltReachesClimateWinner:
         assert result.position != 0
         assert result.tilt is None
 
+    def test_clamped_sunset_position_still_carries_sunset_tilt(self):
+        """Round-2 finding 1: limit clamping must not disqualify the tilt.
+
+        ``compute_default_position`` bypasses the min/max limits during sunset
+        (#128), but ``ClimateCoverState.get_state`` runs every answer through
+        ``apply_snapshot_limits`` — so with ``min_pos=20`` and
+        ``sunset_position=0`` the climate winner sits at 20 while the effective
+        default reads 0. The position was still RESOLVED FROM the default
+        (``climate_modes._default``); a clamp applied afterwards does not make
+        it something else, so the sunset tilt must still ride along. This is
+        the originally reported defect (#1214) for every install whose limits
+        move the sunset position.
+        """
+        snap = make_snapshot(
+            cover=_make_limited_cover(min_pos=20),
+            climate_mode_enabled=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(),
+            is_sunset_active=True,
+            default_position=0,
+            sunset_tilt=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.DEFAULT
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "climate"
+        # The clamp genuinely moved the answer off the effective default —
+        # otherwise this test would not exercise what it claims to.
+        assert compute_default_position(snap) == 0
+        assert result.position == 20
+        assert result.tilt == 0
+
+    def test_sun_tracking_min_floor_still_carries_default_tilt(self):
+        """Round-2 finding 1, non-sunset twin: the sun-only floor is a clamp too.
+
+        ``get_state`` clamps with ``sun_valid = direct_sun_valid and is_summer``
+        while ``compute_default_position`` always uses ``sun_valid=False``. On a
+        hot, cloudy, in-FOV day with ``min_position_sun_tracking=30`` the climate
+        LOW_LIGHT answer (still ``_default``) lands at 30 against an effective
+        default of 0 — and must still carry ``default_tilt``.
+        """
+        snap = make_snapshot(
+            cover=_make_limited_cover(direct_sun_valid=True, min_pos_sun_tracking=30),
+            climate_mode_enabled=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(inside_temperature=30.0),
+            climate_options=_climate_options(),
+            is_sunset_active=False,
+            default_position=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.DEFAULT
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "climate"
+        assert compute_default_position(snap) == 0
+        assert result.position == 30
+        assert result.tilt == 50
+
+    def test_tracking_season_gate_carries_default_tilt(self):
+        """The other DEFAULT-labelled branch resolves from ``_default`` too.
+
+        With the current season deselected the season-scope gate replaces glare
+        tracking with the default position (``_SEASON_GATE`` → ``_default``), so
+        it earns the default tilt on the same provenance grounds as LOW_LIGHT.
+        """
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_mode_enabled=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(is_sunny=True),
+            climate_options=_climate_options(tracking_seasons=frozenset()),
+            is_sunset_active=False,
+            default_position=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.climate_strategy is ClimateStrategy.TRACKING_SEASON_GATE
+        assert result.control_method is ControlMethod.DEFAULT
+        assert result.tilt == 50
+
 
 class TestDefaultTiltReachesCloudSuppressionWinner:
     """CloudSuppressionHandler must carry the effective default/sunset tilt too."""
@@ -605,13 +753,15 @@ class TestDefaultTiltReachesCloudSuppressionWinner:
         assert result.tilt == 0
 
     def test_cloudy_position_not_sunset_stays_untilted(self):
-        """A cloudy_position winner is NOT at the effective default position.
+        """A cloudy_position winner did NOT resolve from the default position.
 
-        Issue #1214 finding 1: the position here (25) is a configured
-        cloudy_position override, not compute_default_position(snapshot) (0).
-        Pairing it with default_tilt would snap a venetian's slats to
-        default_tilt during a cloudy in-FOV daytime hold instead of letting
-        them hold -- exactly what #1153 removed for non-default winners.
+        The position here (25) came from the configured cloudy_position, so
+        the branch states ``tilt=None``. Pairing it with default_tilt would
+        snap a venetian's slats to default_tilt during a cloudy in-FOV
+        daytime hold instead of letting them hold -- exactly what #1153
+        removed for non-default winners. See
+        ``test_cloudy_position_equal_to_default_stays_untilted`` for the same
+        rule when the override's *value* coincides with the default.
         """
         snap = make_snapshot(
             direct_sun_valid=True,
@@ -632,6 +782,49 @@ class TestDefaultTiltReachesCloudSuppressionWinner:
         assert winning_step.priority == CloudSuppressionHandler.priority
         assert result.position == 25
         assert result.tilt is None
+
+    def test_cloudy_position_equal_to_default_stays_untilted(self):
+        """Round-2 finding 2: a coincidental value match is not provenance.
+
+        ``cloudy_position=0`` alongside a venetian's ``default_percentage=0``
+        (the #1214 reporter's own value) makes the cloudy answer numerically
+        equal to the effective default. It is still a configured override, so
+        the slats must hold — 2026.8.0's behaviour and what #1153 established
+        for hold-type winners.
+        """
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(
+                cloud_suppression_enabled=True, cloudy_position=0
+            ),
+            is_sunset_active=False,
+            default_position=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.CLOUD
+        # The coincidence this test is about: same number, different provenance.
+        assert result.position == compute_default_position(snap) == 0
+        assert result.tilt is None
+
+    def test_no_cloudy_position_carries_default_tilt(self):
+        """With no ``cloudy_position`` configured the branch IS the default."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(cloud_suppression_enabled=True),
+            is_sunset_active=False,
+            default_position=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.CLOUD
+        assert result.tilt == 50
 
 
 class TestDefaultTiltReachesMotionTimeoutWinner:

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -16,20 +16,34 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import (
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+    DEFAULT_TRACKING_SEASONS,
+    ControlMethod,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+    ClimateHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
+    CloudSuppressionHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
 from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
     DefaultHandler,
 )
+from custom_components.adaptive_cover_pro.pipeline.handlers.motion_timeout import (
+    MotionTimeoutHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.solar import SolarHandler
 from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
 from custom_components.adaptive_cover_pro.pipeline.types import (
+    ClimateOptions,
     CustomPositionSensorState,
     PipelineResult,
 )
+from custom_components.adaptive_cover_pro.state.climate_provider import ClimateReadings
 from tests.test_pipeline.conftest import make_snapshot
 
 # ---------------------------------------------------------------------------
@@ -393,3 +407,187 @@ class TestNonVenetianPolicyTiltPassthrough:
             options={},
         )
         assert resolved is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #1214 — default/sunset tilt reaches higher-priority DEFAULT winners
+# ---------------------------------------------------------------------------
+#
+# #1153 correctly closed the _MERGEABLE tilt leak (a losing DefaultHandler
+# could no longer stamp its tilt onto a winning handler), but ClimateHandler
+# (LOW_LIGHT), CloudSuppressionHandler, and MotionTimeoutHandler all answer
+# with the *effective default position* via compute_default_position and
+# never supplied a tilt of their own -- so a venetian's sunset_tilt/default_tilt
+# became unreachable whenever one of these three outranked DefaultHandler.
+# These full-stack registry tests lock the fix: each handler supplies its OWN
+# tilt (via compute_default_tilt), so _MERGEABLE stays untouched.
+
+
+def _low_light_climate_readings() -> ClimateReadings:
+    """Build readings that drive ClimateStrategy.LOW_LIGHT: presence, no sun, intermediate temp."""
+    return ClimateReadings(
+        outside_temperature=None,
+        inside_temperature=22.0,
+        is_presence=True,
+        is_sunny=False,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+
+
+def _climate_options(**overrides) -> ClimateOptions:
+    kwargs = {
+        "temp_low": 18.0,
+        "temp_high": 26.0,
+        "temp_switch": False,
+        "transparent_blind": False,
+        "temp_summer_outside": None,
+        "cloud_suppression_enabled": False,
+        "winter_close_insulation": False,
+        "temp_extreme_heat": None,
+        "extreme_heat_position": None,
+        "tracking_seasons": frozenset(DEFAULT_TRACKING_SEASONS),
+    }
+    kwargs.update(overrides)
+    return ClimateOptions(**kwargs)
+
+
+class TestDefaultTiltReachesClimateWinner:
+    """A LOW_LIGHT climate winner must carry the same tilt DefaultHandler would.
+
+    Reproduces the reporter's own trace (issue #1214): climate mode active,
+    no direct sun, presence, intermediate temperature -- ClimateStrategy.LOW_LIGHT
+    labels its branch ControlMethod.DEFAULT and outranks DefaultHandler
+    (priority 50 vs 0), so it must supply the effective default/sunset tilt
+    itself.
+    """
+
+    def _registry(self) -> PipelineRegistry:
+        return PipelineRegistry([ClimateHandler(), SolarHandler(), DefaultHandler()])
+
+    def test_sunset_active_carries_sunset_tilt(self):
+        snap = make_snapshot(
+            direct_sun_valid=False,
+            climate_mode_enabled=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(),
+            is_sunset_active=True,
+            sunset_tilt=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.DEFAULT
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "climate"
+        assert winning_step.priority == ClimateHandler.priority
+        assert result.tilt == 0
+
+    def test_not_sunset_carries_default_tilt(self):
+        snap = make_snapshot(
+            direct_sun_valid=False,
+            climate_mode_enabled=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(),
+            is_sunset_active=False,
+            sunset_tilt=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.DEFAULT
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "climate"
+        assert winning_step.priority == ClimateHandler.priority
+        assert result.tilt == 50
+
+
+class TestDefaultTiltReachesCloudSuppressionWinner:
+    """CloudSuppressionHandler must carry the effective default/sunset tilt too."""
+
+    def _registry(self) -> PipelineRegistry:
+        return PipelineRegistry([CloudSuppressionHandler(), DefaultHandler()])
+
+    def test_sunset_active_carries_sunset_tilt(self):
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(cloud_suppression_enabled=True),
+            is_sunset_active=True,
+            sunset_tilt=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.CLOUD
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "cloud_suppression"
+        assert winning_step.priority == CloudSuppressionHandler.priority
+        assert result.tilt == 0
+
+    def test_cloudy_position_not_sunset_carries_default_tilt(self):
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(
+                cloud_suppression_enabled=True, cloudy_position=25
+            ),
+            is_sunset_active=False,
+            sunset_tilt=0,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.CLOUD
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "cloud_suppression"
+        assert winning_step.priority == CloudSuppressionHandler.priority
+        assert result.tilt == 50
+
+
+class TestDefaultTiltReachesMotionTimeoutWinner:
+    """MotionTimeoutHandler's return_to_default branch must carry the tilt too."""
+
+    def _registry(self) -> PipelineRegistry:
+        return PipelineRegistry([MotionTimeoutHandler(), DefaultHandler()])
+
+    def test_return_to_default_carries_default_tilt(self):
+        snap = make_snapshot(
+            motion_control_enabled=True,
+            motion_timeout_active=True,
+            motion_timeout_mode="return_to_default",
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.MOTION
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "motion_timeout"
+        assert winning_step.priority == MotionTimeoutHandler.priority
+        assert result.tilt == 50
+
+    def test_hold_position_mode_stays_untilted(self):
+        """Regression lock: the hold branch must NOT gain a tilt (skip_command=True).
+
+        Must pass both before and after the fix -- it locks the hold
+        carve-out that must never be given a tilt.
+        """
+        snap = make_snapshot(
+            motion_control_enabled=True,
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=True,
+            direct_sun_valid=True,
+            current_cover_position=42,
+            default_tilt=50,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.MOTION
+        assert result.skip_command is True
+        assert result.tilt is None

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -47,6 +47,36 @@ from custom_components.adaptive_cover_pro.state.climate_provider import ClimateR
 from tests.test_pipeline.conftest import make_snapshot
 
 # ---------------------------------------------------------------------------
+# Mock tilt-cover builder for issue #1214 finding 2's TILT_WITH_PRESENCE case
+# ---------------------------------------------------------------------------
+# The generic conftest mock cover has no `beta` attribute (only position-
+# primary tests need it), and ClimateHandler._build_context reads
+# `tilt_cover.beta` unconditionally for tilt-primary covers. Mirrors
+# `test_climate_handler.py::_make_tilt_cover`.
+
+
+def _make_low_light_solar_tilt_cover(*, percentage: float):
+    from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
+
+    cover = MagicMock(spec=AdaptiveTiltCover)
+    cover.direct_sun_valid = True
+    cover.valid = True
+    cover.calculate_percentage = MagicMock(return_value=percentage)
+    cover.calculate_raw_percentage = MagicMock(return_value=percentage)
+    cover.gamma = 0.0
+    cover.beta = 0.0
+    cover.mode = "mode2"
+    config = MagicMock()
+    config.min_pos = None
+    config.max_pos = None
+    config.min_pos_sun_only = False
+    config.max_pos_sun_only = False
+    config.min_pos_sun_tracking = None
+    cover.config = config
+    return cover
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -504,6 +534,51 @@ class TestDefaultTiltReachesClimateWinner:
         assert winning_step.priority == ClimateHandler.priority
         assert result.tilt == 50
 
+    def test_tilt_primary_low_light_via_solar_stays_untilted(self):
+        """Issue #1214 finding 2: ControlMethod.DEFAULT labels the branch, not
+        the position -- it is not a promise the cover sits at its default.
+
+        On a tilt-primary cover (``cover_tilt``/``cover_louvered_roof``),
+        ``ClimateStrategy.LOW_LIGHT`` resolves via ``TILT_WITH_PRESENCE``'s
+        ``_solar`` rule (climate_modes.py:346), not ``_default`` -- the same
+        ``ControlMethod.DEFAULT`` label the NORMAL-table LOW_LIGHT branch
+        carries, but a solar-tracked position, not the effective default one.
+        Pairing that with the configured default tilt would silently
+        overwrite a genuine solar-tracked slat angle with a stale default.
+        The class docstring says exactly this; the fix is that the tilt is
+        gated on the ACTUAL position matching compute_default_position, not
+        on the DEFAULT label alone -- so this must stay untilted even though
+        default_tilt is configured and the branch is labelled DEFAULT.
+
+        default_tilt/sunset_tilt are only exposed via the UI for
+        position-primary policies (VenetianPolicy, DayNightShadePolicy), but
+        nothing at the pipeline/snapshot layer or in ``set_option`` gates
+        them by cover type -- so this combination, while not reachable
+        through the UI today, must not silently misbehave if it occurs.
+        """
+        snap = make_snapshot(
+            cover=_make_low_light_solar_tilt_cover(percentage=70.0),
+            cover_type="cover_tilt",
+            climate_mode_enabled=True,
+            in_time_window=True,
+            climate_readings=_low_light_climate_readings(),
+            climate_options=_climate_options(),
+            is_sunset_active=False,
+            default_position=0,
+            default_tilt=40,
+        )
+        result = self._registry().evaluate(snap)
+
+        assert result.control_method is ControlMethod.DEFAULT
+        winning_step = next(s for s in result.decision_trace if s.matched)
+        assert winning_step.handler == "climate"
+        assert winning_step.priority == ClimateHandler.priority
+        # Sanity: the winning position is the solar-tracked one (70), not the
+        # effective default (0) -- otherwise this test would not exercise the
+        # gate it claims to.
+        assert result.position != 0
+        assert result.tilt is None
+
 
 class TestDefaultTiltReachesCloudSuppressionWinner:
     """CloudSuppressionHandler must carry the effective default/sunset tilt too."""
@@ -529,7 +604,15 @@ class TestDefaultTiltReachesCloudSuppressionWinner:
         assert winning_step.priority == CloudSuppressionHandler.priority
         assert result.tilt == 0
 
-    def test_cloudy_position_not_sunset_carries_default_tilt(self):
+    def test_cloudy_position_not_sunset_stays_untilted(self):
+        """A cloudy_position winner is NOT at the effective default position.
+
+        Issue #1214 finding 1: the position here (25) is a configured
+        cloudy_position override, not compute_default_position(snapshot) (0).
+        Pairing it with default_tilt would snap a venetian's slats to
+        default_tilt during a cloudy in-FOV daytime hold instead of letting
+        them hold -- exactly what #1153 removed for non-default winners.
+        """
         snap = make_snapshot(
             direct_sun_valid=True,
             in_time_window=True,
@@ -547,7 +630,8 @@ class TestDefaultTiltReachesCloudSuppressionWinner:
         winning_step = next(s for s in result.decision_trace if s.matched)
         assert winning_step.handler == "cloud_suppression"
         assert winning_step.priority == CloudSuppressionHandler.priority
-        assert result.tilt == 50
+        assert result.position == 25
+        assert result.tilt is None
 
 
 class TestDefaultTiltReachesMotionTimeoutWinner:


### PR DESCRIPTION
## Summary
#1153 dropped `"tilt"` from the pipeline registry's `_MERGEABLE` set so a losing `DefaultHandler` could no longer leak `default_tilt` onto a winning handler. Correct, but three handlers that fall back to the effective default position never supplied a tilt of their own, so `sunset_tilt` and `default_tilt` became unreachable whenever one of them won. Venetian tilt-only covers held their last daytime slat angle all night.

`compute_default_tilt(snapshot)` now lives in `pipeline/helpers.py` as the single place resolving the sunset/default tilt, preserving sunset precedence, the `default_tilt` fallback, the #503 clamp on the non-sunset branch and the #128 unclamped sunset carve-out. `ClimateHandler`, `CloudSuppressionHandler`, and `MotionTimeoutHandler`'s return-to-default branch each state their own tilt. Motion's `hold_position` branch stays untilted, because a hold must hold. `_MERGEABLE` is untouched, so #1153's seam stays closed.

Qualification is structural, not numeric. Two audit rounds established that comparing the handler's position against `compute_default_position` fails in both directions: climate's position is limit-clamped while the helper bypasses limits at sunset (#128), so a `min_position` floor silently dropped `sunset_tilt`; and a `cloudy_position` coinciding with the default earned a tilt it should not have. `CloudSuppressionHandler` now states the tilt inside its existing three-way `pos_label` split, and `ClimateRule.resolves_default_position` (the identity test `self.position is _default`, recorded at match time before any clamp) carries provenance out of the rule table. `ControlMethod.DEFAULT` is retained as a separate safety gate, since `post_pipeline_resolve` honours a non-`None` handler tilt unconditionally.

The reporter's daytime `tilt: 100` is not a defect. MODE1 clamps a 122.4 degree raw slat angle to the 90 degree rail, which still blocks the beam at horizontal for their 8 cm / 8 cm slat geometry. `max_tilt` is the knob for capping sun-tracked slat openness.

## Testing
- ✅ 12840 tests passing

## Related Issues
Refs #1214
Refs #1153