### PR TITLE
fix: Target Position follows the dispatched target when a bound clamps a hold (#1175)

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -357,10 +357,12 @@ class _PositionVerificationSensor(_ACPRestorableDiagnosticSensor):
 def _target_position(states: Mapping[str, Any], result: Any) -> Any:
     """Resolve where ACP is putting this cover — the Target Position value.
 
-    The single definition every Target Position surface reads: the sensor's own
-    state, its ``target_distance``, and its ``all_at_target`` verdict. They
-    described the same thing through three separate derivations before #1175,
-    which is how the state and the distance came to disagree.
+    The single definition behind all three of this sensor's target surfaces —
+    its own state, its ``target_distance``, and its ``all_at_target`` verdict.
+    Before #1175 each derived the target itself: the first two identically (and
+    identically wrong once a bound clamped), the third from the raw ``state``
+    with no ``held_position`` term at all, which is how a perfectly-held group
+    read as "not at target".
 
     A hold winner keeps the cover's *physical* position rather than proposing a
     computed one, so ``held_position`` is the honest answer while the hold is
@@ -369,9 +371,17 @@ def _target_position(states: Mapping[str, Any], result: Any) -> Any:
     It stops being the answer once a user-configured bound outranks the holder
     and CLAMPS it. The registry writes the clamped value into ``position``, sets
     ``position_constraint_applied``, and clears ``skip_command`` in one
-    ``dataclasses.replace`` — a command *is* dispatched, while ``held_position``
-    still carries the pre-clamp read. Reporting that read then names a position
-    the cover is actively leaving (#1175).
+    ``dataclasses.replace`` — the hold no longer decides where this cover goes,
+    while ``held_position`` still carries the pre-clamp read. Reporting that read
+    then names a position the cover is being moved off (#1175).
+
+    The flag says a bound re-targeted the winner; it does not promise the frame
+    reached the motor. ``_dispatch_for_cycle`` returns at the clock-window gate
+    before it ever consults ``position_constraint_applied``, so a non-safety
+    clamp resolved outside the user's start/end window updates this sensor and
+    sends nothing. That is deliberate and not special to holds — a computed
+    solar winner outside the window is reported here the same way. This surface
+    is the pipeline's resolved target, not a dispatch log.
 
     ⚠️ The gate is ``position_constraint_applied``, NOT ``skip_command``, and the
     two are not interchangeable. The tilt axis also clears ``skip_command``

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -355,8 +355,34 @@ class _PositionVerificationSensor(_ACPRestorableDiagnosticSensor):
 
 
 def _cover_position_value(s: _ACPSensor) -> Any:
+    """Return where ACP is putting this cover — the Target Position value.
+
+    A hold winner keeps the cover's *physical* position rather than proposing a
+    computed one, so ``held_position`` is the honest answer while the hold is
+    holding: it beats the value the hold merely shadows (#534 / #809).
+
+    It stops being the answer once a user-configured bound outranks the holder
+    and CLAMPS it. The registry writes the clamped value into ``position``, sets
+    ``position_constraint_applied``, and clears ``skip_command`` in one
+    ``dataclasses.replace`` — a command *is* dispatched, while ``held_position``
+    still carries the pre-clamp read. Reporting that read then names a position
+    the cover is actively leaving (#1175).
+
+    ⚠️ The gate is ``position_constraint_applied``, NOT ``skip_command``, and the
+    two are not interchangeable here. The tilt axis also clears ``skip_command``
+    (``registry._release_hold_for_tilt_clamp``) — but that path rewrites
+    ``position`` to the held read itself, so ``state`` and ``held`` already agree
+    and routing it through ``state`` would only push a raw motor read back
+    through ``coordinator._to_cover_frame``, which re-interpolates it under
+    ``CONF_INTERP``. Keying on the position-axis flag flips exactly the cases
+    where the dispatched value genuinely differs, and leaves the tilt-clamp path
+    alone.
+    """
     held = s.data.states.get("held_position")
-    if held is not None:
+    result = s.coordinator._pipeline_result  # noqa: SLF001
+    if held is not None and not (
+        result is not None and result.position_constraint_applied
+    ):
         return held
     return s.data.states["state"]
 
@@ -492,10 +518,11 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         else:
             attrs["all_at_target"] = None
 
-    target_pos = s.data.states.get("held_position")
-    if target_pos is None:
-        target_pos = s.data.states.get("state")
-    distance_attrs = _compute_distance_attrs(s.coordinator, snapshot, target_pos)
+    # Same value the sensor itself reports — one helper, so the distance can
+    # never describe a position the state does not (#1175).
+    distance_attrs = _compute_distance_attrs(
+        s.coordinator, snapshot, _cover_position_value(s)
+    )
     if distance_attrs is not None:
         attrs.update(distance_attrs)
 

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -379,9 +379,12 @@ def _target_position(states: Mapping[str, Any], result: Any) -> Any:
     reached the motor. ``_dispatch_for_cycle`` returns at the clock-window gate
     before it ever consults ``position_constraint_applied``, so a non-safety
     clamp resolved outside the user's start/end window updates this sensor and
-    sends nothing. That is deliberate and not special to holds — a computed
-    solar winner outside the window is reported here the same way. This surface
-    is the pipeline's resolved target, not a dispatch log.
+    sends nothing. That is deliberate and not special to holds: the pipeline
+    runs every cycle regardless, and outside the clock window ``DefaultHandler``
+    wins and is surfaced here the same way, undispatched. (Not ``solar`` — it
+    declines on ``in_time_window``, which is the clock window ANDed with the
+    daytime gate, so it can never be the winner while that gate suppresses.)
+    This surface is the pipeline's resolved target, not a dispatch log.
 
     ⚠️ The gate is ``position_constraint_applied``, NOT ``skip_command``, and the
     two are not interchangeable. The tilt axis also clears ``skip_command``
@@ -389,7 +392,8 @@ def _target_position(states: Mapping[str, Any], result: Any) -> Any:
     stayed inert and the winner's ``position`` is rewritten FROM the held read,
     so the cover is being commanded to where it already is and the physical read
     remains the honest answer. Keying on the position-axis flag confines the
-    change to bounds that actually moved the cover, which is #1175's scope.
+    change to bounds that actually re-targeted the winner, which is #1175's
+    scope.
 
     That leaves the tilt-clamp path on the held read even in the two cases where
     the dispatched number is not literally it — under ``CONF_INTERP``, where

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -354,8 +354,13 @@ class _PositionVerificationSensor(_ACPRestorableDiagnosticSensor):
 # ---------------------------------------------------------------------------
 
 
-def _cover_position_value(s: _ACPSensor) -> Any:
-    """Return where ACP is putting this cover — the Target Position value.
+def _target_position(states: Mapping[str, Any], result: Any) -> Any:
+    """Resolve where ACP is putting this cover — the Target Position value.
+
+    The single definition every Target Position surface reads: the sensor's own
+    state, its ``target_distance``, and its ``all_at_target`` verdict. They
+    described the same thing through three separate derivations before #1175,
+    which is how the state and the distance came to disagree.
 
     A hold winner keeps the cover's *physical* position rather than proposing a
     computed one, so ``held_position`` is the honest answer while the hold is
@@ -369,22 +374,34 @@ def _cover_position_value(s: _ACPSensor) -> Any:
     the cover is actively leaving (#1175).
 
     ⚠️ The gate is ``position_constraint_applied``, NOT ``skip_command``, and the
-    two are not interchangeable here. The tilt axis also clears ``skip_command``
-    (``registry._release_hold_for_tilt_clamp``) — but that path rewrites
-    ``position`` to the held read itself, so ``state`` and ``held`` already agree
-    and routing it through ``state`` would only push a raw motor read back
-    through ``coordinator._to_cover_frame``, which re-interpolates it under
-    ``CONF_INTERP``. Keying on the position-axis flag flips exactly the cases
-    where the dispatched value genuinely differs, and leaves the tilt-clamp path
-    alone.
+    two are not interchangeable. The tilt axis also clears ``skip_command``
+    (``registry._release_hold_for_tilt_clamp``) — but there the position axis
+    stayed inert and the winner's ``position`` is rewritten FROM the held read,
+    so the cover is being commanded to where it already is and the physical read
+    remains the honest answer. Keying on the position-axis flag confines the
+    change to bounds that actually moved the cover, which is #1175's scope.
+
+    That leaves the tilt-clamp path on the held read even in the two cases where
+    the dispatched number is not literally it — under ``CONF_INTERP``, where
+    ``coordinator._to_cover_frame`` interpolates the rewritten position on its
+    way to the wire, and on a coupled type, where
+    ``CoverTypePolicy.hold_reference_position`` decodes one abstract coverage
+    (#1179) while ``held_position`` stays the raw entry mean. Both predate this
+    gate and are unchanged by it; the interpolated-hold divergence is the known
+    limitation ``pipeline/handlers/motion_timeout.py`` and #1175 both flag, and
+    it is a separate fix — not something to launder through this predicate.
     """
-    held = s.data.states.get("held_position")
-    result = s.coordinator._pipeline_result  # noqa: SLF001
-    if held is not None and not (
-        result is not None and result.position_constraint_applied
-    ):
+    held = states.get("held_position")
+    clamped = result is not None and result.position_constraint_applied
+    if held is not None and not clamped:
         return held
-    return s.data.states["state"]
+    return states["state"]
+
+
+def _cover_position_value(s: _ACPSensor) -> Any:
+    """Return the Target Position sensor's own value."""
+    result = s.coordinator._pipeline_result  # noqa: SLF001
+    return _target_position(s.data.states, result)
 
 
 def _compute_distance_attrs(
@@ -441,6 +458,9 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         attrs["reason"] = _localized_reason(
             s.coordinator, pipeline_result.reason_payload, pipeline_result.reason
         )
+    # Resolved once and shared by both surfaces below, from the result already
+    # in hand — the sensor's value goes through the same helper (#1175).
+    target_position = _target_position(s.data.states, pipeline_result)
     diagnostics = s.coordinator.data.diagnostics if s.coordinator.data else None
     if diagnostics:
         position_explanation = diagnostics.get("position_explanation")
@@ -503,12 +523,13 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         }
 
         # all_at_target: True when every cover with a known position is within
-        # tolerance of the coordinator's current target position.
-        target = s.data.states.get("state")
+        # tolerance of the target this sensor reports. Measured against that
+        # target and not the raw ``state``, or a hold reads as "not at target"
+        # while every cover sits exactly where the hold is holding it (#1175).
         tolerance = s.coordinator._cmd_svc._position_tolerance  # noqa: SLF001
-        if target is not None:
+        if target_position is not None:
             try:
-                target_int = int(target)
+                target_int = int(target_position)
                 attrs["all_at_target"] = all(
                     pos is not None and abs(pos - target_int) <= tolerance
                     for pos in actual_positions.values()
@@ -518,11 +539,7 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         else:
             attrs["all_at_target"] = None
 
-    # Same value the sensor itself reports — one helper, so the distance can
-    # never describe a position the state does not (#1175).
-    distance_attrs = _compute_distance_attrs(
-        s.coordinator, snapshot, _cover_position_value(s)
-    )
+    distance_attrs = _compute_distance_attrs(s.coordinator, snapshot, target_position)
     if distance_attrs is not None:
         attrs.update(distance_attrs)
 

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -357,53 +357,28 @@ class _PositionVerificationSensor(_ACPRestorableDiagnosticSensor):
 def _target_position(states: Mapping[str, Any], result: Any) -> Any:
     """Resolve where ACP is putting this cover — the Target Position value.
 
-    The single definition behind all three of this sensor's target surfaces —
-    its own state, its ``target_distance``, and its ``all_at_target`` verdict.
-    Before #1175 each derived the target itself: the first two identically (and
-    identically wrong once a bound clamped), the third from the raw ``state``
-    with no ``held_position`` term at all, which is how a perfectly-held group
-    read as "not at target".
+    The one definition behind all three of this sensor's target surfaces — its
+    own state, its ``target_distance``, and its ``all_at_target`` verdict. Each
+    derived the target separately before #1175, and they disagreed.
 
     A hold winner keeps the cover's *physical* position rather than proposing a
     computed one, so ``held_position`` is the honest answer while the hold is
-    holding: it beats the value the hold merely shadows (#534 / #809).
+    holding: it beats the value the hold merely shadows (#534 / #809). It stops
+    being the answer once a user-configured bound outranks the holder and clamps
+    it — the hold no longer decides where this cover goes, while
+    ``held_position`` still carries the pre-clamp read (#1175).
 
-    It stops being the answer once a user-configured bound outranks the holder
-    and CLAMPS it. The registry writes the clamped value into ``position``, sets
-    ``position_constraint_applied``, and clears ``skip_command`` in one
-    ``dataclasses.replace`` — the hold no longer decides where this cover goes,
-    while ``held_position`` still carries the pre-clamp read. Reporting that read
-    then names a position the cover is being moved off (#1175).
+    ⚠️ The gate is ``position_constraint_applied``, NOT ``skip_command``. The
+    tilt axis clears ``skip_command`` too, but there the position axis stayed
+    inert and the winner's ``position`` was rewritten from the held read — the
+    cover is being commanded to where it already is, so the physical read is
+    still right. Only the position-axis flag means a bound re-targeted this
+    winner.
 
-    The flag says a bound re-targeted the winner; it does not promise the frame
-    reached the motor. ``_dispatch_for_cycle`` returns at the clock-window gate
-    before it ever consults ``position_constraint_applied``, so a non-safety
-    clamp resolved outside the user's start/end window updates this sensor and
-    sends nothing. That is deliberate and not special to holds: the pipeline
-    runs every cycle regardless, and outside the clock window ``DefaultHandler``
-    wins and is surfaced here the same way, undispatched. (Not ``solar`` — it
-    declines on ``in_time_window``, which is the clock window ANDed with the
-    daytime gate, so it can never be the winner while that gate suppresses.)
-    This surface is the pipeline's resolved target, not a dispatch log.
-
-    ⚠️ The gate is ``position_constraint_applied``, NOT ``skip_command``, and the
-    two are not interchangeable. The tilt axis also clears ``skip_command``
-    (``registry._release_hold_for_tilt_clamp``) — but there the position axis
-    stayed inert and the winner's ``position`` is rewritten FROM the held read,
-    so the cover is being commanded to where it already is and the physical read
-    remains the honest answer. Keying on the position-axis flag confines the
-    change to bounds that actually re-targeted the winner, which is #1175's
-    scope.
-
-    That leaves the tilt-clamp path on the held read even in the two cases where
-    the dispatched number is not literally it — under ``CONF_INTERP``, where
-    ``coordinator._to_cover_frame`` interpolates the rewritten position on its
-    way to the wire, and on a coupled type, where
-    ``CoverTypePolicy.hold_reference_position`` decodes one abstract coverage
-    (#1179) while ``held_position`` stays the raw entry mean. Both predate this
-    gate and are unchanged by it; the interpolated-hold divergence is the known
-    limitation ``pipeline/handlers/motion_timeout.py`` and #1175 both flag, and
-    it is a separate fix — not something to launder through this predicate.
+    ``position_constraint_applied`` says a bound re-targeted the winner; it does
+    NOT say a frame reached the motor, and this surface does not claim one did.
+    It reports the pipeline's resolved target — as it already does for every
+    winner the dispatch gates go on to suppress — not a dispatch log.
     """
     held = states.get("held_position")
     clamped = result is not None and result.position_constraint_applied

--- a/tests/_helpers/cover_position_sensor.py
+++ b/tests/_helpers/cover_position_sensor.py
@@ -1,14 +1,19 @@
 """A stub sensor for driving ``sensor._cover_position_attrs`` in unit tests.
 
-Three test modules had grown their own near-identical version of this builder,
-each wiring the same handful of coordinator members that ``_cover_position_attrs``
-touches on its way to the one branch that module cared about. Per
-CODING_GUIDELINES § cross-file test helpers, they share this one instead.
+``test_linear_position.py`` and ``test_sensor_linear_actual_positions.py`` had
+each grown their own near-identical version of this builder, wiring the same
+handful of coordinator members that ``_cover_position_attrs`` touches on its way
+to the one branch that module cared about. Per CODING_GUIDELINES § cross-file
+test helpers, they share this one instead.
 
 Every knob defaults to the inert value — no diagnostics, no snapshot positions,
 no transit or travel state, no lift travel (which short-circuits
 ``_compute_distance_attrs`` to ``None``) — so a caller sets only what its branch
 needs and the rest stays out of the way.
+
+⚠️ ``cover_type`` steers ``inverted_for`` only. ``coordinator._policy`` stays a
+``MagicMock`` with ``lift_travel_metres`` stubbed, so a caller that needs real
+per-type policy behaviour has to set ``_policy`` itself.
 """
 
 from __future__ import annotations

--- a/tests/_helpers/cover_position_sensor.py
+++ b/tests/_helpers/cover_position_sensor.py
@@ -3,8 +3,9 @@
 ``test_linear_position.py`` and ``test_sensor_linear_actual_positions.py`` had
 each grown their own near-identical version of this builder, wiring the same
 handful of coordinator members that ``_cover_position_attrs`` touches on its way
-to the one branch that module cared about. Per CODING_GUIDELINES § cross-file
-test helpers, they share this one instead.
+to the one branch that module cared about. Per CODING_GUIDELINES § "No Magic
+Numbers" ("fixtures and constants used in more than one test file go in
+``tests/_helpers/``"), they share this one instead.
 
 Every knob defaults to the inert value — no diagnostics, no snapshot positions,
 no transit or travel state, no lift travel (which short-circuits

--- a/tests/_helpers/cover_position_sensor.py
+++ b/tests/_helpers/cover_position_sensor.py
@@ -1,0 +1,78 @@
+"""A stub sensor for driving ``sensor._cover_position_attrs`` in unit tests.
+
+Three test modules had grown their own near-identical version of this builder,
+each wiring the same handful of coordinator members that ``_cover_position_attrs``
+touches on its way to the one branch that module cared about. Per
+CODING_GUIDELINES § cross-file test helpers, they share this one instead.
+
+Every knob defaults to the inert value — no diagnostics, no snapshot positions,
+no transit or travel state, no lift travel (which short-circuits
+``_compute_distance_attrs`` to ``None``) — so a caller sets only what its branch
+needs and the rest stays out of the way.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+
+def inverted_for(options: dict, *, cover_type: str = "cover_blind") -> bool:
+    """Evaluate the real ``position_axis_inverted`` property against *options*.
+
+    The effective inversion is derived from the entry options through the
+    policy's position axis (#1028), so a test that needs it must ask the
+    production property rather than hardcoding a bool.
+    """
+    coord = SimpleNamespace(
+        _policy=get_policy(cover_type),
+        config_entry=SimpleNamespace(options=options),
+    )
+    return AdaptiveDataUpdateCoordinator.position_axis_inverted.fget(coord)
+
+
+def make_cover_position_sensor(
+    *,
+    states: dict[str, Any] | None = None,
+    options: dict | None = None,
+    diagnostics: dict | None = None,
+    positions: dict[str, int | None] | None = None,
+    pipeline_result: Any = None,
+    lift_travel_metres: float | None = None,
+    cover_type: str = "cover_blind",
+    position_tolerance: int = 2,
+) -> MagicMock:
+    """Build a stub ``_ACPSensor`` wired for ``_cover_position_attrs``.
+
+    ``pipeline_result`` is passed through as-is — ``None`` (the default) means
+    "no cycle has run yet". Pass a ``SimpleNamespace``/``PipelineResult`` to
+    exercise the branches that read one; note that a bare ``MagicMock`` makes
+    every flag on it truthy, which silently sends ``_target_position`` down the
+    clamped branch.
+    """
+    options = options if options is not None else {}
+    s = MagicMock()
+    s.data.attributes = {}
+    s.data.states = (
+        states
+        if states is not None
+        else {"control": "solar", "state": 70, "held_position": None}
+    )
+    s.coordinator._pipeline_result = pipeline_result
+    s.coordinator.data.diagnostics = diagnostics
+    s.coordinator._cmd_svc.transit_states.return_value = {}
+    s.coordinator._cmd_svc.travel_plans.return_value = {}
+    s.coordinator._cmd_svc._position_tolerance = position_tolerance
+    s.coordinator.config_entry.options = options
+    s.coordinator._snapshot = (
+        SimpleNamespace(cover_positions=positions) if positions is not None else None
+    )
+    s.coordinator._policy.lift_travel_metres.return_value = lift_travel_metres
+    s.coordinator.position_axis_inverted = inverted_for(options, cover_type=cover_type)
+    return s

--- a/tests/test_linear_position.py
+++ b/tests/test_linear_position.py
@@ -9,19 +9,15 @@ from unittest.mock import MagicMock
 
 from custom_components.adaptive_cover_pro.sensor import _cover_position_attrs
 
+from tests._helpers.cover_position_sensor import make_cover_position_sensor
+
 
 def _make_sensor(diagnostics: dict) -> MagicMock:
-    """Minimal MagicMock sensor exercising only the diagnostics branch."""
-    s = MagicMock()
-    s.data.attributes = {}
-    s.data.states = {"control": "solar", "state": 31, "held_position": None}
-    s.coordinator._pipeline_result = None
-    s.coordinator.data.diagnostics = diagnostics
-    s.coordinator._cmd_svc.transit_states.return_value = {}
-    s.coordinator._snapshot = None
-    # lift_travel_metres None -> _compute_distance_attrs returns None (skip).
-    s.coordinator._policy.lift_travel_metres.return_value = None
-    return s
+    """Shared stub, pinned to this module's diagnostics branch."""
+    return make_cover_position_sensor(
+        states={"control": "solar", "state": 31, "held_position": None},
+        diagnostics=diagnostics,
+    )
 
 
 def test_linear_position_mirrored_from_diagnostics():

--- a/tests/test_pipeline/test_manual_override_held_position.py
+++ b/tests/test_pipeline/test_manual_override_held_position.py
@@ -21,12 +21,12 @@ from custom_components.adaptive_cover_pro.pipeline.types import (
     DecisionStep,
     PipelineResult,
 )
-from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.sensor import (
     _cover_position_attrs,
     _cover_position_value,
 )
 
+from tests._helpers.cover_position_sensor import make_cover_position_sensor
 from tests.test_pipeline.conftest import make_snapshot
 
 # ---------------------------------------------------------------------------
@@ -212,31 +212,27 @@ def test_sensor_cover_position_value_without_pipeline_result_keeps_held() -> Non
     assert _cover_position_value(s) == 50
 
 
-def _make_distance_sensor(states: dict, *, position_constraint_applied: bool):
-    """Sensor stub that drives ``_cover_position_attrs`` down the distance branch.
+def _make_attrs_sensor(
+    states: dict,
+    *,
+    position_constraint_applied: bool,
+    positions: dict[str, int | None] | None = None,
+):
+    """Shared stub, wired for the attribute surfaces that read the target.
 
-    Mirrors ``_make_sensor`` in tests/test_sensor_linear_actual_positions.py,
-    but gives ``lift_travel_metres`` a real value so ``_compute_distance_attrs``
+    ``lift_travel_metres`` gets a real 2 m so ``_compute_distance_attrs``
     actually runs instead of short-circuiting to None.
     """
-    s = _make_sensor_stub(
-        states, position_constraint_applied=position_constraint_applied
+    return make_cover_position_sensor(
+        states=states,
+        positions=positions,
+        pipeline_result=SimpleNamespace(
+            position_constraint_applied=position_constraint_applied,
+            reason_payload=None,
+            reason="x",
+        ),
+        lift_travel_metres=2.0,
     )
-    s.data.attributes = {}
-    s.coordinator._pipeline_result.reason_payload = None
-    s.coordinator._pipeline_result.reason = "x"
-    s.coordinator.data.diagnostics = None
-    s.coordinator._cmd_svc.transit_states.return_value = {}
-    s.coordinator._cmd_svc.travel_plans.return_value = {}
-    s.coordinator._cmd_svc._position_tolerance = 2
-    s.coordinator.config_entry.options = {}
-    s.coordinator._snapshot = SimpleNamespace(cover_positions=None)
-    s.coordinator._policy = get_policy("cover_blind")
-    s.coordinator._config_service.get_vertical_data.return_value = SimpleNamespace(
-        h_win=2.0
-    )
-    s.coordinator.position_axis_inverted = False
-    return s
 
 
 def test_distance_attrs_follow_the_dispatched_target_when_clamped() -> None:
@@ -245,7 +241,7 @@ def test_distance_attrs_follow_the_dispatched_target_when_clamped() -> None:
     Both Target Position surfaces read one helper, so a clamped hold cannot
     report 80 % while its distance still describes the pre-clamp 50 % (#1175).
     """
-    s = _make_distance_sensor(
+    s = _make_attrs_sensor(
         {"control": "manual", "state": 80, "held_position": 50},
         position_constraint_applied=True,
     )
@@ -256,12 +252,36 @@ def test_distance_attrs_follow_the_dispatched_target_when_clamped() -> None:
 
 def test_distance_attrs_follow_the_held_position_when_holding() -> None:
     """An unclamped hold keeps deriving the distance from the held read."""
-    s = _make_distance_sensor(
+    s = _make_attrs_sensor(
         {"control": "manual", "state": 80, "held_position": 50},
         position_constraint_applied=False,
     )
     attrs = _cover_position_attrs(s)
     assert attrs["target_distance"] == 1.0
+
+
+def test_all_at_target_measures_against_the_held_position_when_holding() -> None:
+    """Covers parked where the hold holds them ARE at target.
+
+    Measuring against the raw ``state`` compares them to the solar value the
+    hold merely shadows, so a perfectly-held group read as "not at target".
+    """
+    s = _make_attrs_sensor(
+        {"control": "manual", "state": 20, "held_position": 50},
+        position_constraint_applied=False,
+        positions={"cover.a": 50, "cover.b": 51},
+    )
+    assert _cover_position_attrs(s)["all_at_target"] is True
+
+
+def test_all_at_target_measures_against_the_dispatched_target_when_clamped() -> None:
+    """Once a bound clamps, the covers are judged against where it sent them."""
+    s = _make_attrs_sensor(
+        {"control": "manual", "state": 80, "held_position": 50},
+        position_constraint_applied=True,
+        positions={"cover.a": 50, "cover.b": 51},
+    )
+    assert _cover_position_attrs(s)["all_at_target"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_manual_override_held_position.py
+++ b/tests/test_pipeline/test_manual_override_held_position.py
@@ -21,7 +21,11 @@ from custom_components.adaptive_cover_pro.pipeline.types import (
     DecisionStep,
     PipelineResult,
 )
-from custom_components.adaptive_cover_pro.sensor import _cover_position_value
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.sensor import (
+    _cover_position_attrs,
+    _cover_position_value,
+)
 
 from tests.test_pipeline.conftest import make_snapshot
 
@@ -118,10 +122,26 @@ def test_handler_returns_none_when_override_inactive() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_sensor_stub(states: dict) -> MagicMock:
-    """Build a minimal mock of _ACPSensor with the given states dict."""
+def _make_sensor_stub(
+    states: dict,
+    *,
+    position_constraint_applied: bool | None = False,
+) -> MagicMock:
+    """Build a minimal mock of _ACPSensor with the given states dict.
+
+    ``position_constraint_applied`` must be set explicitly: on a bare
+    ``MagicMock`` the attribute is a truthy Mock, which would send every case
+    down the clamped branch and pass for the wrong reason. ``None`` stands for
+    "no pipeline result yet" (the pre-first-cycle read).
+    """
     s = MagicMock()
     s.data.states = states
+    if position_constraint_applied is None:
+        s.coordinator._pipeline_result = None
+    else:
+        s.coordinator._pipeline_result.position_constraint_applied = (
+            position_constraint_applied
+        )
     return s
 
 
@@ -147,6 +167,101 @@ def test_sensor_cover_position_value_handles_held_position_zero() -> None:
     """held_position=0 must be returned (0 is not None — explicit is-not-None check)."""
     s = _make_sensor_stub({"state": 75, "held_position": 0})
     assert _cover_position_value(s) == 0
+
+
+# ---------------------------------------------------------------------------
+# 9a. Sensor helper — a bound that clamped the hold (issue #1175)
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_clamped_hold_reports_the_dispatched_target() -> None:
+    """A bound that clamped the hold sent a command; report where it sent it.
+
+    The issue's repro: a min-mode floor at 80 outranking manual override
+    clamps a cover held at 50, and the registry clears ``skip_command`` in the
+    same breath. 80 is dispatched, so 80 is the target position — not the
+    pre-clamp read the hold no longer holds (#1175).
+    """
+    s = _make_sensor_stub(
+        {"state": 80, "held_position": 50}, position_constraint_applied=True
+    )
+    assert _cover_position_value(s) == 80
+
+
+def test_sensor_unclamped_hold_still_reports_the_held_position() -> None:
+    """No bound clamped, so the hold is genuinely holding — #534/#809 guard."""
+    s = _make_sensor_stub(
+        {"state": 20, "held_position": 50}, position_constraint_applied=False
+    )
+    assert _cover_position_value(s) == 50
+
+
+def test_sensor_clamped_hold_to_zero_reports_zero() -> None:
+    """A ceiling clamping a hold to 0 reports 0, not the held read."""
+    s = _make_sensor_stub(
+        {"state": 0, "held_position": 50}, position_constraint_applied=True
+    )
+    assert _cover_position_value(s) == 0
+
+
+def test_sensor_cover_position_value_without_pipeline_result_keeps_held() -> None:
+    """Before the first cycle there is no result to consult; keep the held read."""
+    s = _make_sensor_stub(
+        {"state": 20, "held_position": 50}, position_constraint_applied=None
+    )
+    assert _cover_position_value(s) == 50
+
+
+def _make_distance_sensor(states: dict, *, position_constraint_applied: bool):
+    """Sensor stub that drives ``_cover_position_attrs`` down the distance branch.
+
+    Mirrors ``_make_sensor`` in tests/test_sensor_linear_actual_positions.py,
+    but gives ``lift_travel_metres`` a real value so ``_compute_distance_attrs``
+    actually runs instead of short-circuiting to None.
+    """
+    s = _make_sensor_stub(
+        states, position_constraint_applied=position_constraint_applied
+    )
+    s.data.attributes = {}
+    s.coordinator._pipeline_result.reason_payload = None
+    s.coordinator._pipeline_result.reason = "x"
+    s.coordinator.data.diagnostics = None
+    s.coordinator._cmd_svc.transit_states.return_value = {}
+    s.coordinator._cmd_svc.travel_plans.return_value = {}
+    s.coordinator._cmd_svc._position_tolerance = 2
+    s.coordinator.config_entry.options = {}
+    s.coordinator._snapshot = SimpleNamespace(cover_positions=None)
+    s.coordinator._policy = get_policy("cover_blind")
+    s.coordinator._config_service.get_vertical_data.return_value = SimpleNamespace(
+        h_win=2.0
+    )
+    s.coordinator.position_axis_inverted = False
+    return s
+
+
+def test_distance_attrs_follow_the_dispatched_target_when_clamped() -> None:
+    """``target_distance`` is derived from the same value the sensor reports.
+
+    Both Target Position surfaces read one helper, so a clamped hold cannot
+    report 80 % while its distance still describes the pre-clamp 50 % (#1175).
+    """
+    s = _make_distance_sensor(
+        {"control": "manual", "state": 80, "held_position": 50},
+        position_constraint_applied=True,
+    )
+    attrs = _cover_position_attrs(s)
+    # 80 % of a 2 m window, not the 1.0 m the held 50 % would have given.
+    assert attrs["target_distance"] == 1.6
+
+
+def test_distance_attrs_follow_the_held_position_when_holding() -> None:
+    """An unclamped hold keeps deriving the distance from the held read."""
+    s = _make_distance_sensor(
+        {"control": "manual", "state": 80, "held_position": 50},
+        position_constraint_applied=False,
+    )
+    attrs = _cover_position_attrs(s)
+    assert attrs["target_distance"] == 1.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_linear_actual_positions.py
+++ b/tests/test_sensor_linear_actual_positions.py
@@ -10,46 +10,21 @@ whether the install is inverted.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from custom_components.adaptive_cover_pro.const import CONF_INTERP, CONF_INVERSE_STATE
-from custom_components.adaptive_cover_pro.coordinator import (
-    AdaptiveDataUpdateCoordinator,
-)
-from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.sensor import _cover_position_attrs
+
+from tests._helpers.cover_position_sensor import make_cover_position_sensor
 
 pytestmark = pytest.mark.unit
 
 
-def _inverted_for(options: dict) -> bool:
-    """Evaluate the real coordinator property against *options*."""
-    coord = SimpleNamespace(
-        _policy=get_policy("cover_blind"),
-        config_entry=SimpleNamespace(options=options),
-    )
-    return AdaptiveDataUpdateCoordinator.position_axis_inverted.fget(coord)
-
-
 def _make_sensor(*, options: dict, positions: dict | None) -> MagicMock:
-    """Minimal sensor mock exercising the snapshot.cover_positions branch."""
-    s = MagicMock()
-    s.data.attributes = {}
-    s.data.states = {"control": "solar", "state": 70, "held_position": None}
-    s.coordinator._pipeline_result = None
-    s.coordinator.data.diagnostics = None
-    s.coordinator._cmd_svc.transit_states.return_value = {}
-    s.coordinator._cmd_svc._position_tolerance = 2
-    s.coordinator._snapshot = (
-        SimpleNamespace(cover_positions=positions) if positions is not None else None
-    )
-    # lift_travel_metres None -> _compute_distance_attrs returns None (skip).
-    s.coordinator._policy.lift_travel_metres.return_value = None
-    s.coordinator.position_axis_inverted = _inverted_for(options)
-    return s
+    """Shared stub, pinned to this module's snapshot.cover_positions branch."""
+    return make_cover_position_sensor(options=options, positions=positions)
 
 
 def test_linear_actual_positions_inverted() -> None:


### PR DESCRIPTION
## Summary

The **Target Position** sensor preferred `held_position` unconditionally. That is right while a hold is holding — the field exists so the sensor shows where the cover physically sits rather than the value the hold shadows — but it stops being right the moment a user-configured bound outranks the holder and *clamps* it. The registry writes the clamped value into `position`, sets `position_constraint_applied`, and clears `skip_command` in one `dataclasses.replace`, so the hold no longer decides where the cover goes while `held_position` still carries the pre-clamp read.

Reachable today: a min-mode floor at 80% with priority 82 (above manual override's 80), cover parked at 50% by hand → ACP targets 80%, the sensor reported 50%.

I gated the preference on `position_constraint_applied` rather than `skip_command`. The tilt axis clears `skip_command` too, but there the position axis stayed inert and `position` was rewritten *from* the held read — the cover is being commanded to where it already is, so the physical read is still the right thing to show.

While unifying, two neighbouring surfaces turned out to derive the same target independently:

- `target_distance` carried a byte-for-byte copy of the old three lines, so it was stale in exactly the same cases.
- `all_at_target` measured against the raw `state`, ignoring `held_position` entirely — so a group parked exactly where a hold holds it read as *not* at target.

All three now resolve through one `_target_position(states, result)` helper, which also drops a duplicated `_pipeline_result` read per attributes build.

⚠️ **Behaviour note:** `all_at_target` is a recorded attribute, so its corrected semantics land in recorder history. It stays noisy for divergent multi-cover groups because `held_position` is the instance mean — that is #1174/#1179's territory, not this change's.

Out of scope, and unchanged: the interpolated-hold divergence (`CONF_INTERP` re-interpolating a held motor read) and the coupled-type `hold_reference_position` case. Both predate this gate; #1175's body and `motion_timeout.py`'s own comment record them.

## Testing

- ✅ 12865 tests passing (4 skipped, 17 xfailed)
- 7 new tests: the clamped/unclamped/zero-target/no-result matrix on the sensor value, both distance-attribute directions, and both `all_at_target` directions
- Consolidated three near-identical `_cover_position_attrs` stubs into `tests/_helpers/cover_position_sensor.py`
- Three opus audit rounds; `./scripts/lint` and `black --check` clean

## Related Issues

Refs #1175