### PR TITLE
fix: retire the sign-inverted vertical safety margin (#1173)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
@@ -113,8 +113,8 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
           projection decays smoothly to 0 as ``|γ| → 90°`` and stays 0 for
           ``|γ| ≥ 90°`` (sun behind the window plane), so there is no
           discontinuity — the issue #1025 defect. It intentionally ignores
-          ``sill_height`` / ``window_depth`` / the safety margin (they belonged
-          to the old, incorrect vertical-blind coupling) but keeps ``distance``.
+          ``sill_height`` / ``window_depth`` (they belonged to the old,
+          incorrect vertical-blind coupling) but keeps ``distance``.
         * **area**: keep the awning fully extended across the whole field of
           view (patio / area shading). ``calculate_position`` is only ever
           invoked when the sun is in-FOV, so returning full extension means

--- a/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
@@ -9,7 +9,7 @@ vertical wall.
 
 The engine subclasses :class:`AdaptiveVerticalCover` and reuses its edge-case
 handling, window-depth/sill effective-distance pipeline, ``cos(gamma)`` clamp,
-safety margin, and final clamp to the travel length. Only the projection and the
+and final clamp to the travel length. Only the projection and the
 illumination / ridge gates change.
 
 Geometry (vectors in a frame whose ``d̂_h`` is the down-slope *horizontal*

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -14,7 +14,7 @@ from ...const import (
     TRACE_KEY_POSITION_PCT,
     TRACE_KEY_SOL_ELEV_DEG,
 )
-from ...geometry import EdgeCaseHandler, SafetyMarginCalculator
+from ...geometry import EdgeCaseHandler
 from ...position_utils import PositionConverter
 from ..sun_geometry import clamped_cos_gamma, ray_x_at_window_plane
 from .base import AdaptiveGeneralCover
@@ -123,21 +123,6 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         """Get sill height from vert_config."""
         return self.vert_config.sill_height
 
-    def _calculate_safety_margin(self, gamma: float, sol_elev: float) -> float:
-        """Calculate angle-dependent safety margin multiplier (≥1.0).
-
-        Delegates to SafetyMarginCalculator utility class.
-
-        Args:
-            gamma: Surface solar azimuth in degrees (-180 to 180)
-            sol_elev: Sun elevation angle in degrees (0-90)
-
-        Returns:
-            Safety margin multiplier (1.0 to 1.45)
-
-        """
-        return SafetyMarginCalculator.calculate(gamma, sol_elev)
-
     def _handle_edge_cases(self) -> tuple[bool, float]:
         """Handle extreme angles with safe fallbacks.
 
@@ -227,7 +212,6 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
 
         Phase 1 (Automatic):
         - Edge case handling: Safe fallbacks for extreme sun angles
-        - Safety margins: Angle-dependent multipliers (1.0-1.45x)
 
         Phase 2 (Optional):
         - Window depth: a binary full-open gate for window reveals/frames
@@ -381,15 +365,23 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
                 )
                 return result
 
-        # Apply safety margin for extreme angles
-        safety_margin = self._calculate_safety_margin(self.gamma, self.sol_elev)
-        adjusted_height = base_height * safety_margin
+        # No safety margin on this axis (#1173): `position` is already the
+        # exposed-glass boundary derived above — `base_height` sits exactly
+        # on it with zero headroom (see the sill-geometry comment block).
+        # Multiplying it by anything > 1.0 can only push the exposed band
+        # PAST that boundary, i.e. it lets more sun in, never less — the
+        # opposite of a safety margin. The angle-dependent margin from
+        # SafetyMarginCalculator is applied correctly elsewhere: on the tilt
+        # axis (`tilt.py:304-331`, #783/#1089) it closes the slats further
+        # instead of opening the blind, which is the direction that
+        # actually adds slack.
+        adjusted_height = base_height
         result = float(np.clip(adjusted_height, 0, self.h_win))
         clamped_to_window = bool(adjusted_height > self.h_win)
 
         self.logger.debug(
             "Vertical calc: elev=%.1f°, gamma=%.1f°, dist=%.3f→%.3f (sill=%.3f), "
-            "base=%.3f, lintel_shadow=%.3f (below gate), margin=%.3f, adjusted=%.3f, "
+            "base=%.3f, lintel_shadow=%.3f (below gate), adjusted=%.3f, "
             "clipped=%.3f, source=%s",
             self.sol_elev,
             self.gamma,
@@ -398,14 +390,13 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
             sill_offset,
             base_height,
             depth_contribution,
-            safety_margin,
             adjusted_height,
             result,
             effective_distance_source,
         )
         self._last_calc_details = self._build_vertical_trace(
             edge_case_detected=False,
-            safety_margin=float(safety_margin),
+            safety_margin=1.0,
             effective_distance=float(effective_distance),
             effective_distance_source=effective_distance_source,
             window_depth_contribution=float(depth_contribution),

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -193,8 +193,8 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         Factored out of ``calculate_position`` so pitched-glass cover types
         (roof / skylight windows) can re-project the *same* effective distance
         onto a tilted plane without duplicating the surrounding edge-case /
-        window-depth / sill / safety-margin pipeline (CODING_GUIDELINES.md
-        "Code duplication is not okay").
+        window-depth / sill pipeline (CODING_GUIDELINES.md "Code duplication
+        is not okay").
 
         The divisor comes from the shared one-sided ``clamped_cos_gamma`` guard
         (#1030); the raw ``cos_gamma`` is still returned for the #682 trace.
@@ -349,16 +349,16 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
                     cos_gamma_clamped=float(cos_gamma_clamped),
                     path_length=float(path_length),
                     base_height=float(base_height),
-                    # No safety margin is applied on the gate path (it returns
-                    # before that step), so report it consistent with every
-                    # other branch: adjusted_height_m == base_height_m *
-                    # safety_margin (#1169 audit). The gated height that
-                    # actually drove the full-open decision is still fully
-                    # recoverable as base_height_m + window_depth_contribution_m
-                    # (the lintel shadow), so nothing is lost. The trade is
-                    # that clamped_to_window is now True here while
-                    # adjusted_height_m sits below h_win — on this path the
-                    # flag reports the gated height, not the adjusted one.
+                    # The vertical axis has no safety-margin step at all now
+                    # (#1173), so report the gate path consistent with every
+                    # other branch: adjusted_height_m == base_height_m. The
+                    # gated height that actually drove the full-open decision
+                    # is still fully recoverable as base_height_m +
+                    # window_depth_contribution_m (the lintel shadow), so
+                    # nothing is lost. The trade is that clamped_to_window is
+                    # now True here while adjusted_height_m sits below h_win —
+                    # on this path the flag reports the gated height, not the
+                    # adjusted one.
                     adjusted_height=float(base_height),
                     result=result,
                     clamped_to_window=clamped_to_window,

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -99,12 +99,15 @@ class SafetyMarginCalculator:
     def calculate(gamma: float, sol_elev: float) -> float:
         """Calculate the angle-dependent safety-margin multiplier (>= 1.0).
 
+        Composed of two additive terms atop the 1.0 baseline:
+
         - Gamma margin: increases at extreme horizontal angles
         - Elevation margin: increases at very low or high angles
 
         The tilt axis is the only consumer (`tilt.py`, #783/#1089): a
         multiplier > 1.0 there closes the slats further, the direction that
-        actually adds slack.
+        actually adds slack — but only when the user opts in via
+        `tilt_safety_margin` (it defaults to 0.0, an exact no-op).
 
         ⚠️ Do not apply this to the vertical axis's output position — it
         already sits exactly on the `distance_shaded_area` contract boundary
@@ -119,7 +122,8 @@ class SafetyMarginCalculator:
             sol_elev: Sun elevation angle in degrees (0-90)
 
         Returns:
-            Safety margin multiplier (1.0 to 1.45)
+            Safety margin multiplier (1.0 to `1.0 + SAFETY_MARGIN_USER_SLACK_MAX`,
+            currently 1.35 — the two elevation branches above never both fire).
 
         """
         return _safety_margin(gamma, sol_elev)

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -97,11 +97,19 @@ class SafetyMarginCalculator:
 
     @staticmethod
     def calculate(gamma: float, sol_elev: float) -> float:
-        """Calculate safety margin multiplier (≥1.0).
+        """Calculate the angle-dependent safety-margin multiplier (>= 1.0).
 
-        Increases blind extension at extreme angles to ensure effective sun blocking:
         - Gamma margin: increases at extreme horizontal angles
         - Elevation margin: increases at very low or high angles
+
+        The tilt axis is the only consumer (`tilt.py`, #783/#1089): a
+        multiplier > 1.0 there closes the slats further, the direction that
+        actually adds slack.
+
+        ⚠️ Do not apply this to the vertical axis's output position — it
+        already sits exactly on the `distance_shaded_area` contract boundary
+        with zero headroom, so multiplying by anything > 1.0 pushes it PAST
+        the boundary and lets more sun in, not less (#1173).
 
         Delegates to the module-level cached :func:`_safety_margin` so the result
         is shared across all instances at the same sun angles.

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -14,6 +14,7 @@ import pytest
 import numpy as np
 
 from custom_components.adaptive_cover_pro.calculation import AdaptiveVerticalCover
+from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
 from tests.cover_helpers import build_vertical_cover
 
 
@@ -77,8 +78,17 @@ def base_cover_params(mock_sun_data, mock_logger):
     }  # These flat kwargs are routed by build_vertical_cover() to typed configs
 
 
-class TestSafetyMargins:
-    """Test angle-dependent safety margin calculations."""
+class TestSafetyMarginCalculatorValues:
+    """Test SafetyMarginCalculator's angle-dependent multiplier values.
+
+    The vertical axis retired this multiplier from its output path (#1173:
+    it was sign-inverted there, increasing sun penetration instead of
+    reducing it). ``SafetyMarginCalculator`` itself is unchanged and still
+    correctly consumed by the tilt axis (`tilt.py`, #783/#1089), so these
+    tests call the calculator directly rather than through
+    ``AdaptiveVerticalCover`` — they pin the multiplier's *values*, not any
+    vertical-axis behaviour.
+    """
 
     def test_safety_margin_normal_angles_returns_baseline(self, base_cover_params):
         """Safety margin should be 1.0 for normal angles."""
@@ -88,37 +98,31 @@ class TestSafetyMargins:
         base_cover_params["sol_elev"] = 45.0
         cover = build_vertical_cover(**base_cover_params)
 
-        margin = cover._calculate_safety_margin(cover.gamma, cover.sol_elev)
+        margin = SafetyMarginCalculator.calculate(cover.gamma, cover.sol_elev)
         assert margin == 1.0
 
     def test_safety_margin_moderate_gamma_returns_baseline(self, base_cover_params):
         """Safety margin should be 1.0 for gamma <= 45°."""
-        cover = build_vertical_cover(**base_cover_params)
-
         for gamma in [0, 15, 30, 45]:
-            margin = cover._calculate_safety_margin(gamma, 45.0)
+            margin = SafetyMarginCalculator.calculate(gamma, 45.0)
             assert margin == 1.0, f"Expected 1.0 at gamma={gamma}, got {margin}"
 
     def test_safety_margin_extreme_gamma_increases(self, base_cover_params):
         """Safety margin should increase at extreme gamma angles."""
-        cover = build_vertical_cover(**base_cover_params)
-
         # Test progressive increase
-        margin_60 = cover._calculate_safety_margin(60.0, 45.0)
-        margin_75 = cover._calculate_safety_margin(75.0, 45.0)
-        margin_90 = cover._calculate_safety_margin(90.0, 45.0)
+        margin_60 = SafetyMarginCalculator.calculate(60.0, 45.0)
+        margin_75 = SafetyMarginCalculator.calculate(75.0, 45.0)
+        margin_90 = SafetyMarginCalculator.calculate(90.0, 45.0)
 
         assert 1.0 < margin_60 < margin_75 < margin_90
         assert margin_90 <= 1.2  # Max 20% increase
 
     def test_safety_margin_low_elevation_increases(self, base_cover_params):
         """Safety margin should increase at low elevations."""
-        cover = build_vertical_cover(**base_cover_params)
-
         # Test progressive increase as elevation decreases
-        margin_10 = cover._calculate_safety_margin(0.0, 10.0)
-        margin_5 = cover._calculate_safety_margin(0.0, 5.0)
-        margin_2 = cover._calculate_safety_margin(0.0, 2.0)
+        margin_10 = SafetyMarginCalculator.calculate(0.0, 10.0)
+        margin_5 = SafetyMarginCalculator.calculate(0.0, 5.0)
+        margin_2 = SafetyMarginCalculator.calculate(0.0, 2.0)
 
         assert margin_10 == 1.0  # Threshold
         assert 1.0 < margin_5 < margin_2
@@ -126,12 +130,10 @@ class TestSafetyMargins:
 
     def test_safety_margin_high_elevation_increases(self, base_cover_params):
         """Safety margin should increase at high elevations."""
-        cover = build_vertical_cover(**base_cover_params)
-
         # Test progressive increase as elevation increases
-        margin_75 = cover._calculate_safety_margin(0.0, 75.0)
-        margin_82 = cover._calculate_safety_margin(0.0, 82.5)
-        margin_90 = cover._calculate_safety_margin(0.0, 90.0)
+        margin_75 = SafetyMarginCalculator.calculate(0.0, 75.0)
+        margin_82 = SafetyMarginCalculator.calculate(0.0, 82.5)
+        margin_90 = SafetyMarginCalculator.calculate(0.0, 90.0)
 
         assert margin_75 == 1.0  # Threshold
         assert 1.0 < margin_82 < margin_90
@@ -139,32 +141,26 @@ class TestSafetyMargins:
 
     def test_safety_margin_combined_extremes(self, base_cover_params):
         """Safety margin should combine gamma and elevation effects."""
-        cover = build_vertical_cover(**base_cover_params)
-
         # Extreme gamma + low elevation
-        margin = cover._calculate_safety_margin(85.0, 5.0)
+        margin = SafetyMarginCalculator.calculate(85.0, 5.0)
         assert 1.2 < margin <= 1.35  # ~20% + ~7.5% combined
 
         # Extreme gamma + high elevation
-        margin = cover._calculate_safety_margin(85.0, 85.0)
+        margin = SafetyMarginCalculator.calculate(85.0, 85.0)
         assert 1.2 < margin <= 1.30  # ~20% + ~6.7% combined
 
     def test_safety_margin_symmetric_gamma(self, base_cover_params):
         """Safety margin should be symmetric for positive/negative gamma."""
-        cover = build_vertical_cover(**base_cover_params)
-
-        margin_pos = cover._calculate_safety_margin(70.0, 45.0)
-        margin_neg = cover._calculate_safety_margin(-70.0, 45.0)
+        margin_pos = SafetyMarginCalculator.calculate(70.0, 45.0)
+        margin_neg = SafetyMarginCalculator.calculate(-70.0, 45.0)
 
         assert margin_pos == margin_neg
 
     def test_safety_margin_smoothstep_interpolation(self, base_cover_params):
         """Safety margin should use smooth interpolation (no sharp transitions)."""
-        cover = build_vertical_cover(**base_cover_params)
-
         # Test smooth transition in gamma range
         margins = [
-            cover._calculate_safety_margin(gamma, 45.0) for gamma in range(45, 91, 5)
+            SafetyMarginCalculator.calculate(gamma, 45.0) for gamma in range(45, 91, 5)
         ]
 
         # Check monotonic increase
@@ -175,6 +171,78 @@ class TestSafetyMargins:
         diffs = [margins[i + 1] - margins[i] for i in range(len(margins) - 1)]
         max_diff = max(diffs)
         assert max_diff < 0.05  # No jump > 5%
+
+
+class TestVerticalSafetyMarginRetirement:
+    """Direction/no-op guards for the vertical safety margin fix (#1173).
+
+    ``TestSafetyMarginCalculatorValues`` above tests the multiplier's
+    *values*; these tests exercise its *effect* on ``calculate_position()``
+    — the assertion that would have caught the #1173 inversion when it
+    shipped (evidence packet TEST_GAP #3: "Eight tests assert ... None
+    asserts that applying the margin makes the cover shade more").
+    """
+
+    def test_vertical_margin_never_increases_penetration(self, base_cover_params):
+        """The vertical margin must never let more sun penetrate past the
+        configured ``distance`` than the base projection alone allows
+        (#1173) — a direction guard the 216-case contract grid never had.
+
+        ``h_win=8.0`` is deliberately taller than the grid's usual 0.62/2.2:
+        at ``h_win=2.2`` the base projection alone already saturates to
+        ``h_win`` once ``elev > 75``, which masks the high-elevation branch
+        of the margin behind clipping (clipping only ever *reduces*
+        penetration, so it can hide but never cause a violation). A taller
+        window keeps that branch observable so this sweep actually exercises
+        both elevation thresholds (``elev < 10`` and ``elev > 75``), not just
+        the gamma one — see TEST_GAP #2 in the #1173 evidence packet.
+        """
+        params = base_cover_params.copy()
+        params["distance"] = 1.5
+        params["h_win"] = 8.0
+
+        for gamma in range(-89, 90):
+            for elev in (2.1, *range(3, 90)):
+                cover = make_cover_with_angles(
+                    params, gamma=float(gamma), sol_elev=float(elev)
+                )
+                position = cover.calculate_position()
+                penetration = _lintel_gate_max_penetration(
+                    position, params["h_win"], 0.0, gamma, elev
+                )
+                assert penetration <= params["distance"] + 1e-9, (
+                    f"gamma={gamma} elev={elev}: position={position:.4f} -> "
+                    f"penetration={penetration:.4f} exceeds "
+                    f"distance={params['distance']}"
+                )
+
+    def test_no_op_inside_the_normal_envelope(self, base_cover_params):
+        """Inside |gamma| <= 45 deg and 10 <= elev <= 75 deg, calculate_position()
+        must exactly match the un-margined base projection.
+
+        Characterization test (passes both before and after this fix): the
+        margin's own thresholds are gamma>45, elev<10 and elev>75, so it is
+        already 1.0 throughout this envelope today, and after the fix it is
+        1.0 everywhere. This pins the #783/#1089-style no-op guarantee to the
+        vertical axis too, so a future change to either envelope — not this
+        fix — is what would break it.
+        """
+        params = base_cover_params.copy()
+        params["distance"] = 1.5
+        params["h_win"] = 2.2
+
+        for gamma in range(-45, 46):
+            for elev in range(10, 76):
+                cover = make_cover_with_angles(
+                    params, gamma=float(gamma), sol_elev=float(elev)
+                )
+                base_height, *_ = cover._project_drop(cover.distance)
+                expected = float(np.clip(base_height, 0, cover.h_win))
+                actual = cover.calculate_position()
+                assert actual == pytest.approx(expected), (
+                    f"gamma={gamma} elev={elev}: expected no-op position "
+                    f"{expected:.6f}, got {actual:.6f}"
+                )
 
 
 class TestEdgeCases:
@@ -665,67 +733,17 @@ def _lintel_gate_max_penetration(
     return z * math.cos(math.radians(gamma)) / math.tan(math.radians(elev))
 
 
-# SafetyMarginCalculator (geometry.py) inflates the returned position beyond
-# what the base projection alone would allow at extreme low elevation + high
-# gamma — a pre-existing characteristic of the angle-dependent safety margin,
-# not of window_depth: it reproduces bit-for-bit with window_depth=0 (the gate
-# never fires for any of these cases; the position is identical either way).
-# It predates #1169, is out of scope for this fix (no window_depth involved),
-# and is tracked by #1173 rather than being papered over here by weakening
-# the contract for every other configuration.
-_SAFETY_MARGIN_OVERSHOOT_CASES = {
-    (0.5, 0.62, 0.05, 60, 20),
-    (0.5, 0.62, 0.18, 60, 20),
-    (0.5, 2.2, 0.05, 60, 20),
-    (0.5, 2.2, 0.05, 60, 45),
-    (0.5, 2.2, 0.05, 75, 20),
-    (0.5, 2.2, 0.05, 75, 45),
-    (0.5, 2.2, 0.18, 60, 20),
-    (0.5, 2.2, 0.18, 60, 45),
-    (0.5, 2.2, 0.18, 75, 20),
-    (0.5, 2.2, 0.5, 60, 20),
-    (0.5, 2.2, 0.5, 60, 45),
-    (0.5, 2.2, 0.5, 75, 20),
-    (1.5, 2.2, 0.05, 60, 20),
-    (1.5, 2.2, 0.05, 75, 20),
-    (1.5, 2.2, 0.18, 60, 20),
-    (1.5, 2.2, 0.5, 60, 20),
-}
-
-
-def _lintel_gate_contract_case(
-    distance: float, h_win: float, depth: float, gamma: float, elev: float
-):
-    case = (distance, h_win, depth, gamma, elev)
-    if case in _SAFETY_MARGIN_OVERSHOOT_CASES:
-        return pytest.param(
-            *case,
-            marks=pytest.mark.xfail(
-                reason=(
-                    "#1173: SafetyMarginCalculator inflates position past the "
-                    f"distance_shaded_area contract at elev={elev:g}°, "
-                    f"gamma={gamma:g}° (distance={distance:g}, h_win={h_win:g}, "
-                    f"depth={depth:g}) — bit-identical with window_depth=0, so "
-                    "orthogonal to the #1169 lintel gate."
-                ),
-                strict=True,
-            ),
-        )
-    return case
-
-
 @pytest.mark.parametrize(
     "distance,h_win,depth,gamma,elev",
-    [
-        _lintel_gate_contract_case(*case)
-        for case in itertools.product(
+    list(
+        itertools.product(
             [0.0, 0.5, 1.5],
             [0.62, 2.2],
             [0.05, 0.18, 0.5],
             [0, 30, 60, 75],
             [20, 45, 75],
         )
-    ],
+    ),
 )
 def test_no_direct_sun_lands_past_the_configured_distance(
     base_cover_params, distance, h_win, depth, gamma, elev

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -101,13 +101,13 @@ class TestSafetyMarginCalculatorValues:
         margin = SafetyMarginCalculator.calculate(cover.gamma, cover.sol_elev)
         assert margin == 1.0
 
-    def test_safety_margin_moderate_gamma_returns_baseline(self, base_cover_params):
+    def test_safety_margin_moderate_gamma_returns_baseline(self):
         """Safety margin should be 1.0 for gamma <= 45°."""
         for gamma in [0, 15, 30, 45]:
             margin = SafetyMarginCalculator.calculate(gamma, 45.0)
             assert margin == 1.0, f"Expected 1.0 at gamma={gamma}, got {margin}"
 
-    def test_safety_margin_extreme_gamma_increases(self, base_cover_params):
+    def test_safety_margin_extreme_gamma_increases(self):
         """Safety margin should increase at extreme gamma angles."""
         # Test progressive increase
         margin_60 = SafetyMarginCalculator.calculate(60.0, 45.0)
@@ -117,7 +117,7 @@ class TestSafetyMarginCalculatorValues:
         assert 1.0 < margin_60 < margin_75 < margin_90
         assert margin_90 <= 1.2  # Max 20% increase
 
-    def test_safety_margin_low_elevation_increases(self, base_cover_params):
+    def test_safety_margin_low_elevation_increases(self):
         """Safety margin should increase at low elevations."""
         # Test progressive increase as elevation decreases
         margin_10 = SafetyMarginCalculator.calculate(0.0, 10.0)
@@ -128,7 +128,7 @@ class TestSafetyMarginCalculatorValues:
         assert 1.0 < margin_5 < margin_2
         assert margin_2 <= 1.15  # Max 15% increase
 
-    def test_safety_margin_high_elevation_increases(self, base_cover_params):
+    def test_safety_margin_high_elevation_increases(self):
         """Safety margin should increase at high elevations."""
         # Test progressive increase as elevation increases
         margin_75 = SafetyMarginCalculator.calculate(0.0, 75.0)
@@ -139,7 +139,7 @@ class TestSafetyMarginCalculatorValues:
         assert 1.0 < margin_82 < margin_90
         assert margin_90 <= 1.1  # Max 10% increase
 
-    def test_safety_margin_combined_extremes(self, base_cover_params):
+    def test_safety_margin_combined_extremes(self):
         """Safety margin should combine gamma and elevation effects."""
         # Extreme gamma + low elevation
         margin = SafetyMarginCalculator.calculate(85.0, 5.0)
@@ -149,14 +149,14 @@ class TestSafetyMarginCalculatorValues:
         margin = SafetyMarginCalculator.calculate(85.0, 85.0)
         assert 1.2 < margin <= 1.30  # ~20% + ~6.7% combined
 
-    def test_safety_margin_symmetric_gamma(self, base_cover_params):
+    def test_safety_margin_symmetric_gamma(self):
         """Safety margin should be symmetric for positive/negative gamma."""
         margin_pos = SafetyMarginCalculator.calculate(70.0, 45.0)
         margin_neg = SafetyMarginCalculator.calculate(-70.0, 45.0)
 
         assert margin_pos == margin_neg
 
-    def test_safety_margin_smoothstep_interpolation(self, base_cover_params):
+    def test_safety_margin_smoothstep_interpolation(self):
         """Safety margin should use smooth interpolation (no sharp transitions)."""
         # Test smooth transition in gamma range
         margins = [

--- a/tests/test_solar_calc_trace.py
+++ b/tests/test_solar_calc_trace.py
@@ -67,6 +67,17 @@ class TestVerticalTrace:
         assert details[TRACE_KEY_GAMMA_DEG] == pytest.approx(0.0)
         # position_pct is the raw vertical percentage (height / h_win * 100).
         assert details[TRACE_KEY_POSITION_PCT] == 25  # 0.5m / 2.0m
+        # No safety margin on the vertical axis (#1173): the normal
+        # fall-through path must report safety_margin=1.0 and
+        # adjusted_height_m == base_height_m * safety_margin, matching the
+        # invariant already pinned on the edge-case and lintel-gate branches.
+        # Asserting the identity alone would be vacuously satisfiable by a
+        # reintroduced margin applied to both sides, so pin the margin value
+        # too (#1169-style audit precedent).
+        assert details["safety_margin"] == 1.0
+        assert details["adjusted_height_m"] == pytest.approx(
+            details["base_height_m"] * details["safety_margin"]
+        )
 
     def test_normal_branch_native_types(self, vertical_cover_instance):
         vertical_cover_instance.calculate_position()


### PR DESCRIPTION
## Summary

`SafetyMarginCalculator` was applied to the wrong side of the vertical axis. On that axis `position` is the *exposed* glass band, and the projection `effective_distance*tan(theta)/cos(gamma)` lands exactly on the `distance_shaded_area` boundary with zero headroom, so multiplying it by a margin >= 1.0 opened the blind further and let *more* sun in. That is the opposite of what its docstring claimed ("increases blind extension at extreme angles to ensure effective sun blocking"). It was never a safety margin on this axis, only an inflation of the contract violation, and it survived because nothing asserted the contract until #1169 added a test.

Provenance: commit `100b1f19` added the margin alongside two edge cases that returned `h_win` for "full coverage". Both were later found inverted and removed by #304/#358 and #598/#600/#601. The margin was the third and last surviving artifact of the same inversion.

I removed the multiply from `calculate_position()`, deleted the unused `_calculate_safety_margin` delegate, and pinned `safety_margin=1.0` on all three trace paths so the #682 diagnostic key keeps its contract (the key is retained, so the Lovelace card contract holds). The multiplier itself is untouched: the tilt axis applies it correctly, in the closing direction and user-gated (#783/#1089).

### Why removal rather than a clamp

Clamping the post-margin position to the boundary is *mathematically identical* to deleting the multiply, since the boundary is `base_height` and the margin is always >= 1.0, so `min(base*margin, base) === base`. Verified: max absolute difference is exactly 0 across 112,320 configurations. A clamp would ship a provably inert multiplier that invites the next reader to restore it.

The alternative of accepting the overshoot was ruled out by the data. The 16 failing cases are not grazing angles: they all sit at elevation 20-45 degrees and gamma 60-75 degrees, inside the default 90 degree FOV and well above the 2 degree low-elevation floor. That is routine mid-morning geometry on a flanking facade.

### Behaviour change

Covers close slightly further at gamma > 45 degrees, or outside 10-75 degrees elevation. Inside `|gamma| <= 45` and `10 <= elev <= 75` the output is byte-identical. A 657,288-configuration sweep found **zero** cases where the change opens a cover further than before; worst-case additional coverage is 1.086 m. Overshoot removed ranges from 15.75 cm (gamma=0, elev=3) to 44.72 cm (gamma=85) at 1 m of configured distance, and up to 0.536 m at 2 m.

### Tests

The 16 `xfail(strict=True)` cases are gone, so `test_no_direct_sun_lands_past_the_configured_distance` now runs 216/216 with the assertion byte-identical to before. Two guards the suite never had are added:

- `test_vertical_margin_never_increases_penetration` sweeps gamma -89..89 by elevation 2.1..89 and asserts penetration never exceeds the configured distance. This covers the two elevation branches the 216-case grid never sampled (its elevation axis is 20/45/75, which never crosses the margin's own 10 and 75 degree thresholds). It uses `h_win=8.0` rather than 2.2 because at 2.2 the clipping masks the elev>75 branch entirely.
- `test_no_op_inside_the_normal_envelope` pins the byte-identical guarantee inside the normal envelope.

The pre-merge audit also found the normal-path trace invariant was pinned by nothing (injecting `safety_margin=1.23` left all tests green), so `test_normal_branch_keys` now asserts it. Each of the three trace call sites is now pinned by a different test.

### Regression guards

`#600` is the one worth a second look: it deleted the `|gamma| > 85` edge-case branch on the grounds that "the clamped formula plus the angle-dependent safety margin" replaced it. That rationale rested on the same inversion, so the protection was never real. A 16,464-configuration sweep in that band confirms the projection saturates to `h_win` identically with and without the margin, and all six `TestEdgeCases` guards stay green.

Also verified green: `TestLintelGate` (#1169), `TestVenetianTiltSafetyMargin` and the `SAFETY_MARGIN_USER_SLACK_MAX` lock (#783/#1089), the 72 `distance=0.0` params (#427), `test_solar_math_review.py` (#304/#358/#559), `test_solar_calc_trace.py` (#682), and `tests/test_engine/` (#1030).

A user-configurable vertical margin mirroring the tilt axis is tracked separately in #1220.

## Testing
- 12,875 tests passing (4 skipped, 1 unrelated xfail)

## Related Issues
Refs #1173
