### PR TITLE
fix: give is_safety a defined lifetime across skips and resends (#1165)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -3483,16 +3483,29 @@ class CoverCommandService:
             # Nothing was booked, so nothing has to be unwound — and the caller
             # counts no attempt against this entity.
             return False
-        # Capabilities are read on the FAR side of the acquisition, for the same
-        # reason ``apply_position`` re-derives ``_caps_for_plan`` after its own
-        # wait: the queue can hold a resend for tens of seconds while unrelated
-        # covers transmit, which is ample time for this entity to reload with
-        # different capabilities. Passing ``caps=`` on to
-        # ``_prepare_service_call`` also removes a duplicate fetch.
-        caps = self.get_cover_capabilities(entity_id)
-        axis = self._policy.select_default_axis(caps)
+        # Everything from the grant to the service call runs INSIDE the queue
+        # slot, and the single ``finally`` below hands it back on EVERY path out
+        # — the early returns, an exception, and a task cancellation alike. The
+        # same invariant ``apply_position`` states at its own acquisition: a
+        # missed release strands the slot until this entity happens to dispatch
+        # again, at which point every other member burns its whole budget before
+        # transmitting — unspaced and simultaneous, the exact collision #1189
+        # prevents. Nothing may be hoisted above the ``try``.
         transmitted = False
         try:
+            # Capabilities are read on the FAR side of the acquisition, for the
+            # same reason ``apply_position`` re-derives ``_caps_for_plan`` after
+            # its own wait: the queue can hold a resend for tens of seconds
+            # while unrelated covers transmit, which is ample time for this
+            # entity to reload with different capabilities. Passing ``caps=`` on
+            # to ``_prepare_service_call`` also removes a duplicate fetch.
+            #
+            # This read is a live raise site, which is why it sits under the
+            # ``try`` rather than beside the acquisition: ``check_cover_features``
+            # masks ``supported_features`` without guarding its type, so a cover
+            # publishing a non-int raises here.
+            caps = self.get_cover_capabilities(entity_id)
+            axis = self._policy.select_default_axis(caps)
             service, service_data, _ = self._prepare_service_call(
                 entity_id,
                 target,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -42,7 +42,12 @@ from . import gates
 from .diagnostics import DiagnosticsRecorder
 from .position_context import PositionContextTracker
 from .queue import CommandQueue, QueueGrant
-from .routing import ServiceCallPlan, build_special_positions, route_service_call
+from .routing import (
+    ServiceCallPlan,
+    build_special_positions,
+    is_my_preset_target,
+    route_service_call,
+)
 from .state_classifier import StateClassifier
 from .state_store import (
     PerEntityState,
@@ -1857,6 +1862,36 @@ class CoverCommandService:
                 )
             )
         ):
+            # THIS CYCLE'S safety verdict, recorded first and unconditionally —
+            # ahead of the booking block below and outside its value-change
+            # guard (issue #1165).
+            #
+            # `PerEntityState.is_safety` records the safety verdict for the
+            # entity ACP is currently tracking: it is a property of the
+            # protection, not of the booked number. So it is written on every
+            # path where `apply_position` reaches a decision about the entity —
+            # every real dispatch (`_prepare_service_call`) and every
+            # same_position skip — whether or not a target is booked this cycle.
+            # A reconciliation resend RESTATES it rather than re-deciding it,
+            # because a resend makes no new verdict; the only other writer is the
+            # blanket reset `clear_safety_targets()`.
+            #
+            # That lifetime is exactly why the verdict cannot ride inside the
+            # `(target, dispatch_token)` value-change guard below.
+            # `dispatch_token` IS a property of the booking, so that guard
+            # governs it correctly. A verdict governed by the same guard
+            # freezes instead: a since-cleared safety condition can never come
+            # back down, because the guard suppresses the write on precisely the
+            # cycles that re-confirm an unchanged target. A frozen True then
+            # survives `clear_non_safety_targets()` and makes
+            # `run_reconciliation_pass` steps 3/4 resend the target with
+            # auto_control off or outside the time window — what those steps
+            # exist to prevent.
+            #
+            # `self.state()` inserts a row, which is correct for a write on an
+            # entity ACP is actively commanding; the non-inserting `_get`
+            # discipline is scoped to read-only predicates (`is_target_unreached`).
+            self.state(entity_id).is_safety = context.is_safety
             # Book the target even though nothing is dispatched (issue #1158),
             # so get_diagnostics()["at_target"] and the Lovelace rails see a
             # value instead of a permanent None — for every sub-arm except
@@ -1908,21 +1943,9 @@ class CoverCommandService:
             # dispatch_token a prior real dispatch stamped it with (#1115) —
             # set_target(dispatch_token=None) would erase that provenance.
             #
-            # Deliberately do NOT write `is_safety` here. The two writers of
-            # `target` are NOT symmetrical: `_prepare_service_call` stamps
-            # `is_safety` unconditionally on every REAL dispatch, but this
-            # branch only writes when booking is allowed at all (above) AND
-            # the value changes. Mirroring that write under this narrower
-            # guard would let a since-cleared safety condition
-            # (context.is_safety flips back to False) freeze `is_safety=True`
-            # forever the moment a later skip re-confirms the same unchanged
-            # value (the guard suppresses the write entirely, so the stale
-            # True can never clear). A frozen True then survives
-            # `clear_non_safety_targets()` and makes `run_reconciliation_pass`
-            # resend it with auto_control off or outside the time window —
-            # precisely what its steps 3/4 exist to prevent. Leaving
-            # `is_safety` at its default (False) matches merge-base behaviour
-            # (no booking at all) for the one axis that matters here.
+            # This guard governs the `(target, dispatch_token)` pair and nothing
+            # else. The safety verdict is written at the top of this branch,
+            # deliberately outside it — see the lifetime rule there (#1165).
             _target_would_mismatch_actual = (
                 _current_is_genuine and _current != _plan.routed_target
             )
@@ -2637,11 +2660,14 @@ class CoverCommandService:
         # fallback) — so "can this cover verify a granular target?" is answered
         # consistently with how it is read and commanded. A cover that cannot
         # report the axis it was commanded on can only surface an endpoint.
+        #
+        # That question and "must a resend of this target re-route through
+        # stop_cover?" (``_execute_command``, issue #1134) are the SAME
+        # predicate — both ask whether the booked number is a My preset — so
+        # both delegate to ``is_my_preset_target`` rather than restating the
+        # formula.
         axis = self._policy.select_default_axis(caps)
-        if not caps_get(caps, axis.capability_key, default=True) and s.target not in (
-            POSITION_CLOSED,
-            POSITION_OPEN,
-        ):
+        if is_my_preset_target(caps, axis, s.target):
             return False
         return not self._at_target(actual, s.target)
 
@@ -2664,12 +2690,13 @@ class CoverCommandService:
            reconciliation does not fight the user's intentional move.
            Safety handlers (force override, weather) overwrite ``target_call``
            via ``apply_position(is_safety=True)`` so they are always protected.
-        4. If ``_auto_control_enabled`` is False and the entity is not in
-           ``_safety_targets`` → skip.  Safety targets (set via
+        4. If ``_auto_control_enabled`` is False and ``PerEntityState.is_safety``
+           is False → skip.  Safety targets (set via
            ``apply_position(is_safety=True)``) are still resent so covers reach
            a safe position regardless of the automatic control toggle.
-        5. If ``_in_time_window`` is False and entity is not in ``_safety_targets``
-           → skip.  Prevents stale daytime targets from being resent overnight.
+        5. If ``_in_time_window`` is False and ``PerEntityState.is_safety`` is
+           False → skip.  Prevents stale daytime targets from being resent
+           overnight.
         6. Compare actual position to ``target_call`` within tolerance.
         7. If match → reset retry count, done.
         8. If mismatch → ask the cover-type policy whether the entity is
@@ -2904,6 +2931,14 @@ class CoverCommandService:
             # value going back on the wire moves.
             resend_target = s.target
             resend_token = s.dispatch_token
+            # The safety verdict travels with the pair for the same reason the
+            # stamp does: a resend RESTATES the record rather than making a new
+            # decision, and ``_prepare_service_call`` rewrites ``is_safety``
+            # unconditionally on every booking. Left to its default, the first
+            # resend of a safety target would clear the very flag that steps 3/4
+            # just used to authorise it, and the next pass would skip it with
+            # auto_control off or outside the window (issue #1134).
+            resend_is_safety = s.is_safety
             if resend_target is None:
                 # Cleared out from under the pass (time-window close, reload).
                 # There is no longer a target to restate.
@@ -2975,6 +3010,7 @@ class CoverCommandService:
                 entity_id,
                 resend_target,
                 dispatch_token=resend_token,
+                is_safety=resend_is_safety,
                 queue_budget=wait_allowance,
             ):
                 self._logger.debug(
@@ -3184,11 +3220,15 @@ class CoverCommandService:
                 for this entity when a new target is recorded. Pass False from
                 ``_execute_command`` so reconciliation retries do not reset the
                 counter they themselves manage.
-            is_safety: If True, this target was set via a safety override
-                (force override, weather handler).  Adds the entity to
-                ``_safety_targets`` so reconciliation will resend it even when
-                automatic control is off or outside the time window.
-                Non-safety targets remove the entity from ``_safety_targets``.
+            is_safety: Whether the target being booked is protected by a safety
+                override (force override, weather handler). Written straight
+                onto ``PerEntityState.is_safety``, which
+                ``run_reconciliation_pass`` steps 3/4 read to decide whether to
+                resend with automatic control off or outside the time window.
+                ``apply_position`` passes THIS cycle's verdict;
+                ``_execute_command`` passes the flag its caller read alongside
+                the target it is restating, because a resend re-states the
+                record rather than making a new verdict (issue #1134).
             use_my_position: If True and the cover lacks set_cover_position,
                 send cover.stop_cover to trigger the hardware My preset instead
                 of falling back to open/close threshold routing.
@@ -3331,6 +3371,7 @@ class CoverCommandService:
         target: int,
         *,
         dispatch_token: Any = None,
+        is_safety: bool = False,
         queue_budget: float = COMMAND_QUEUE_MAX_WAIT_SECONDS,
     ) -> bool:
         """Send command directly, bypassing gate checks (reconciliation use only).
@@ -3356,6 +3397,28 @@ class CoverCommandService:
         read — re-reading the record would let a re-booking that landed during
         the caller's clearance await pair this target with another number's
         frame. A caller with no dispatch behind ``target`` leaves it ``None``.
+
+        ``is_safety`` is handled the same way, and for the same reason: a resend
+        RESTATES the record rather than reaching a new verdict, so the flag comes
+        from the caller's single read alongside ``target`` rather than being
+        re-read here. ``_prepare_service_call`` rewrites
+        ``PerEntityState.is_safety`` unconditionally on every booking, so leaving
+        this at its default cleared the very flag ``run_reconciliation_pass``
+        steps 3/4 had just used to authorise the resend — a safety target
+        un-protected itself on its own first retry (issue #1134). It stays a
+        caller-passed keyword rather than an internal ``self.state()`` read so
+        the second caller, ``TravelCalibrationManager``, is byte-identical: a
+        calibration sweep must never invent or preserve a safety target.
+
+        ``use_my_position`` is NOT passed by callers — it is DERIVED here from
+        the booked number via :func:`is_my_preset_target`, against capabilities
+        read on the far side of the queue wait. There is no recorded My flag to
+        restate (``send_my_position`` books its percent without ever entering
+        ``_prepare_service_call``), and defaulting it to ``False`` dropped the
+        resend past the My branch onto the open/close threshold: a My of 10
+        went back out as ``close_cover``, slamming the cover shut, and rebooked
+        the user's target as 0 (issue #1134). Calibration is unaffected — it
+        only ever drives the 0/100 endpoints, where the predicate is False.
 
         NB: callers are responsible for entity-loaded-ness. Reconciliation only
         runs for entities that already passed the cover_unavailable gate in
@@ -3384,12 +3447,23 @@ class CoverCommandService:
             # Nothing was booked, so nothing has to be unwound — and the caller
             # counts no attempt against this entity.
             return False
+        # Capabilities are read on the FAR side of the acquisition, for the same
+        # reason ``apply_position`` re-derives ``_caps_for_plan`` after its own
+        # wait: the queue can hold a resend for tens of seconds while unrelated
+        # covers transmit, which is ample time for this entity to reload with
+        # different capabilities. Passing ``caps=`` on to
+        # ``_prepare_service_call`` also removes a duplicate fetch.
+        caps = self.get_cover_capabilities(entity_id)
+        axis = self._policy.select_default_axis(caps)
         transmitted = False
         try:
             service, service_data, _ = self._prepare_service_call(
                 entity_id,
                 target,
+                caps=caps,
                 reset_retries=False,
+                is_safety=is_safety,
+                use_my_position=is_my_preset_target(caps, axis, target),
                 dispatch_token=dispatch_token,
             )
             if service is None:

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1927,57 +1927,68 @@ class CoverCommandService:
 
             # THIS CYCLE'S safety verdict (issues #1165 / #1134).
             #
-            # `PerEntityState.is_safety` describes THE ENTITY'S BOOKED TARGET:
-            # "is the number ACP currently has this cover down for a
-            # safety-protected one?" That is what its two readers ask —
-            # `clear_non_safety_targets()` decides whether to sweep the booked
-            # target, and `run_reconciliation_pass` steps 3/4 decide whether to
-            # resend it with automatic control off or outside the time window.
+            # `PerEntityState.is_safety` answers "is the number ACP currently
+            # has this cover down for a safety-protected one?" — the question
+            # its two readers ask. `clear_non_safety_targets()` uses it to
+            # decide whether to sweep the booked target; `run_reconciliation_pass`
+            # steps 3/4 use it to decide whether to resend that target with
+            # automatic control off or outside the time window. Both no-op when
+            # nothing is booked.
             #
-            # So the verdict is written whenever it is ABOUT the booked number:
+            # The two polarities are NOT symmetrical, so the write is not
+            # either:
             #
-            # - every real dispatch (`_prepare_service_call`), which books and
-            #   stamps in the same breath, so the two can never disagree;
-            # - every same_position skip whose booked target is the one this
-            #   cycle routed to — including the cycles where the booking guard
-            #   above suppressed `set_target` because the value did not change,
-            #   which is exactly issue #1165's requirement. The verdict must NOT
-            #   ride inside that guard: `dispatch_token` is a property of the
-            #   booking so the guard governs it correctly, but a verdict under
-            #   the same guard freezes, because the guard suppresses the write
-            #   on precisely the cycles that re-confirm an unchanged target. A
-            #   frozen True survives `clear_non_safety_targets()` and gets
-            #   resent by steps 3/4 — what they exist to prevent;
-            # - every same_position skip on an entity with nothing booked, where
-            #   there is no target for the verdict to contradict (and both
-            #   readers are no-ops on a target-less entity anyway).
+            # - REVOKING is unconditional. It only takes away a licence to act
+            #   outside those two gates, which is safe on any number — booked,
+            #   foreign, or absent. Withholding it IS issue #1165: a safety
+            #   dispatch books 60, the cover comes to rest short of it (nothing
+            #   chases it — position matching is off by default), and every
+            #   later cycle skips inside endpoint tolerance of 0 with the
+            #   booking withheld (#1158). A gated revoke would then never fire
+            #   again: 60 stays protected forever, survives every sweep, and is
+            #   re-driven at night with automatic control off the moment the
+            #   user enables position matching.
+            # - GRANTING requires the booked target to be the one this cycle
+            #   routed to, because a licence must attach to the number the
+            #   safety decision was actually about. The same withheld-booking
+            #   sub-arm is where that can go wrong in the other direction: a
+            #   solar-booked 60 the cover missed, plus a weather cycle that
+            #   skips because the cover happens to sit within tolerance of the
+            #   0 endpoint, would mark 60 safety-protected — #1165's own defect
+            #   with the polarity reversed, protecting and re-driving a number
+            #   no safety handler asked for.
             #
-            # And it is withheld in exactly one case: the skip books nothing
-            # (arm 1's endpoint-tolerance sub-arm, #1158) AND the entity is
-            # still holding a FOREIGN target — some earlier decision's number,
-            # not the one this cycle routed to. This cycle's verdict is not
-            # about that number, so the flag keeps describing the decision that
-            # did produce it. Stamping it there is #1165's own defect with the
-            # polarity reversed: a solar-booked 60 that the cover missed, plus a
-            # weather cycle that skips because the cover happens to sit within
-            # tolerance of the 0 endpoint, would mark 60 safety-protected —
-            # surviving the sweep and driving the cover to 60 at night with
-            # automatic control off, for a number the safety handler never
-            # asked for. Note the gate is read AFTER the booking block, so the
-            # three arms that do book have already made the booked target this
-            # cycle's routed target and write normally.
+            #   `_plan.routed_target` is a plain `int`, never None, so that one
+            #   equality also declines to grant on an entity with NOTHING
+            #   booked. That is deliberate, not incidental: no booked number
+            #   means no subject for the verdict, and while both readers ignore
+            #   a target-less row today, five `set_target` sites book without
+            #   touching the verdict (listed on `PerEntityState.is_safety`) —
+            #   any of them would inherit the licence for free. The venetian
+            #   carriage rebase is reachable from this very cycle, since
+            #   `_service_secondary_axis` runs just below.
+            #
+            # Neither polarity may ride inside the booking's value-change guard
+            # above. That guard governs `dispatch_token` correctly — the stamp
+            # describes the booking — but it suppresses the write on exactly
+            # the cycles that re-confirm an unchanged target, which is where a
+            # verdict would freeze. Reading `get_target` AFTER the guard is
+            # deliberate for the opposite reason: the arms that DO book have
+            # already made the booked target this cycle's routed target, so
+            # they grant normally.
             #
             # A reconciliation resend RESTATES this flag rather than re-deciding
             # it (`_execute_command` passes the recorded value through, #1134),
-            # because a resend makes no new verdict. The only other writer is
-            # the blanket reset `clear_safety_targets()`.
+            # because a resend makes no new verdict.
             #
             # `self.state()` inserts a row, which is correct for a write on an
             # entity ACP is actively commanding; the non-inserting `_get`
             # discipline is scoped to read-only predicates (`is_target_unreached`).
             _booked_target = self.get_target(entity_id)
-            if _booked_target is None or _booked_target == _plan.routed_target:
-                self.state(entity_id).is_safety = context.is_safety
+            if not context.is_safety:
+                self.state(entity_id).is_safety = False
+            elif _booked_target == _plan.routed_target:
+                self.state(entity_id).is_safety = True
 
             # Secondary axis LAST: on a venetian this may rebase the target
             # via set_commanded_position (== set_target) after a tilt-only

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1862,36 +1862,6 @@ class CoverCommandService:
                 )
             )
         ):
-            # THIS CYCLE'S safety verdict, recorded first and unconditionally —
-            # ahead of the booking block below and outside its value-change
-            # guard (issue #1165).
-            #
-            # `PerEntityState.is_safety` records the safety verdict for the
-            # entity ACP is currently tracking: it is a property of the
-            # protection, not of the booked number. So it is written on every
-            # path where `apply_position` reaches a decision about the entity —
-            # every real dispatch (`_prepare_service_call`) and every
-            # same_position skip — whether or not a target is booked this cycle.
-            # A reconciliation resend RESTATES it rather than re-deciding it,
-            # because a resend makes no new verdict; the only other writer is the
-            # blanket reset `clear_safety_targets()`.
-            #
-            # That lifetime is exactly why the verdict cannot ride inside the
-            # `(target, dispatch_token)` value-change guard below.
-            # `dispatch_token` IS a property of the booking, so that guard
-            # governs it correctly. A verdict governed by the same guard
-            # freezes instead: a since-cleared safety condition can never come
-            # back down, because the guard suppresses the write on precisely the
-            # cycles that re-confirm an unchanged target. A frozen True then
-            # survives `clear_non_safety_targets()` and makes
-            # `run_reconciliation_pass` steps 3/4 resend the target with
-            # auto_control off or outside the time window — what those steps
-            # exist to prevent.
-            #
-            # `self.state()` inserts a row, which is correct for a write on an
-            # entity ACP is actively commanding; the non-inserting `_get`
-            # discipline is scoped to read-only predicates (`is_target_unreached`).
-            self.state(entity_id).is_safety = context.is_safety
             # Book the target even though nothing is dispatched (issue #1158),
             # so get_diagnostics()["at_target"] and the Lovelace rails see a
             # value instead of a permanent None — for every sub-arm except
@@ -1944,8 +1914,8 @@ class CoverCommandService:
             # set_target(dispatch_token=None) would erase that provenance.
             #
             # This guard governs the `(target, dispatch_token)` pair and nothing
-            # else. The safety verdict is written at the top of this branch,
-            # deliberately outside it — see the lifetime rule there (#1165).
+            # else. The safety verdict is written just below, deliberately
+            # outside it — see the lifetime rule there (#1165).
             _target_would_mismatch_actual = (
                 _current_is_genuine and _current != _plan.routed_target
             )
@@ -1954,6 +1924,61 @@ class CoverCommandService:
                 and self.get_target(entity_id) != _plan.routed_target
             ):
                 self.set_target(entity_id, _plan.routed_target, dispatch_token=None)
+
+            # THIS CYCLE'S safety verdict (issues #1165 / #1134).
+            #
+            # `PerEntityState.is_safety` describes THE ENTITY'S BOOKED TARGET:
+            # "is the number ACP currently has this cover down for a
+            # safety-protected one?" That is what its two readers ask —
+            # `clear_non_safety_targets()` decides whether to sweep the booked
+            # target, and `run_reconciliation_pass` steps 3/4 decide whether to
+            # resend it with automatic control off or outside the time window.
+            #
+            # So the verdict is written whenever it is ABOUT the booked number:
+            #
+            # - every real dispatch (`_prepare_service_call`), which books and
+            #   stamps in the same breath, so the two can never disagree;
+            # - every same_position skip whose booked target is the one this
+            #   cycle routed to — including the cycles where the booking guard
+            #   above suppressed `set_target` because the value did not change,
+            #   which is exactly issue #1165's requirement. The verdict must NOT
+            #   ride inside that guard: `dispatch_token` is a property of the
+            #   booking so the guard governs it correctly, but a verdict under
+            #   the same guard freezes, because the guard suppresses the write
+            #   on precisely the cycles that re-confirm an unchanged target. A
+            #   frozen True survives `clear_non_safety_targets()` and gets
+            #   resent by steps 3/4 — what they exist to prevent;
+            # - every same_position skip on an entity with nothing booked, where
+            #   there is no target for the verdict to contradict (and both
+            #   readers are no-ops on a target-less entity anyway).
+            #
+            # And it is withheld in exactly one case: the skip books nothing
+            # (arm 1's endpoint-tolerance sub-arm, #1158) AND the entity is
+            # still holding a FOREIGN target — some earlier decision's number,
+            # not the one this cycle routed to. This cycle's verdict is not
+            # about that number, so the flag keeps describing the decision that
+            # did produce it. Stamping it there is #1165's own defect with the
+            # polarity reversed: a solar-booked 60 that the cover missed, plus a
+            # weather cycle that skips because the cover happens to sit within
+            # tolerance of the 0 endpoint, would mark 60 safety-protected —
+            # surviving the sweep and driving the cover to 60 at night with
+            # automatic control off, for a number the safety handler never
+            # asked for. Note the gate is read AFTER the booking block, so the
+            # three arms that do book have already made the booked target this
+            # cycle's routed target and write normally.
+            #
+            # A reconciliation resend RESTATES this flag rather than re-deciding
+            # it (`_execute_command` passes the recorded value through, #1134),
+            # because a resend makes no new verdict. The only other writer is
+            # the blanket reset `clear_safety_targets()`.
+            #
+            # `self.state()` inserts a row, which is correct for a write on an
+            # entity ACP is actively commanding; the non-inserting `_get`
+            # discipline is scoped to read-only predicates (`is_target_unreached`).
+            _booked_target = self.get_target(entity_id)
+            if _booked_target is None or _booked_target == _plan.routed_target:
+                self.state(entity_id).is_safety = context.is_safety
+
             # Secondary axis LAST: on a venetian this may rebase the target
             # via set_commanded_position (== set_target) after a tilt-only
             # send back-drives the carriage (#33/#187), and that rebase must

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -67,6 +67,7 @@ __all__ = [
     "TravelPlan",
     "build_special_positions",
     "build_travel_plan",
+    "is_my_preset_target",
     "route_service_call",
 ]
 
@@ -1915,7 +1916,7 @@ class CoverCommandService:
             #
             # This guard governs the `(target, dispatch_token)` pair and nothing
             # else. The safety verdict is written just below, deliberately
-            # outside it — see the lifetime rule there (#1165).
+            # outside it — see `_record_safety_verdict` (#1165).
             _target_would_mismatch_actual = (
                 _current_is_genuine and _current != _plan.routed_target
             )
@@ -1925,70 +1926,23 @@ class CoverCommandService:
             ):
                 self.set_target(entity_id, _plan.routed_target, dispatch_token=None)
 
-            # THIS CYCLE'S safety verdict (issues #1165 / #1134).
+            # THIS CYCLE'S safety verdict (issue #1165). The asymmetric rule and
+            # the failure behind each half live on `_record_safety_verdict`;
+            # what belongs HERE is the placement.
             #
-            # `PerEntityState.is_safety` answers "is the number ACP currently
-            # has this cover down for a safety-protected one?" — the question
-            # its two readers ask. `clear_non_safety_targets()` uses it to
-            # decide whether to sweep the booked target; `run_reconciliation_pass`
-            # steps 3/4 use it to decide whether to resend that target with
-            # automatic control off or outside the time window. Both no-op when
-            # nothing is booked.
+            # BELOW the booking and OUTSIDE its value-change guard. Outside,
+            # because that guard suppresses the write on exactly the cycles
+            # that re-confirm an unchanged target — where a verdict freezes.
+            # Below, because by then every arm that books has made the booked
+            # target this cycle's routed target (including when the guard
+            # suppressed the write for already being equal), so those arms
+            # grant normally. Only the withheld-booking sub-arm can leave a
+            # DIFFERENT number booked, and there the grant declines.
             #
-            # The two polarities are NOT symmetrical, so the write is not
-            # either:
-            #
-            # - REVOKING is unconditional. It only takes away a licence to act
-            #   outside those two gates, which is safe on any number — booked,
-            #   foreign, or absent. Withholding it IS issue #1165: a safety
-            #   dispatch books 60, the cover comes to rest short of it (nothing
-            #   chases it — position matching is off by default), and every
-            #   later cycle skips inside endpoint tolerance of 0 with the
-            #   booking withheld (#1158). A gated revoke would then never fire
-            #   again: 60 stays protected forever, survives every sweep, and is
-            #   re-driven at night with automatic control off the moment the
-            #   user enables position matching.
-            # - GRANTING requires the booked target to be the one this cycle
-            #   routed to, because a licence must attach to the number the
-            #   safety decision was actually about. The same withheld-booking
-            #   sub-arm is where that can go wrong in the other direction: a
-            #   solar-booked 60 the cover missed, plus a weather cycle that
-            #   skips because the cover happens to sit within tolerance of the
-            #   0 endpoint, would mark 60 safety-protected — #1165's own defect
-            #   with the polarity reversed, protecting and re-driving a number
-            #   no safety handler asked for.
-            #
-            #   `_plan.routed_target` is a plain `int`, never None, so that one
-            #   equality also declines to grant on an entity with NOTHING
-            #   booked. That is deliberate, not incidental: no booked number
-            #   means no subject for the verdict, and while both readers ignore
-            #   a target-less row today, five `set_target` sites book without
-            #   touching the verdict (listed on `PerEntityState.is_safety`) —
-            #   any of them would inherit the licence for free. The venetian
-            #   carriage rebase is reachable from this very cycle, since
-            #   `_service_secondary_axis` runs just below.
-            #
-            # Neither polarity may ride inside the booking's value-change guard
-            # above. That guard governs `dispatch_token` correctly — the stamp
-            # describes the booking — but it suppresses the write on exactly
-            # the cycles that re-confirm an unchanged target, which is where a
-            # verdict would freeze. Reading `get_target` AFTER the guard is
-            # deliberate for the opposite reason: the arms that DO book have
-            # already made the booked target this cycle's routed target, so
-            # they grant normally.
-            #
-            # A reconciliation resend RESTATES this flag rather than re-deciding
-            # it (`_execute_command` passes the recorded value through, #1134),
-            # because a resend makes no new verdict.
-            #
-            # `self.state()` inserts a row, which is correct for a write on an
-            # entity ACP is actively commanding; the non-inserting `_get`
-            # discipline is scoped to read-only predicates (`is_target_unreached`).
-            _booked_target = self.get_target(entity_id)
-            if not context.is_safety:
-                self.state(entity_id).is_safety = False
-            elif _booked_target == _plan.routed_target:
-                self.state(entity_id).is_safety = True
+            # And ABOVE `_service_secondary_axis`, which on a venetian may
+            # rebase the target — one of the verdict-blind `set_target` sites
+            # listed on the field, and the one reachable from this very cycle.
+            self._record_safety_verdict(entity_id, context, _plan.routed_target)
 
             # Secondary axis LAST: on a venetian this may rebase the target
             # via set_commanded_position (== set_target) after a tilt-only
@@ -2026,6 +1980,15 @@ class CoverCommandService:
                 # and min-delta check) — give it the same chance the
                 # same_position branch above already gives it, before this
                 # skip drops the carriage command.
+                #
+                # Same verdict rule as that branch, for the same reason and in
+                # the same position (before the secondary axis can rebase the
+                # target): a carriage-hysteresis hold is not a safety decision,
+                # and leaving the previous cycle's verdict standing is what
+                # #1165 reports. This gate books nothing, so the booked number
+                # is whatever an earlier decision left — which is exactly why
+                # the grant half tests it rather than assuming it.
+                self._record_safety_verdict(entity_id, context, _plan.routed_target)
                 await self._service_secondary_axis(
                     entity_id,
                     current_position=_current,
@@ -2048,7 +2011,10 @@ class CoverCommandService:
             if not self._check_time_delta(entity_id, context.time_threshold):
                 _elapsed = self._elapsed_minutes(entity_id)
                 # Issue #954: delta_time is a carriage rate-limiter, not a
-                # tilt gate — same reasoning as delta_too_small above.
+                # tilt gate — same reasoning as delta_too_small above. A rate
+                # limiter is not a safety decision either, so the verdict is
+                # recorded here too (#1165).
+                self._record_safety_verdict(entity_id, context, _plan.routed_target)
                 await self._service_secondary_axis(
                     entity_id,
                     current_position=_current,
@@ -2824,8 +2790,12 @@ class CoverCommandService:
 
             # 4. Skip non-safety targets outside the operational time window.
             # Prevents stale daytime targets from being resent overnight.
-            # Safety targets (force override, weather, end_time_default) are
-            # always resent regardless of the time window.
+            # Safety targets (force override, weather) are always resent
+            # regardless of the time window. The end-of-window return-to-default
+            # is NOT one of them: ``_on_window_closed`` builds its context with
+            # is_safety=False on purpose, because safety-tagging that send lets
+            # reconciliation resurrect it hours later once a manual override
+            # expires (issues #215/#216).
             if not self._in_time_window and not s.is_safety:
                 self._logger.debug(
                     "Reconcile: %s skipped — outside time window", entity_id
@@ -3184,6 +3154,70 @@ class CoverCommandService:
         """Return minutes elapsed since last command to entity_id, or None."""
         return gates.elapsed_minutes(get_last_updated(entity_id, self._hass))
 
+    def _record_safety_verdict(
+        self, entity_id: str, context: PositionContext, routed_target: int
+    ) -> None:
+        """Record THIS cycle's safety verdict on a skip that dispatches nothing.
+
+        ``PerEntityState.is_safety`` is a verdict ABOUT the booked number — see
+        the field for what it means and who reads it. ``_prepare_service_call``
+        writes it on every real dispatch. The three hysteresis gates in
+        ``apply_position`` that return without dispatching (``same_position``,
+        ``delta_too_small``, ``time_delta_too_small``) write it through here
+        instead, because a skipped cycle still reached a verdict, and a verdict
+        nobody records is the previous cycle's, indefinitely.
+
+        The two directions are NOT symmetrical, so this write is not either:
+
+        * REVOKING is unconditional. It only takes away a licence to act
+          outside ``clear_non_safety_targets()`` and reconciliation steps 3/4,
+          which is safe on any number — booked, foreign, or absent. Withholding
+          it IS issue #1165: a safety dispatch books 60, the cover comes to
+          rest short of it (nothing chases it — position matching is off by
+          default), and every later cycle skips with the booking withheld
+          (#1158). A gated revoke then never fires again — 60 stays protected
+          forever, survives every sweep, and is re-driven at night with
+          automatic control off the moment the user enables position matching.
+        * GRANTING requires the booked target to BE ``routed_target``, because
+          a licence must attach to the number the safety decision was actually
+          about. Without that equality a solar-booked 60 the cover missed, plus
+          a safety cycle that skips on some other number, would mark 60
+          safety-protected — #1165's own defect with the polarity reversed,
+          protecting and re-driving a number no safety handler asked for.
+          ``routed_target`` is a plain ``int``, never None, so the same
+          equality also declines to grant on a row with NOTHING booked; that is
+          deliberate, for the inheritance reason listed on the field.
+
+        Neither direction may ride inside a booking's value-change guard. Such
+        a guard is correct for ``dispatch_token`` — the stamp describes the
+        booking — but it suppresses the write on exactly the cycles that
+        re-confirm an unchanged target, which is where a verdict freezes.
+
+        At the two delta gates the GRANT half is currently unreachable: every
+        ``PositionContext`` producer that sets ``is_safety`` also sets
+        ``force``, and those gates run only under ``not force``. They are still
+        routed through this one rule rather than a revoke-only variant, so the
+        three sites cannot drift and the grant does not have to be re-argued if
+        that coupling is ever relaxed.
+
+        ``self.state()`` inserts a row, which is correct for a write on an
+        entity ACP is actively commanding; the non-inserting ``_get``
+        discipline is scoped to read-only predicates (``is_target_unreached``).
+
+        Args:
+            entity_id: The cover this cycle is commanding.
+            context: This cycle's position context; ``is_safety`` is the
+                verdict being recorded.
+            routed_target: The number this cycle's routing settled on
+                (``ServiceCallPlan.routed_target``). A grant only lands when
+                that is also what is booked.
+
+        """
+        if not context.is_safety:
+            self.state(entity_id).is_safety = False
+        elif self.get_target(entity_id) == routed_target:
+            self.state(entity_id).is_safety = True
+
     def _skip(
         self,
         entity_id: str,
@@ -3504,6 +3538,19 @@ class CoverCommandService:
             # ``try`` rather than beside the acquisition: ``check_cover_features``
             # masks ``supported_features`` without guarding its type, so a cover
             # publishing a non-int raises here.
+            #
+            # ``_prepare_service_call`` derives the same axis again from the
+            # same ``caps`` object when it routes. Left duplicated on purpose:
+            # ``select_default_axis`` is a pure function of ``(policy, caps)``
+            # and both calls are synchronous with no await between them, so the
+            # second is provably the first — harmless by construction rather
+            # than by contract. Threading an ``axis=`` keyword down instead
+            # would trade that for a tenth parameter carrying a NEW silent
+            # invariant ("must be ``select_default_axis`` of the ``caps`` you
+            # also passed"), on the one function whose ``plan=`` contract this
+            # call site already had to be designed around. A mismatched pair
+            # would route on one axis and derive ``use_my_position`` from
+            # another, and nothing would say so.
             caps = self.get_cover_capabilities(entity_id)
             axis = self._policy.select_default_axis(caps)
             service, service_data, _ = self._prepare_service_call(

--- a/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
@@ -184,6 +184,58 @@ def route_service_call(
     )
 
 
+def is_my_preset_target(
+    caps: dict[str, bool], axis: CoverAxis, target: int | None
+) -> bool:
+    """Whether a booked ``target`` can only have come from a My-preset dispatch.
+
+    :func:`route_service_call` is invertible on the axis that matters. Where
+    ``caps_get(caps, axis.capability_key)`` is False, exactly three branches are
+    reachable: the My branch (``routed_target = state``, requires
+    ``use_my_position``), the open/close threshold branch (``routed_target`` is
+    0 or 100), and the no-capable-service branch — which never books at all,
+    because ``_prepare_service_call`` returns before its state-mutation block.
+    The endpoint-substitution branch requires ``supports_position`` and is
+    unreachable there. So a booked NON-endpoint target on a
+    non-position-capable axis can only have been put there by a My dispatch.
+
+    Two consequences hang off that, which is why the predicate is shared rather
+    than spelled out twice:
+
+    * A reconciliation resend of such a target must re-route through
+      ``stop_cover`` (issue #1134). Left to ``use_my_position=False`` the resend
+      falls to the threshold branch and sends ``close_cover``/``open_cover``,
+      physically slamming the cover to an endpoint AND rebooking the user's My
+      percent as 0 or 100.
+    * Such a target can never be verified against a reported position (issue
+      #990). A cover that cannot report the axis it was commanded on surfaces
+      only endpoints, so a My percent never registers as reached and
+      ``is_target_unreached`` must stay quiet rather than nag forever.
+
+    Derived from CURRENT capabilities at the moment it is asked, so it needs no
+    stored flag and cannot go stale — unlike a remembered ``use_my_position``,
+    whose forget-value would silently mis-route.
+
+    At the two ambiguous values (a My preset configured to exactly 0 or 100)
+    this answers "not My", and the resulting ``close_cover``/``open_cover``
+    reaches the identical routed target — physically equivalent, no drift.
+
+    Args:
+        caps: Capabilities for the entity, read now (not at booking time).
+        axis: The policy-selected default axis for this cover.
+        target: The booked target, or ``None`` when nothing is booked.
+
+    Returns:
+        True when ``target`` is a My preset on this cover.
+
+    """
+    if target is None:
+        return False
+    if caps_get(caps, axis.capability_key, default=True):
+        return False
+    return target not in (POSITION_CLOSED, POSITION_OPEN)
+
+
 def build_special_positions(options: dict) -> list[int]:
     """Build list of special positions from options.
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
@@ -199,8 +199,38 @@ def is_my_preset_target(
     unreachable there. So a booked NON-endpoint target on a
     non-position-capable axis can only have been put there by a My dispatch.
 
-    Two consequences hang off that, which is why the predicate is shared rather
-    than spelled out twice:
+    That covers ``_prepare_service_call``. A SECOND site books
+    ``plan.routed_target`` — ``apply_position``'s ``same_position`` skip (issue
+    #1158) — and it has no ``service is None`` check of its own, so the
+    inference has to survive it too. It does, because of the gate's arms rather
+    than any explicit guard:
+
+    * Arms 1 and 2 both require a GENUINE ``_current``, and on a
+      non-position-capable axis ``read_axis_value`` falls through to
+      ``get_open_close_state``, which returns only 0, 100 or ``None``. Arm 1
+      books ``routed_target == position == _current`` and arm 2's own gate is
+      ``_current == routed_target``, so either way the booked number is one of
+      those endpoints. Arm 1's endpoint-tolerance sub-arm is the single case
+      where ``routed_target`` may diverge from ``_current``, and it books
+      nothing at all.
+    * Arm 3 fires only when ``_current`` is ``None`` or a synthetic open/close
+      mapping, and its gate IS ``last_target == plan.routed_target``
+      (``_same_position_via_target_fallback``). By the time it books, the
+      booking's own value-change guard is already False, so the ``set_target``
+      is a no-op — it can never introduce a number that was not already there.
+
+    A future change that let the skip branch book a ``routed_target`` the gate
+    did not compare against — a new arm, or dropping ``_current_is_genuine`` —
+    would break that half; the ``same_position``-booking tests in
+    ``tests/test_managers/test_cover_command.py`` are what catch it. The
+    routing-algebra half is pinned in the same file by
+    ``test_route_service_call_blind_axis_obeys_the_my_preset_trichotomy``
+    (every blind-axis capability shape) and, for the unbookability of the
+    no-capable-service branch specifically,
+    ``test_prepare_service_call_books_nothing_when_no_capable_service``.
+
+    Two consequences hang off all of that, which is why the predicate is shared
+    rather than spelled out twice:
 
     * A reconciliation resend of such a target must re-route through
       ``stop_cover`` (issue #1134). Left to ``use_my_position=False`` the resend

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -242,38 +242,50 @@ class PerEntityState:
     last_progress_at: dt.datetime | None = None
     retry_count: int = 0
     gave_up: bool = False
-    # Whether ``target`` above is a safety-protected number: the answer both
-    # readers actually want, since ``clear_non_safety_targets()`` decides
-    # whether to sweep ``target`` and ``run_reconciliation_pass`` steps 3/4
-    # decide whether to resend it with automatic control off or outside the
-    # time window. It is a verdict ABOUT the booked number, which is what makes
-    # its lifetime different from ``dispatch_token``'s just above: the token
-    # describes how one dispatch expressed the value, the verdict describes
-    # what is protecting it now.
+    # Whether ``target`` above is a safety-protected number — the question both
+    # readers ask: ``clear_non_safety_targets()`` decides whether to sweep
+    # ``target``, and ``run_reconciliation_pass`` steps 3/4 decide whether to
+    # resend it with automatic control off or outside the time window. Both
+    # ignore a row whose ``target`` is None. It is a verdict ABOUT the booked
+    # number, which is what makes its lifetime differ from ``dispatch_token``'s
+    # just above: the token describes how one dispatch expressed the value, the
+    # verdict describes what is protecting it.
     #
-    # Written wherever ``apply_position`` reaches a decision about the booked
-    # number: every real dispatch (``_prepare_service_call``, which books and
-    # stamps together so the two can never disagree), and every
-    # ``same_position`` skip whose booked target is the one that cycle routed
-    # to — or that has nothing booked at all, leaving no target to contradict.
-    # A reconciliation resend RESTATES it rather than re-deciding it (#1134),
-    # because a resend makes no new verdict. The only other writer is the
-    # blanket reset ``clear_safety_targets()``.
+    # "About the booked number" is the INTENT, not an invariant this dataclass
+    # enforces. Only two writers keep the pair in step by construction:
+    # ``_prepare_service_call``, which books and stamps in the same breath on
+    # every real dispatch, and ``apply_position``'s ``same_position`` skip,
+    # whose asymmetric rule is spelled out at that call site — revoke
+    # unconditionally, grant only when the booked target is the one that cycle
+    # routed to, and never under the booking's own value-change guard (#1165;
+    # that guard is right for ``dispatch_token`` but suppresses the write on
+    # exactly the cycles that re-confirm an unchanged target, which is where a
+    # verdict freezes). ``clear_safety_targets()`` is a third writer: a blanket
+    # reset that clears the verdict on every row without touching any target.
     #
-    # Two corollaries, one on each side (both issue #1165):
+    # FIVE other sites write ``target`` and leave the verdict exactly as they
+    # found it, so a row can pair a fresh target with an older decision's
+    # verdict:
     #
-    # * It must NEVER be governed by the booking's value-change guard.
-    #   ``dispatch_token`` is correctly governed by it — the stamp describes the
-    #   booking — but a verdict under that guard freezes, because the guard
-    #   suppresses the write on exactly the cycles that re-confirm an unchanged
-    #   target. A frozen True survives ``clear_non_safety_targets()`` and makes
-    #   steps 3/4 resend with automatic control off or outside the time window.
-    # * It must NEVER be written from a cycle whose verdict is about some OTHER
-    #   number. The one place that can happen is the ``same_position`` sub-arm
-    #   where #1158 withholds the booking while the entity still holds a foreign
-    #   target: writing there marks a stale, unrelated target safety-protected —
-    #   the same defect with the polarity reversed, and it re-drives a number no
-    #   safety decision produced.
+    # * ``CoverCommandService.restore_target`` — rehydration after a reload.
+    # * ``CoverCommandService.send_my_position`` — books the configured My
+    #   percent (no production caller today).
+    # * ``coordinator.py``'s two external-stop -> My paths — a user stop that
+    #   engages the #875 override is dropped by ``run_reconciliation_pass``
+    #   step 2 before it ever reads this field, which covers the common case;
+    #   neither site conditions its ``set_target`` on the override actually
+    #   having engaged, so that is a mitigation, not a guarantee.
+    # * ``cover_types/venetian/sequencer.py``'s carriage rebase — pushes the
+    #   observed carriage position back through ``set_commanded_position``
+    #   (== ``set_target``) after a tilt-only send back-drives it.
+    #
+    # Those parentheticals keep today's blast radius small, but the inheritance
+    # is real, and it is why the ``same_position`` skip declines to GRANT on a
+    # row with nothing booked: an unbooked True is inert against both readers,
+    # yet any of the five would hand it straight to the next target.
+    #
+    # A reconciliation resend RESTATES the recorded value rather than
+    # re-deciding it (#1134), because a resend makes no new verdict.
     is_safety: bool = False
     last_reconcile_at: dt.datetime | None = None
     # Display-only assumed position (issue #888). Set on covers with no native

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -242,23 +242,38 @@ class PerEntityState:
     last_progress_at: dt.datetime | None = None
     retry_count: int = 0
     gave_up: bool = False
-    # This cycle's safety verdict for the entity ACP is currently tracking — a
-    # property of the PROTECTION, not of the booked number, which is what makes
-    # its lifetime different from ``dispatch_token``'s just above. It is written
-    # on every path where ``apply_position`` reaches a decision about the
-    # entity: every real dispatch (``_prepare_service_call``) and every
-    # ``same_position`` skip, unconditionally, whether or not a target is booked
-    # that cycle. A reconciliation resend RESTATES it rather than re-deciding
-    # it, because a resend makes no new verdict. The only other writer is the
+    # Whether ``target`` above is a safety-protected number: the answer both
+    # readers actually want, since ``clear_non_safety_targets()`` decides
+    # whether to sweep ``target`` and ``run_reconciliation_pass`` steps 3/4
+    # decide whether to resend it with automatic control off or outside the
+    # time window. It is a verdict ABOUT the booked number, which is what makes
+    # its lifetime different from ``dispatch_token``'s just above: the token
+    # describes how one dispatch expressed the value, the verdict describes
+    # what is protecting it now.
+    #
+    # Written wherever ``apply_position`` reaches a decision about the booked
+    # number: every real dispatch (``_prepare_service_call``, which books and
+    # stamps together so the two can never disagree), and every
+    # ``same_position`` skip whose booked target is the one that cycle routed
+    # to — or that has nothing booked at all, leaving no target to contradict.
+    # A reconciliation resend RESTATES it rather than re-deciding it (#1134),
+    # because a resend makes no new verdict. The only other writer is the
     # blanket reset ``clear_safety_targets()``.
     #
-    # Corollary (issue #1165): it must never be governed by the booking's
-    # value-change guard. ``dispatch_token`` is correctly governed by it — the
-    # stamp describes the booking — but a verdict under that guard freezes,
-    # because the guard suppresses the write on exactly the cycles that
-    # re-confirm an unchanged target. A frozen True survives
-    # ``clear_non_safety_targets()`` and makes ``run_reconciliation_pass``
-    # steps 3/4 resend with automatic control off or outside the time window.
+    # Two corollaries, one on each side (both issue #1165):
+    #
+    # * It must NEVER be governed by the booking's value-change guard.
+    #   ``dispatch_token`` is correctly governed by it — the stamp describes the
+    #   booking — but a verdict under that guard freezes, because the guard
+    #   suppresses the write on exactly the cycles that re-confirm an unchanged
+    #   target. A frozen True survives ``clear_non_safety_targets()`` and makes
+    #   steps 3/4 resend with automatic control off or outside the time window.
+    # * It must NEVER be written from a cycle whose verdict is about some OTHER
+    #   number. The one place that can happen is the ``same_position`` sub-arm
+    #   where #1158 withholds the booking while the entity still holds a foreign
+    #   target: writing there marks a stale, unrelated target safety-protected —
+    #   the same defect with the polarity reversed, and it re-drives a number no
+    #   safety decision produced.
     is_safety: bool = False
     last_reconcile_at: dt.datetime | None = None
     # Display-only assumed position (issue #888). Set on covers with no native

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -252,16 +252,15 @@ class PerEntityState:
     # verdict describes what is protecting it.
     #
     # "About the booked number" is the INTENT, not an invariant this dataclass
-    # enforces. Only two writers keep the pair in step by construction:
+    # enforces. Two writers keep the pair in step by construction:
     # ``_prepare_service_call``, which books and stamps in the same breath on
-    # every real dispatch, and ``apply_position``'s ``same_position`` skip,
-    # whose asymmetric rule is spelled out at that call site — revoke
-    # unconditionally, grant only when the booked target is the one that cycle
-    # routed to, and never under the booking's own value-change guard (#1165;
-    # that guard is right for ``dispatch_token`` but suppresses the write on
-    # exactly the cycles that re-confirm an unchanged target, which is where a
-    # verdict freezes). ``clear_safety_targets()`` is a third writer: a blanket
-    # reset that clears the verdict on every row without touching any target.
+    # every real dispatch, and ``_record_safety_verdict``, which the three
+    # ``apply_position`` gates that skip WITHOUT dispatching all call — revoke
+    # unconditionally, grant only when the booked target is the number that
+    # cycle routed to, never inside a booking's value-change guard. That rule
+    # and the failure behind each half are argued on the helper (#1165).
+    # ``clear_safety_targets()`` is a third writer: a blanket reset that clears
+    # the verdict on every row without touching any target.
     #
     # FIVE other sites write ``target`` and leave the verdict exactly as they
     # found it, so a row can pair a fresh target with an older decision's
@@ -270,19 +269,23 @@ class PerEntityState:
     # * ``CoverCommandService.restore_target`` — rehydration after a reload.
     # * ``CoverCommandService.send_my_position`` — books the configured My
     #   percent (no production caller today).
-    # * ``coordinator.py``'s two external-stop -> My paths — a user stop that
-    #   engages the #875 override is dropped by ``run_reconciliation_pass``
-    #   step 2 before it ever reads this field, which covers the common case;
-    #   neither site conditions its ``set_target`` on the override actually
-    #   having engaged, so that is a mitigation, not a guarantee.
+    # * ``coordinator.py``'s two external-stop -> My paths. Step 2 of
+    #   ``run_reconciliation_pass`` drops an entity under manual override
+    #   before it ever reads this field, but only one site gets that for free:
+    #   ``async_apply_user_stop`` (``coordinator.py:4608``) books below an
+    #   unconditional ``mark_user_command``. ``async_check_cover_service_call``
+    #   (``coordinator.py:1288``) books whether or not
+    #   ``handle_stop_service_call`` engaged the override — it RETURNS that
+    #   answer and the booking ignores it — so an untracked cover, or one the
+    #   #875 wait-for-target gate declined, books with no override behind it.
     # * ``cover_types/venetian/sequencer.py``'s carriage rebase — pushes the
     #   observed carriage position back through ``set_commanded_position``
     #   (== ``set_target``) after a tilt-only send back-drives it.
     #
-    # Those parentheticals keep today's blast radius small, but the inheritance
-    # is real, and it is why the ``same_position`` skip declines to GRANT on a
-    # row with nothing booked: an unbooked True is inert against both readers,
-    # yet any of the five would hand it straight to the next target.
+    # Today's blast radius is small, but the inheritance is real, and it is why
+    # ``_record_safety_verdict`` declines to GRANT on a row with nothing
+    # booked: an unbooked True is inert against both readers, yet any of the
+    # five would hand it straight to the next target.
     #
     # A reconciliation resend RESTATES the recorded value rather than
     # re-deciding it (#1134), because a resend makes no new verdict.

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -242,6 +242,23 @@ class PerEntityState:
     last_progress_at: dt.datetime | None = None
     retry_count: int = 0
     gave_up: bool = False
+    # This cycle's safety verdict for the entity ACP is currently tracking — a
+    # property of the PROTECTION, not of the booked number, which is what makes
+    # its lifetime different from ``dispatch_token``'s just above. It is written
+    # on every path where ``apply_position`` reaches a decision about the
+    # entity: every real dispatch (``_prepare_service_call``) and every
+    # ``same_position`` skip, unconditionally, whether or not a target is booked
+    # that cycle. A reconciliation resend RESTATES it rather than re-deciding
+    # it, because a resend makes no new verdict. The only other writer is the
+    # blanket reset ``clear_safety_targets()``.
+    #
+    # Corollary (issue #1165): it must never be governed by the booking's
+    # value-change guard. ``dispatch_token`` is correctly governed by it — the
+    # stamp describes the booking — but a verdict under that guard freezes,
+    # because the guard suppresses the write on exactly the cycles that
+    # re-confirm an unchanged target. A frozen True survives
+    # ``clear_non_safety_targets()`` and makes ``run_reconciliation_pass``
+    # steps 3/4 resend with automatic control off or outside the time window.
     is_safety: bool = False
     last_reconcile_at: dt.datetime | None = None
     # Display-only assumed position (issue #888). Set on covers with no native

--- a/tests/test_command_queue.py
+++ b/tests/test_command_queue.py
@@ -1093,6 +1093,45 @@ class TestOtherWireSites:
         assert queue.busy_for_seconds() == 0.0
 
     @pytest.mark.asyncio
+    async def test_a_resend_erroring_before_the_send_hands_the_slot_back(self):
+        """``apply_position``'s release invariant, on the resend seam.
+
+        Sibling of ``test_an_error_before_the_send_hands_the_slot_back``:
+        nothing between the grant and the send may sit outside the ``finally``.
+        The capability read is a live raise site — ``check_cover_features``
+        calls ``bin(supported_features)`` and masks the value against
+        ``CoverEntityFeature`` without guarding its type, so a cover
+        publishing a non-int raises ``TypeError`` synchronously.
+
+        A slot stranded here never comes back on its own: every other member
+        of the queue then enqueues, burns its whole budget and transmits
+        ``budget_expired`` — unspaced and simultaneous, the exact collision
+        issue #1189 exists to prevent, across every cover on the queue.
+        """
+        hass = _svc_hass()
+        queue = _queue(gap=0.0)
+        svc = _svc(hass, command_queue=queue)
+
+        with (
+            patch.object(svc, "get_cover_capabilities", side_effect=TypeError("boom")),
+            pytest.raises(TypeError),
+        ):
+            await svc._execute_command("cover.a", 50)
+
+        assert queue._owner is None
+        # Nothing went out, so nobody owes the air anything.
+        assert queue.busy_for_seconds() == 0.0
+        # And the next member is actually grantable, not blocked behind a
+        # phantom holder.
+        assert (
+            await asyncio.wait_for(
+                queue.acquire("cover.b", head_of_line=False, budget=_BUDGET),
+                timeout=1.0,
+            )
+            is not None
+        )
+
+    @pytest.mark.asyncio
     async def test_a_resend_waits_out_spacing_it_can_afford(self):
         """Spacing owed is not contention — it is the queue doing its job.
 

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -549,6 +549,50 @@ def test_route_endpoint_falls_back_when_no_close_capability():
     assert plan.supports_position is True
 
 
+def test_route_service_call_non_position_axis_books_endpoint_unless_my():
+    """Premise lock for ``is_my_preset_target`` (issue #1134 defect 1).
+
+    Green from the start — this is not a bug reproduction. It pins the routing
+    algebra the resend-time derivation inverts: on an axis with no position
+    capability, an ordinary route can only ever book an endpoint (0 or 100),
+    while a My route books the raw value and sends ``stop_cover``. That is what
+    makes "a booked non-endpoint target on a non-position-capable axis came
+    from a My dispatch" a sound inference. If a future routing change breaks
+    the premise, this goes red at the source rather than as a mysterious
+    mis-route in reconciliation.
+    """
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+    axis = get_policy("cover_blind").select_default_axis(caps)
+
+    for state in range(101):
+        plan = route_service_call(
+            "cover.rts",
+            state,
+            caps,
+            axis=axis,
+            use_my_position=False,
+            open_close_threshold=50,
+        )
+        assert plan.routed_target in (0, 100), state
+
+        my_plan = route_service_call(
+            "cover.rts",
+            state,
+            caps,
+            axis=axis,
+            use_my_position=True,
+            open_close_threshold=50,
+        )
+        assert my_plan.service == "stop_cover", state
+        assert my_plan.routed_target == state
+
+
 def test_route_service_call_missing_open_close_caps():
     """Returns no service when no capable HA service is available."""
     caps = {

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -8,17 +8,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import caps_get
 from custom_components.adaptive_cover_pro.managers.cover_command import (
     CoverCommandService,
     PositionContext,
     build_special_positions,
+    is_my_preset_target,
     route_service_call,
 )
 from custom_components.adaptive_cover_pro.managers.cover_command.gates import (
     check_position_delta,
-)
-from custom_components.adaptive_cover_pro.managers.cover_command.routing import (
-    is_my_preset_target,
 )
 
 
@@ -594,6 +593,207 @@ def test_route_service_call_non_position_axis_books_endpoint_unless_my():
         )
         assert my_plan.service == "stop_cover", state
         assert my_plan.routed_target == state
+
+
+# Every capability shape that lands on a NON-position-capable axis, which is
+# the only place ``is_my_preset_target``'s inference has to hold. The shape
+# above covers one of them; these are the rest, including the two the
+# inference's proof leans on hardest — a cover with no ``stop_cover`` to reach
+# the My branch with, and a cover missing an open/close service so routing
+# bottoms out with no capable service at all.
+_BLIND_AXIS_CAPS_SHAPES = [
+    (
+        "rts_open_close_stop",
+        "cover_blind",
+        {
+            "has_set_position": False,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
+    ),
+    (
+        "no_stop_service",
+        "cover_blind",
+        {
+            "has_set_position": False,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": False,
+        },
+    ),
+    (
+        "open_but_no_close",
+        "cover_blind",
+        {
+            "has_set_position": False,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": False,
+            "has_stop": True,
+        },
+    ),
+    (
+        "close_but_no_open",
+        "cover_blind",
+        {
+            "has_set_position": False,
+            "has_set_tilt_position": False,
+            "has_open": False,
+            "has_close": True,
+            "has_stop": True,
+        },
+    ),
+    (
+        "no_capable_service_at_all",
+        "cover_blind",
+        {
+            "has_set_position": False,
+            "has_set_tilt_position": False,
+            "has_open": False,
+            "has_close": False,
+            "has_stop": False,
+        },
+    ),
+    # A tilt-primary policy bound to an entity with no tilt service (#991's
+    # contradiction shape). The axis's OWN capability key is what makes it
+    # blind here — ``has_set_position`` is True and must not rescue it.
+    (
+        "tilt_axis_without_tilt_service",
+        "cover_tilt",
+        {
+            "has_set_position": True,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("shape", "cover_type", "caps"),
+    _BLIND_AXIS_CAPS_SHAPES,
+    ids=[s[0] for s in _BLIND_AXIS_CAPS_SHAPES],
+)
+def test_route_service_call_blind_axis_obeys_the_my_preset_trichotomy(
+    shape, cover_type, caps
+):
+    """Premise lock, widened (issues #1134 / #1165 optional-polish round).
+
+    ``test_route_service_call_non_position_axis_books_endpoint_unless_my``
+    above pins one capability shape. The inference
+    ``is_my_preset_target`` performs is stated over ALL of them, so state it
+    over all of them: on a non-position-capable axis, every route is one of
+    exactly three things, and nothing else is reachable.
+
+    1. ``service is None`` — no capable service. ``routed_target`` here is the
+       raw ``state`` and CAN be a non-endpoint, which is exactly why the
+       inference depends on this branch never booking. That half is a
+       ``_prepare_service_call`` property, locked separately by
+       ``test_prepare_service_call_books_nothing_when_no_capable_service``.
+    2. ``stop_cover`` — the My branch, which needs ``use_my_position`` AND
+       ``has_stop``. Books the raw value.
+    3. ``open_cover`` / ``close_cover`` — the threshold branch, which can only
+       ever book 0 or 100.
+
+    On every BOOKABLE plan the predicate must then agree exactly: True for a
+    My route to a non-endpoint, False for everything else. Break the algebra —
+    let the threshold branch book the raw state, let the My branch fire without
+    ``use_my_position``, let ``is_my_preset_target`` drop its endpoint
+    carve-out — and this goes red here rather than as a cover slamming shut on
+    a reconciliation resend.
+    """
+    axis = get_policy(cover_type).select_default_axis(caps)
+    # Precondition: every shape above really does land on a blind axis. If a
+    # policy change made one of them position-capable the sweep would pass
+    # vacuously.
+    assert caps_get(caps, axis.capability_key, default=True) is False, shape
+
+    for state in range(101):
+        for use_my in (False, True):
+            plan = route_service_call(
+                "cover.rts",
+                state,
+                caps,
+                axis=axis,
+                use_my_position=use_my,
+                open_close_threshold=50,
+            )
+            if plan.service is None:
+                # Unbookable. Assert the shape that makes it so, since the
+                # whole inference rests on it.
+                assert plan.service_data is None, (shape, state, use_my)
+                assert plan.supports_position is False, (shape, state, use_my)
+                continue
+
+            assert plan.supports_position is False, (shape, state, use_my)
+            if plan.service == "stop_cover":
+                assert use_my, (shape, state)
+                assert caps_get(caps, "has_stop") is True, shape
+                assert plan.routed_target == state, (shape, state)
+            else:
+                assert plan.service in ("open_cover", "close_cover"), (shape, state)
+                assert plan.routed_target in (0, 100), (shape, state, use_my)
+
+            # The predicate inverts exactly this, on the number that got
+            # booked — not on the raw state.
+            assert is_my_preset_target(caps, axis, plan.routed_target) is (
+                plan.service == "stop_cover" and plan.routed_target not in (0, 100)
+            ), (shape, state, use_my)
+
+
+@pytest.mark.parametrize(
+    ("shape", "cover_type", "caps"),
+    [
+        s
+        for s in _BLIND_AXIS_CAPS_SHAPES
+        if not (s[2]["has_open"] and s[2]["has_close"])
+    ],
+    ids=[
+        s[0]
+        for s in _BLIND_AXIS_CAPS_SHAPES
+        if not (s[2]["has_open"] and s[2]["has_close"])
+    ],
+)
+def test_prepare_service_call_books_nothing_when_no_capable_service(
+    mock_hass, logger, grace_mgr, shape, cover_type, caps
+):
+    """The other half of the premise: the no-capable-service branch never books.
+
+    ``route_service_call`` hands that branch back with ``routed_target =
+    state`` — a non-endpoint for most values — so if it ever reached a
+    ``set_target`` the booked number would look exactly like a My preset to
+    ``is_my_preset_target``, and the next reconciliation resend would answer
+    ``stop_cover`` for a cover that has no My and possibly no stop at all.
+    ``_prepare_service_call`` returning before its state-mutation block is the
+    only thing standing between those two facts, and it is asserted nowhere
+    else.
+
+    ``use_my_position=False`` throughout: the My branch is what these shapes
+    are chosen to fall past, and where ``has_stop`` is present it would
+    otherwise intercept them.
+    """
+    svc = CoverCommandService(
+        hass=mock_hass,
+        logger=logger,
+        cover_type=cover_type,
+        grace_mgr=grace_mgr,
+        open_close_threshold=50,
+    )
+    for state in (0, 10, 37, 50, 63, 100):
+        service, data, supports_position = svc._prepare_service_call(
+            "cover.rts", state, caps=caps
+        )
+        assert service is None, (shape, state)
+        assert data is None, (shape, state)
+        assert supports_position is False, (shape, state)
+        assert svc.get_target("cover.rts") is None, (shape, state)
+        assert svc.is_waiting_for_target("cover.rts") is False, (shape, state)
+    grace_mgr.start_command_grace_period.assert_not_called()
 
 
 def test_is_my_preset_target_only_claims_non_endpoints_on_a_blind_axis():

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -17,6 +17,9 @@ from custom_components.adaptive_cover_pro.managers.cover_command import (
 from custom_components.adaptive_cover_pro.managers.cover_command.gates import (
     check_position_delta,
 )
+from custom_components.adaptive_cover_pro.managers.cover_command.routing import (
+    is_my_preset_target,
+)
 
 
 @pytest.fixture
@@ -591,6 +594,45 @@ def test_route_service_call_non_position_axis_books_endpoint_unless_my():
         )
         assert my_plan.service == "stop_cover", state
         assert my_plan.routed_target == state
+
+
+def test_is_my_preset_target_only_claims_non_endpoints_on_a_blind_axis():
+    """The predicate itself, clause by clause (issues #1134 / #990).
+
+    Its two readers both act on the answer physically — ``_execute_command``
+    sends ``stop_cover`` instead of ``open_cover``/``close_cover``, and
+    ``is_target_unreached`` goes quiet — so each clause needs its own case.
+
+    The endpoint carve-out is the one the calibration-safety argument rests on:
+    ``TravelCalibrationManager`` drives only ``axis.value_min`` /
+    ``axis.value_max`` on covers that cannot report position, and a sweep that
+    answered True there would ``stop_cover`` a cover it meant to run to its
+    stop. It is also what keeps every threshold-routed resend honest, since
+    ordinary routing on this axis books nothing BUT 0 and 100 (pinned by
+    ``test_route_service_call_non_position_axis_books_endpoint_unless_my``).
+    """
+    rts_caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+    axis = get_policy("cover_blind").select_default_axis(rts_caps)
+
+    # The endpoints are reachable by ordinary threshold routing, so they prove
+    # nothing about intent — and calibration only ever drives these two.
+    assert is_my_preset_target(rts_caps, axis, 0) is False
+    assert is_my_preset_target(rts_caps, axis, 100) is False
+    # A non-endpoint on this axis could only have been booked by a My dispatch.
+    assert is_my_preset_target(rts_caps, axis, 10) is True
+    # Nothing booked is nothing to infer from.
+    assert is_my_preset_target(rts_caps, axis, None) is False
+
+    # A cover that CAN take a position never routes through My: the same
+    # number is an ordinary set_cover_position target.
+    position_caps = dict(rts_caps, has_set_position=True)
+    assert is_my_preset_target(position_caps, axis, 10) is False
 
 
 def test_route_service_call_missing_open_close_caps():

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -826,6 +826,158 @@ async def test_same_position_skip_regrants_is_safety_when_the_condition_returns(
 
 
 @pytest.mark.asyncio
+async def test_delta_skip_revokes_is_safety_after_condition_ends(svc, mock_hass):
+    """Issue #1165, same rule at the ``delta_too_small`` skip.
+
+    ``same_position`` is not the only gate that can hold a booked safety target
+    in place indefinitely. Once weather clears, a cover parked within
+    ``min_change`` of every subsequent calculated position skips on delta
+    forever — no dispatch, so ``_prepare_service_call`` never runs, so nothing
+    revokes the verdict a genuine earlier safety dispatch stamped. The booked
+    50 stays licensed to survive ``clear_non_safety_targets()`` and to be
+    re-driven by reconciliation steps 3/4 with automatic control off.
+
+    Unlike the ``same_position`` case this one self-corrects the moment the
+    calculated value moves outside ``min_change`` — it is not a fixed point —
+    but "eventually, if the sun cooperates" is not a lifetime.
+    """
+    # Cycle 1: weather safety drives 90 -> 50. A REAL dispatch, so
+    # ``_prepare_service_call`` genuinely stamps is_safety=True.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 50, "weather", context=_ctx(force=True, is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.get_target("cover.test") == 50
+    assert svc.state("cover.test").is_safety is True
+
+    # The cover arrives and settles.
+    _patch_position(svc, 50)
+    svc.set_waiting("cover.test", False)
+
+    # Cycle 2: weather clears. Solar wants 51 — one percent away, under
+    # min_change, so the delta gate skips. Nothing is dispatched and nothing is
+    # booked, but the verdict for THIS cycle is False.
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 51, "solar", context=_ctx(min_change=5, is_safety=False)
+        )
+    assert (outcome, reason) == ("skipped", "delta_too_small")
+    assert svc.state("cover.test").is_safety is False
+    # The skip books nothing — the 50 the safety dispatch put there is still
+    # the booked number, and it is now unprotected.
+    assert svc.get_target("cover.test") == 50
+
+    # Window closes: the sweep must take it.
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+    # And with automatic control off AND outside the time window, nothing is
+    # resent for this entity.
+    svc._auto_control_enabled = False
+    svc._in_time_window = False
+    _patch_position(svc, 90)
+    mock_hass.services.async_call.reset_mock()
+    with _patch_caps():
+        await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_time_delta_skip_revokes_is_safety_after_condition_ends(svc, mock_hass):
+    """Issue #1165, same rule at the ``time_delta_too_small`` skip.
+
+    The sibling of the ``delta_too_small`` case: here the position delta is
+    large enough to act on but the rate limiter holds the command back, so
+    again nothing dispatches and again the stale verdict would ride forward.
+    Both gates are hysteresis on the carriage, neither is a safety decision,
+    and neither may leave the previous decision's licence standing.
+    """
+    # Cycle 1: weather safety drives 90 -> 50 with the delta/time gates
+    # bypassed, exactly as a safety context does in production.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 50, "weather", context=_ctx(force=True, is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.get_target("cover.test") == 50
+    assert svc.state("cover.test").is_safety is True
+
+    _patch_position(svc, 50)
+    svc.set_waiting("cover.test", False)
+
+    # Cycle 2: weather clears. Solar wants 90 — a big move, so the position
+    # delta passes — but the last command was ten seconds ago and the
+    # rate limiter is five minutes.
+    recent = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=10)
+    with (
+        _patch_caps(),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+            return_value=recent,
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 90, "solar", context=_ctx(time_threshold=5, is_safety=False)
+        )
+    assert (outcome, reason) == ("skipped", "time_delta_too_small")
+    assert svc.state("cover.test").is_safety is False
+    assert svc.get_target("cover.test") == 50
+
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+
+@pytest.mark.asyncio
+async def test_delta_skip_does_not_protect_a_target_it_did_not_route_to(svc, mock_hass):
+    """Issue #1165: the GRANT half stays attached to the booked number here too.
+
+    The delta gates book nothing, so ``get_target`` is whatever an earlier
+    decision left. A safety cycle that skips on delta must not therefore
+    license that older number: the licence has to attach to the number the
+    safety decision actually routed to.
+
+    In production this shape is currently unreachable — every
+    ``PositionContext`` producer that sets ``is_safety=True`` also sets
+    ``force=True``, and the delta gates run only under ``not force`` — which is
+    exactly why it is pinned here. The rule lives in one helper shared with the
+    ``same_position`` site rather than being re-decided per gate, so if that
+    coupling is ever relaxed the grant does not silently start protecting
+    stale numbers.
+    """
+    # Solar books 50 through a real dispatch — no safety flag.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 50, "solar", context=_ctx(is_safety=False)
+        )
+    assert outcome == "sent"
+    assert svc.get_target("cover.test") == 50
+    assert svc.state("cover.test").is_safety is False
+
+    # The cover misses and comes to rest at 47; nothing chases it.
+    _patch_position(svc, 47)
+    svc.set_waiting("cover.test", False)
+
+    # A weather-safety cycle wants 49 and skips on delta. 49 is not the booked
+    # 50, and nothing was sent, so the booked 50 must NOT become protected.
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 49, "weather", context=_ctx(min_change=5, is_safety=True)
+        )
+    assert (outcome, reason) == ("skipped", "delta_too_small")
+    assert svc.state("cover.test").is_safety is False
+    assert svc.get_target("cover.test") == 50
+
+    # So the window-close sweep still takes it.
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+
+@pytest.mark.asyncio
 async def test_reconcile_resend_preserves_is_safety_flag(svc, mock_hass):
     """Issue #1134 defect 2: a reconciliation resend RESTATES the safety
     verdict; it must not clear the very flag that authorised it.

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -91,6 +91,26 @@ def _patch_caps(position_supported=True):
     )
 
 
+def _patch_explicit_caps(caps):
+    """Patch check_cover_features with a caller-supplied capability dict."""
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=caps,
+    )
+
+
+def _patch_no_prior_command():
+    """Patch get_last_updated to None so the time-delta gate always passes.
+
+    The ``mock_hass`` fixture is a bare MagicMock, so an unpatched
+    ``get_last_updated`` hands the gate a MagicMock it cannot subtract.
+    """
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+        return_value=None,
+    )
+
+
 # ------------------------------------------------------------------ #
 # apply_position — gate checks
 # ------------------------------------------------------------------ #
@@ -401,27 +421,26 @@ async def test_reconcile_resends_booked_target_after_skip_then_drift(svc, mock_h
 
 
 @pytest.mark.asyncio
-async def test_same_position_skip_does_not_stamp_stale_is_safety(svc, mock_hass):
-    """Issue #1158 MUST-FIX 2 (round-2 audit): a same_position skip must
-    never write ``is_safety`` from ``context.is_safety``.
+async def test_same_position_skip_tracks_this_cycles_is_safety_verdict(svc, mock_hass):
+    """Issues #1158 / #1165: a same_position skip records THIS cycle's safety
+    verdict, and the verdict comes back down when the condition ends.
 
-    The two writers of ``PerEntityState.target`` are NOT symmetrical:
-    ``_prepare_service_call`` stamps ``is_safety`` unconditionally on every
-    REAL dispatch, but the same_position skip's booking only writes when the
-    value CHANGES (the #1115 value-change guard). Mirroring the ``is_safety``
-    write under that narrower guard would let a since-cleared safety
-    condition freeze ``is_safety=True`` forever: a later skip that
-    re-confirms the same unchanged value has the guard suppress the write
-    entirely, so a stale True can never clear. A frozen True then survives
-    ``clear_non_safety_targets()`` and makes ``run_reconciliation_pass``
-    resend it with auto_control off or outside the time window — precisely
-    what steps 3/4 exist to prevent. Reproduces the auditor's
-    ``repro_is_safety_stale.py``.
+    ``PerEntityState.is_safety`` is a property of the protection currently in
+    force, not of the booked number — so the skip writes it unconditionally,
+    outside the ``(target, dispatch_token)`` value-change guard the booking
+    uses. Governing it with that guard is what #1165 reports as the bug: a
+    since-cleared condition could never come back down, because the guard
+    suppresses the write on exactly the cycles that re-confirm an unchanged
+    target. A frozen ``True`` then survives ``clear_non_safety_targets()`` and
+    makes ``run_reconciliation_pass`` resend with auto_control off or outside
+    the time window — what steps 3/4 exist to prevent, and what the tail of
+    this test guards.
     """
     # Cycle 1: a weather-safety cycle skips because the cover is already at
     # the safety position (50) — nothing is dispatched, so
-    # ``_prepare_service_call`` (the one REAL is_safety writer) never runs.
-    # The skip must NOT record is_safety=True on its own.
+    # ``_prepare_service_call`` (the REAL-dispatch writer) never runs. The skip
+    # is still a decision about this entity, and this cycle's verdict is
+    # "safety-protected".
     _patch_position(svc, 50)
     with _patch_caps():
         outcome, reason = await svc.apply_position(
@@ -429,11 +448,12 @@ async def test_same_position_skip_does_not_stamp_stale_is_safety(svc, mock_hass)
         )
     assert (outcome, reason) == ("skipped", "same_position")
     assert svc.get_target("cover.test") == 50
-    assert svc.state("cover.test").is_safety is False
+    assert svc.state("cover.test").is_safety is True
 
-    # Cycle 2: weather clears; an ordinary cycle re-confirms the same 50.
-    # The value-change guard suppresses the write entirely (booked value
-    # unchanged) — is_safety stays exactly what it already was (False).
+    # Cycle 2: weather clears; an ordinary cycle re-confirms the same 50. The
+    # value-change guard suppresses the BOOKING (unchanged value) — the verdict
+    # is written anyway, so the flag comes back down. This is the #1165
+    # assertion: it was vacuous while cycle 1 left the flag at its default.
     with _patch_caps():
         outcome, reason = await svc.apply_position(
             "cover.test", 50, "solar", context=_ctx(is_safety=False)
@@ -459,6 +479,207 @@ async def test_same_position_skip_does_not_stamp_stale_is_safety(svc, mock_hass)
         await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
 
     mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_position_skip_clears_is_safety_after_condition_ends(svc, mock_hass):
+    """Issue #1165: a same_position skip must record THIS cycle's safety
+    verdict, so a flag left ``True`` by an earlier REAL dispatch comes back
+    down once the safety condition ends.
+
+    ``PerEntityState.is_safety`` describes the protection currently in force
+    for the entity, not the booked number. The skip branch used to leave it
+    untouched, so a weather dispatch's ``True`` rode forward onto every later
+    cycle that re-confirmed the same target — and the #1115 value-change guard
+    made that permanent, because an unchanged target suppresses ``set_target``
+    entirely. A frozen ``True`` then defeats ``clear_non_safety_targets()`` and
+    lets ``run_reconciliation_pass`` steps 3/4 resend the target with automatic
+    control off and outside the time window.
+    """
+    # Cycle 1: weather safety drives the cover from 90 to 50 — a REAL dispatch,
+    # so ``_prepare_service_call`` genuinely stamps is_safety=True.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 50, "weather", context=_ctx(is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.state("cover.test").is_safety is True
+    assert svc.get_target("cover.test") == 50
+
+    # The cover arrives and settles on the safety position.
+    _patch_position(svc, 50)
+    svc.set_waiting("cover.test", False)
+
+    # Cycle 2: weather clears. An ordinary solar cycle re-confirms the SAME 50
+    # through the same_position skip. The booked value does not change, so the
+    # value-change guard suppresses set_target — but the safety verdict for
+    # this cycle is False and must be recorded regardless.
+    with _patch_caps():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 50, "solar", context=_ctx(is_safety=False)
+        )
+    assert (outcome, reason) == ("skipped", "same_position")
+    assert svc.state("cover.test").is_safety is False
+
+    # Window closes: the target is no longer safety-protected, so the sweep
+    # must take it.
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+    # And with automatic control off AND outside the time window, nothing is
+    # resent for this entity — what steps 3/4 exist to guarantee.
+    svc._auto_control_enabled = False
+    svc._in_time_window = False
+    _patch_position(svc, 90)  # cover drifted / was moved since
+    mock_hass.services.async_call.reset_mock()
+    with _patch_caps():
+        await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_position_skip_endpoint_tolerance_still_refreshes_is_safety(
+    svc, mock_hass
+):
+    """Issue #1165: the safety verdict is refreshed on EVERY same_position
+    skip — including the one sub-arm that deliberately books nothing.
+
+    ``is_safety`` is a property of the protection, not of the booking, so it
+    cannot ride inside the booking guard. Arm 1's endpoint-tolerance sub-arm
+    proves the point: a cover resting at 98 against a 100 target skips, and
+    #1158's narrowed fix withholds the booking there because the routed target
+    (100) does not match the actual (98). The verdict still has to be written.
+    """
+    # Cycle 1: a weather-safety dispatch to the 100 endpoint. Real dispatch →
+    # is_safety=True, target booked at the routed endpoint.
+    _patch_position(svc, 50)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 100, "weather", context=_ctx(is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.state("cover.test").is_safety is True
+    assert svc.get_target("cover.test") == 100
+
+    # The motor settles two percent short — inside position_tolerance=3, but
+    # not on the endpoint.
+    _patch_position(svc, 98)
+    svc.set_waiting("cover.test", False)
+
+    # Cycle 2: weather clears. The endpoint-tolerance sub-arm skips and does
+    # NOT book (target/actual would mismatch, #1158) — but the verdict for
+    # this cycle is False.
+    with _patch_caps():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "solar", context=_ctx(is_safety=False)
+        )
+
+    assert (outcome, reason) == ("skipped", "same_position")
+    assert svc.get_target("cover.test") == 100  # unbooked-guard still holds
+    assert svc.state("cover.test").is_safety is False
+
+
+@pytest.mark.asyncio
+async def test_reconcile_resend_preserves_is_safety_flag(svc, mock_hass):
+    """Issue #1134 defect 2: a reconciliation resend RESTATES the safety
+    verdict; it must not clear the very flag that authorised it.
+
+    ``_execute_command`` funnels into ``_prepare_service_call``, which writes
+    ``is_safety`` unconditionally. Omitting the keyword let it default to
+    ``False``, so a safety target un-protected itself on its own first resend
+    — the second pass then hit steps 3/4 and skipped, with automatic control
+    off and outside the time window, exactly where a safety target is supposed
+    to keep being resent.
+    """
+    # A weather-safety dispatch to 50, from 90.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 50, "weather", context=_ctx(is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.state("cover.test").is_safety is True
+
+    # The cover never got there. Automatic control is off and we are outside
+    # the time window — only the safety flag keeps this target eligible.
+    svc.set_waiting("cover.test", False)
+    _patch_position(svc, 90)
+    svc._auto_control_enabled = False
+    svc._in_time_window = False
+
+    now = dt.datetime.now(dt.UTC)
+
+    # Pass 1: resent because is_safety is True.
+    mock_hass.services.async_call.reset_mock()
+    with _patch_caps():
+        await svc.run_reconciliation_pass(now)
+
+    mock_hass.services.async_call.assert_called_once()
+    assert mock_hass.services.async_call.call_args[0][1] == "set_cover_position"
+    assert mock_hass.services.async_call.call_args[0][2]["position"] == 50
+    assert svc.state("cover.test").is_safety is True
+
+    # Pass 2: still a safety target, so it is resent again (max_retries=3).
+    svc.set_waiting("cover.test", False)
+    mock_hass.services.async_call.reset_mock()
+    with _patch_caps():
+        await svc.run_reconciliation_pass(now)
+
+    mock_hass.services.async_call.assert_called_once()
+    assert mock_hass.services.async_call.call_args[0][1] == "set_cover_position"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_resend_of_my_target_reroutes_through_stop_cover(
+    svc, mock_hass
+):
+    """Issue #1134 defect 1: a resend of a My-preset target must go back out
+    as ``stop_cover``, and must not silently rebook the user's My value as 0.
+
+    ``_execute_command`` let ``use_my_position`` default to ``False``, so
+    ``route_service_call`` fell past the My branch to the open/close threshold:
+    a My of 10 is below the 50 threshold, so the resend sent ``close_cover``
+    and slammed the cover shut — and ``_prepare_service_call`` then booked the
+    branch's ``routed_target`` of 0 over the user's 10.
+
+    The RTS/ZVIDAR shape makes this reachable: the cover reports HA state
+    "open" forever, so ``get_open_close_state`` maps it to 100 and the pass
+    always judges the 10 target missed.
+    """
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+    mock_hass.states.get.return_value = MagicMock(state="open", attributes={})
+    _patch_position(svc, None)
+
+    with _patch_explicit_caps(caps), _patch_no_prior_command():
+        outcome, reason = await svc.apply_position(
+            "cover.rts",
+            10,
+            "solar",
+            context=_ctx(use_my_position=True, special_positions=[0, 100, 10]),
+        )
+    assert (outcome, reason) == ("sent", "stop_cover")
+    assert svc.get_target("cover.rts") == 10
+
+    # The cover parks at its My preset but keeps reporting "open" → 100, so
+    # reconciliation always sees the target as missed.
+    svc.set_waiting("cover.rts", False)
+    _patch_position(svc, 100)
+    mock_hass.services.async_call.reset_mock()
+
+    with _patch_explicit_caps(caps):
+        await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_called_once()
+    assert mock_hass.services.async_call.call_args[0][1] == "stop_cover"
+    assert svc.get_target("cover.rts") == 10
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -764,8 +764,12 @@ async def test_same_position_skip_does_not_protect_an_unbooked_entity(svc, mock_
     assert svc.state("cover.test").is_safety is False
 
     # A later booking through one of the verdict-blind ``set_target`` sites
-    # must therefore start unprotected, not inherit a licence.
-    svc.restore_target("cover.test", 60)
+    # must therefore start unprotected, not inherit a licence. ``restore_target``
+    # only seeds a target the cover is already resting on, so the cover has to
+    # move to 60 first — otherwise it returns False, books nothing, and the
+    # three assertions below have no subject to be about.
+    _patch_position(svc, 60)
+    assert svc.restore_target("cover.test", 60) is True
     assert svc.state("cover.test").is_safety is False
     svc.clear_non_safety_targets()
     assert svc.get_target("cover.test") is None

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -582,6 +582,67 @@ async def test_same_position_skip_endpoint_tolerance_still_refreshes_is_safety(
 
 
 @pytest.mark.asyncio
+async def test_same_position_skip_does_not_protect_a_foreign_stale_target(
+    svc, mock_hass
+):
+    """Issue #1165 (round-2 audit): the verdict describes the BOOKED target,
+    so a skip that withholds its booking must not stamp ``is_safety`` onto a
+    stale number some earlier, non-safety decision left behind.
+
+    The withheld-booking sub-arm (#1158) is the one place where the entity can
+    still be holding a target that has nothing to do with the value this cycle
+    routed to. Writing the verdict there anyway inverts #1165's own defect: a
+    ``True`` that protects and re-drives a number the safety handler never
+    asked for. ``clear_non_safety_targets()`` then leaves the stale target in
+    place, and steps 3/4 resend it with automatic control off and outside the
+    time window.
+    """
+    # Cycle 1: an ordinary solar dispatch books 60. No safety involved.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 60, "solar", context=_ctx(is_safety=False)
+        )
+    assert outcome == "sent"
+    assert svc.get_target("cover.test") == 60
+    assert svc.state("cover.test").is_safety is False
+
+    # The cover never lands on 60 — it comes to rest at 2 (landing error, or
+    # someone moved it), and the booking is still 60.
+    svc.set_waiting("cover.test", False)
+    _patch_position(svc, 2)
+
+    # Cycle 2: weather safety wants the 0 endpoint. ``_current=2`` is inside
+    # position_tolerance of 0, so the endpoint-tolerance sub-arm skips — and
+    # #1158 withholds the booking because 2 != the routed target 0. The entity
+    # therefore still holds 60, a target no safety decision produced.
+    with _patch_caps():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 0, "weather", context=_ctx(is_safety=True)
+        )
+    assert (outcome, reason) == ("skipped", "same_position")
+    assert svc.get_target("cover.test") == 60  # unbooked-guard still holds
+
+    # The safety verdict was about 0, not about 60. The booked 60 must stay
+    # unprotected.
+    assert svc.state("cover.test").is_safety is False
+
+    # Window closes: 60 is an ordinary stale target, so the sweep takes it.
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+    # And with automatic control off AND outside the time window, nothing is
+    # driven to 60 — the resend steps 3/4 exist to prevent.
+    svc._auto_control_enabled = False
+    svc._in_time_window = False
+    mock_hass.services.async_call.reset_mock()
+    with _patch_caps():
+        await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_resend_preserves_is_safety_flag(svc, mock_hass):
     """Issue #1134 defect 2: a reconciliation resend RESTATES the safety
     verdict; it must not clear the very flag that authorised it.

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -425,22 +425,26 @@ async def test_same_position_skip_tracks_this_cycles_is_safety_verdict(svc, mock
     """Issues #1158 / #1165: a same_position skip records THIS cycle's safety
     verdict, and the verdict comes back down when the condition ends.
 
-    ``PerEntityState.is_safety`` is a property of the protection currently in
-    force, not of the booked number — so the skip writes it unconditionally,
-    outside the ``(target, dispatch_token)`` value-change guard the booking
-    uses. Governing it with that guard is what #1165 reports as the bug: a
-    since-cleared condition could never come back down, because the guard
-    suppresses the write on exactly the cycles that re-confirm an unchanged
-    target. A frozen ``True`` then survives ``clear_non_safety_targets()`` and
-    makes ``run_reconciliation_pass`` resend with auto_control off or outside
-    the time window — what steps 3/4 exist to prevent, and what the tail of
-    this test guards.
+    ``PerEntityState.is_safety`` describes the BOOKED number — "is what ACP
+    currently has this cover down for a safety-protected number?" Cycle 1
+    books 50 and grants the flag in the same breath, so the grant is about the
+    number this cycle routed to. Cycle 2 revokes it, and revoking is
+    unconditional: it only removes a licence.
+
+    What neither polarity may do is ride inside the ``(target,
+    dispatch_token)`` value-change guard the booking uses. That is what #1165
+    reports as the bug: the guard suppresses the write on exactly the cycles
+    that re-confirm an unchanged target, so a since-cleared condition could
+    never come back down. A frozen ``True`` then survives
+    ``clear_non_safety_targets()`` and makes ``run_reconciliation_pass``
+    resend with auto_control off or outside the time window — what steps 3/4
+    exist to prevent, and what the tail of this test guards.
     """
     # Cycle 1: a weather-safety cycle skips because the cover is already at
     # the safety position (50) — nothing is dispatched, so
     # ``_prepare_service_call`` (the REAL-dispatch writer) never runs. The skip
-    # is still a decision about this entity, and this cycle's verdict is
-    # "safety-protected".
+    # books the 50 itself, and the grant that follows is about that booked
+    # number.
     _patch_position(svc, 50)
     with _patch_caps():
         outcome, reason = await svc.apply_position(
@@ -487,13 +491,20 @@ async def test_same_position_skip_clears_is_safety_after_condition_ends(svc, moc
     verdict, so a flag left ``True`` by an earlier REAL dispatch comes back
     down once the safety condition ends.
 
-    ``PerEntityState.is_safety`` describes the protection currently in force
-    for the entity, not the booked number. The skip branch used to leave it
-    untouched, so a weather dispatch's ``True`` rode forward onto every later
-    cycle that re-confirmed the same target — and the #1115 value-change guard
-    made that permanent, because an unchanged target suppresses ``set_target``
-    entirely. A frozen ``True`` then defeats ``clear_non_safety_targets()`` and
-    lets ``run_reconciliation_pass`` steps 3/4 resend the target with automatic
+    ``PerEntityState.is_safety`` describes the booked number, and revoking it
+    is unconditional — a revoke only removes a licence to act outside
+    ``clear_non_safety_targets()`` and reconciliation steps 3/4. Here the
+    booked 50 also happens to be this cycle's routed target, so the revoke is
+    about the booked number either way;
+    ``..._revokes_is_safety_on_a_foreign_stale_target`` covers the case where
+    it is not, and the revoke has to fire anyway.
+
+    The skip branch used to leave the flag untouched, so a weather dispatch's
+    ``True`` rode forward onto every later cycle that re-confirmed the same
+    target — and the #1115 value-change guard made that permanent, because an
+    unchanged target suppresses ``set_target`` entirely. A frozen ``True``
+    then defeats ``clear_non_safety_targets()`` and lets
+    ``run_reconciliation_pass`` steps 3/4 resend the target with automatic
     control off and outside the time window.
     """
     # Cycle 1: weather safety drives the cover from 90 to 50 — a REAL dispatch,
@@ -540,17 +551,25 @@ async def test_same_position_skip_clears_is_safety_after_condition_ends(svc, moc
 
 
 @pytest.mark.asyncio
-async def test_same_position_skip_endpoint_tolerance_still_refreshes_is_safety(
+async def test_same_position_skip_endpoint_tolerance_still_revokes_is_safety(
     svc, mock_hass
 ):
-    """Issue #1165: the safety verdict is refreshed on EVERY same_position
-    skip — including the one sub-arm that deliberately books nothing.
+    """Issue #1165: the safety verdict is revoked even on the one same_position
+    sub-arm that deliberately books nothing.
 
-    ``is_safety`` is a property of the protection, not of the booking, so it
-    cannot ride inside the booking guard. Arm 1's endpoint-tolerance sub-arm
-    proves the point: a cover resting at 98 against a 100 target skips, and
-    #1158's narrowed fix withholds the booking there because the routed target
-    (100) does not match the actual (98). The verdict still has to be written.
+    Revoking is unconditional — it only removes a licence — so it cannot ride
+    inside the booking guard. Arm 1's endpoint-tolerance sub-arm proves the
+    point: a cover resting at 98 against a 100 target skips, and #1158's
+    narrowed fix withholds the booking there because the routed target (100)
+    does not match the actual (98). The revoke still has to be written.
+
+    The entity's booked 100 does happen to equal this cycle's routed target
+    here, so a grant would also have been permitted — but that is incidental.
+    ``..._does_not_protect_a_foreign_stale_target`` is the grant-side case on
+    this same sub-arm, where the booked number differs and the grant is
+    correctly refused, and
+    ``..._revokes_is_safety_on_a_foreign_stale_target`` is the revoke under
+    the same mismatch.
     """
     # Cycle 1: a weather-safety dispatch to the 100 endpoint. Real dispatch →
     # is_safety=True, target booked at the routed endpoint.
@@ -585,17 +604,21 @@ async def test_same_position_skip_endpoint_tolerance_still_refreshes_is_safety(
 async def test_same_position_skip_does_not_protect_a_foreign_stale_target(
     svc, mock_hass
 ):
-    """Issue #1165 (round-2 audit): the verdict describes the BOOKED target,
-    so a skip that withholds its booking must not stamp ``is_safety`` onto a
-    stale number some earlier, non-safety decision left behind.
+    """Issue #1165 (round-2 audit): GRANTING the verdict describes the BOOKED
+    target, so a skip that withholds its booking must not stamp ``is_safety``
+    onto a stale number some earlier, non-safety decision left behind.
 
     The withheld-booking sub-arm (#1158) is the one place where the entity can
     still be holding a target that has nothing to do with the value this cycle
-    routed to. Writing the verdict there anyway inverts #1165's own defect: a
-    ``True`` that protects and re-drives a number the safety handler never
-    asked for. ``clear_non_safety_targets()`` then leaves the stale target in
-    place, and steps 3/4 resend it with automatic control off and outside the
-    time window.
+    routed to. Granting there anyway inverts #1165's own defect: a ``True``
+    that protects and re-drives a number the safety handler never asked for.
+    ``clear_non_safety_targets()`` then leaves the stale target in place, and
+    steps 3/4 resend it with automatic control off and outside the time window.
+
+    Only the grant is gated this way. The mirror-image test
+    ``..._revokes_is_safety_on_a_foreign_stale_target`` pins the other
+    polarity: a revoke on the same foreign-target shape fires unconditionally,
+    because it only takes a licence away.
     """
     # Cycle 1: an ordinary solar dispatch books 60. No safety involved.
     _patch_position(svc, 90)
@@ -640,6 +663,162 @@ async def test_same_position_skip_does_not_protect_a_foreign_stale_target(
         await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
 
     mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_position_skip_revokes_is_safety_on_a_foreign_stale_target(
+    svc, mock_hass
+):
+    """Issue #1165 (round-2 audit): REVOKING the safety verdict is never
+    gated on the booked target — only granting it is.
+
+    The two polarities are not symmetrical. Granting ``True`` hands out a
+    licence to act outside ``clear_non_safety_targets()`` and reconciliation
+    steps 3/4, so it has to be about the number actually booked. Revoking only
+    takes that licence away, which is safe on any number.
+
+    Gating both directions leaves #1165 reachable and, in this configuration,
+    permanent: a safety cycle books 60, the cover never arrives (position
+    matching is off by default, so nothing resends it) and comes to rest at 2,
+    and from then on every cycle computes the 0 endpoint. Each of those cycles
+    lands in arm 1's endpoint-tolerance sub-arm, where #1158 withholds the
+    booking because 2 != 0 — so the entity keeps holding the foreign 60 and a
+    symmetric gate withholds the revoke forever. Nothing in the loop can
+    correct it, which is why this test runs the cycle twice.
+    """
+    # Cycle 1: weather safety books 60 with a REAL dispatch, so
+    # ``_prepare_service_call`` genuinely stamps is_safety=True.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 60, "weather", context=_ctx(is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.get_target("cover.test") == 60
+    assert svc.state("cover.test").is_safety is True
+
+    # The cover never reaches 60. It comes to rest at 2 and stays there —
+    # enable_position_matching is off on a real install, so no resend chases it.
+    svc.set_waiting("cover.test", False)
+    _patch_position(svc, 2)
+
+    # Weather clears. Every later cycle computes 0 (sunset, climate-close, a
+    # north window). Run it twice: the state is a fixed point, so a single
+    # pass would not distinguish "revoked" from "about to self-correct".
+    for cycle in (1, 2):
+        with _patch_caps():
+            outcome, reason = await svc.apply_position(
+                "cover.test", 0, "solar", context=_ctx(is_safety=False)
+            )
+        assert (outcome, reason) == ("skipped", "same_position"), cycle
+        # #1158 still withholds the booking: 2 is not the routed 0.
+        assert svc.get_target("cover.test") == 60, cycle
+        # ...but the licence is gone. This is the assertion #1165 is about.
+        assert svc.state("cover.test").is_safety is False, cycle
+
+    # Window closes: 60 is an ordinary abandoned target, so the sweep takes it.
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+    # And with automatic control off AND outside the time window, nothing is
+    # driven to the abandoned 60 — what steps 3/4 exist to guarantee.
+    svc._auto_control_enabled = False
+    svc._in_time_window = False
+    mock_hass.services.async_call.reset_mock()
+    with _patch_caps():
+        await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_position_skip_does_not_protect_an_unbooked_entity(svc, mock_hass):
+    """Issue #1165 (round-2 audit): a skip that books nothing on an entity
+    with nothing booked must not leave ``is_safety`` True.
+
+    The verdict describes the booked target, so with no booked target there is
+    no subject for it and ``False`` is the honest answer. Granting ``True``
+    would be inert against both readers today — each no-ops on ``target is
+    None`` — but five ``set_target`` sites book without touching the verdict
+    (``restore_target``, ``send_my_position``, the two coordinator external-
+    stop paths, and the venetian carriage rebase), so the next booking through
+    any of them would silently inherit the licence. The rebase is reachable in
+    this very cycle: ``_service_secondary_axis`` runs after the verdict write.
+    """
+    # A fresh entity: nothing booked, verdict at its default.
+    assert svc.get_target("cover.test") is None
+    assert svc.state("cover.test").is_safety is False
+
+    # A weather-safety cycle wants the 0 endpoint and the cover already sits
+    # at 2 — inside position_tolerance=3. Arm 1's endpoint-tolerance sub-arm
+    # skips, and #1158 withholds the booking because 2 != 0.
+    _patch_position(svc, 2)
+    with _patch_caps():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 0, "weather", context=_ctx(is_safety=True)
+        )
+    assert (outcome, reason) == ("skipped", "same_position")
+    assert svc.get_target("cover.test") is None
+
+    # No booked number, so no licence to hand out.
+    assert svc.state("cover.test").is_safety is False
+
+    # A later booking through one of the verdict-blind ``set_target`` sites
+    # must therefore start unprotected, not inherit a licence.
+    svc.restore_target("cover.test", 60)
+    assert svc.state("cover.test").is_safety is False
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") is None
+
+
+@pytest.mark.asyncio
+async def test_same_position_skip_regrants_is_safety_when_the_condition_returns(
+    svc, mock_hass
+):
+    """Issue #1165: the GRANT polarity does not ride inside the booking guard
+    either — a returning safety condition re-protects an unchanged target.
+
+    The revoke tests all leave the flag ``False``, so on their own they would
+    stay green under a rule that simply never granted from a skip. This pins
+    the other direction on the one shape where the ``(target,
+    dispatch_token)`` value-change guard suppresses ``set_target`` entirely:
+    the booked 50 never changes across all three cycles, so every grant and
+    revoke here has to come from outside that guard.
+    """
+    # Cycle 1: weather safety drives 90 -> 50. Real dispatch, flag True.
+    _patch_position(svc, 90)
+    with _patch_caps(), _patch_no_prior_command():
+        outcome, _ = await svc.apply_position(
+            "cover.test", 50, "weather", context=_ctx(is_safety=True)
+        )
+    assert outcome == "sent"
+    assert svc.get_target("cover.test") == 50
+    assert svc.state("cover.test").is_safety is True
+
+    _patch_position(svc, 50)
+    svc.set_waiting("cover.test", False)
+
+    # Cycle 2: weather clears, solar re-confirms the same 50 -> revoked.
+    with _patch_caps():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 50, "solar", context=_ctx(is_safety=False)
+        )
+    assert (outcome, reason) == ("skipped", "same_position")
+    assert svc.state("cover.test").is_safety is False
+
+    # Cycle 3: the weather condition returns on the SAME 50. Nothing is
+    # dispatched and nothing is re-booked — the grant has to happen anyway.
+    with _patch_caps():
+        outcome, reason = await svc.apply_position(
+            "cover.test", 50, "weather", context=_ctx(is_safety=True)
+        )
+    assert (outcome, reason) == ("skipped", "same_position")
+    assert svc.get_target("cover.test") == 50
+    assert svc.state("cover.test").is_safety is True
+
+    # The licence is real: the window-close sweep leaves the target alone.
+    svc.clear_non_safety_targets()
+    assert svc.get_target("cover.test") == 50
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`PerEntityState.is_safety` had three writers with three different rules and no writer that cleared it when the safety condition ended, so its lifetime was "until the next dispatch". Two opposite failures came out of that.

The `same_position` skip books a target without a dispatch behind it and wrote nothing to the flag, so a skip-booked target inherited whatever the last real dispatch left. A stale `True` survives `clear_non_safety_targets()` and lets `run_reconciliation_pass` steps 3 and 4 resend with automatic control off or outside the time window (#1165).

`_execute_command`, the reconciliation resend path, called `_prepare_service_call` without `is_safety` or `use_my_position`, so both took their defaults on every resend (#1134). The first resend of a safety target cleared its own flag and was skipped on every later pass. A My-route cover fell past the My branch to the open/close threshold, so a My position of 10 resent as `close_cover` and was silently rebooked as 0.

The three hysteresis gates that return without dispatching now record the cycle's verdict through one shared rule in `_record_safety_verdict`. Revoking is unconditional, because it only takes away a licence to act outside the sweep and the reconciliation skips. Granting requires the booked target to be the number this cycle routed to, so a licence cannot attach to a number no safety decision produced.

`is_safety` is threaded through the resend path from the reconciliation record. `use_my_position` is re-derived instead, via a new pure `is_my_preset_target()` in `routing.py`: a booked non-endpoint target on a non-position-capable axis can only have come from a My dispatch. A stored field would need a writer at all six booking sites, and `send_my_position` never goes through `_prepare_service_call` at all, so it would reproduce this issue's own bug shape on a new field. `is_target_unreached` already computed that predicate and now delegates to the shared helper.

The pre-merge audit ran five rounds and found seven must-fix items, including a first attempt that reintroduced #1165's defect with the polarity reversed, and a caps read hoisted outside the command queue's `try`/`finally` that could strand a slot permanently. Both are fixed and covered.

## Testing

- ✅ 12880 tests passing (4 skipped, 17 xfailed)

Twelve new tests plus one amended guard. Mutation-verified: dropping the verdict write reds 7; writing it inside the value-change guard reds 5; ungating the grant reds 3; gating the revoke reds 3; dropping `is_safety` from the resend reds 1; dropping the derived `use_my_position` reds 1.

## Related Issues

Refs #1165
Refs #1134
Refs #1225