### PR TITLE
fix: inherit drift-reset ineligibility on the tilt retry (#1234) (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -1120,6 +1120,12 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             current_position=current_position,
             reason=reason,
             force=True,
+            # Issue #1234 (#684 leak): reuse the shared eligibility predicate
+            # with a null context rather than open-coding a scope comparison
+            # here. A user-requested tilt is by definition not a
+            # solar-tracking win, so this evaluates to "eligible iff scope is
+            # all_tilt_commands" — exactly right for a user command.
+            drift_reset_eligible=self._drift_reset_eligible(None),
         )
         return True
 

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -717,8 +717,15 @@ class DualAxisSequencer:
             )
             if verify and entity_id not in self._tilt_targets_verified:
                 await asyncio.sleep(VENETIAN_POST_TILT_REBASE_DELAY_SECONDS)
+                # Issue #1234: pass the RAW drift_reset_eligible parameter,
+                # deliberately not the derived drift_reset_enabled — a retry
+                # spawned from here re-derives its own _reset_in_progress /
+                # threshold > 0 folds inside _send_tilt_command itself.
                 await self._verify_and_record_tilt(
-                    entity_id, tilt_target, _retry_depth=_retry_depth
+                    entity_id,
+                    tilt_target,
+                    _retry_depth=_retry_depth,
+                    drift_reset_eligible=drift_reset_eligible,
                 )
             return False
 
@@ -868,8 +875,16 @@ class DualAxisSequencer:
         # may back-rotate the slats during position movement, leaving the cover
         # at tilt=0 even though we sent tilt=N. If we detect drift, clear the
         # recorded target so the next update_tilt_only cycle retries.
+        #
+        # Issue #1234: pass the RAW drift_reset_eligible parameter, deliberately
+        # not the derived drift_reset_enabled — a retry spawned from here
+        # re-derives its own _reset_in_progress / threshold > 0 folds inside
+        # _send_tilt_command itself.
         await self._verify_and_record_tilt(
-            entity_id, tilt_target, _retry_depth=_retry_depth
+            entity_id,
+            tilt_target,
+            _retry_depth=_retry_depth,
+            drift_reset_eligible=drift_reset_eligible,
         )
 
         if position_settled:
@@ -1295,7 +1310,12 @@ class DualAxisSequencer:
         )
 
     async def _verify_and_record_tilt(
-        self, entity_id: str, tilt_target: int, *, _retry_depth: int = 0
+        self,
+        entity_id: str,
+        tilt_target: int,
+        *,
+        _retry_depth: int = 0,
+        drift_reset_eligible: bool = True,
     ) -> None:
         """Poll actual tilt up to N samples; accept on the first in-tolerance read.
 
@@ -1315,6 +1335,14 @@ class DualAxisSequencer:
         retry passes ``_retry_depth=1`` to block further recursion: a still-
         drifting second attempt drops out and the next coordinator cycle
         owns ultimate recovery.
+
+        ``drift_reset_eligible`` (issue #1234) rides along with the retry
+        send. Without it, the flag could not survive the round trip
+        ``_send_tilt_command`` → ``_verify_and_record_tilt`` →
+        ``_send_tilt_command``: the retry always re-defaulted to eligible,
+        silently re-arming drift-reset accumulation on a send that the
+        caller had already ruled ineligible (e.g. ``sun_tracking_only``
+        scope on a non-solar win).
         """
         if self._get_current_tilt_position is None:
             return
@@ -1386,5 +1414,10 @@ class DualAxisSequencer:
                 reason="drift_retry",
                 force=True,
                 verify=True,
+                # Issue #1234: forward the caller's eligibility rather than
+                # letting it fall back to the True default — otherwise a
+                # scope-ineligible primary send that drifts silently re-arms
+                # drift-reset accumulation on the retry.
+                drift_reset_eligible=drift_reset_eligible,
                 _retry_depth=1,
             )

--- a/tests/test_cover_types/test_venetian_drift_reset.py
+++ b/tests/test_cover_types/test_venetian_drift_reset.py
@@ -714,6 +714,80 @@ class TestDriftResetScope:
         events = [e["event"] for e in buf.snapshot()]
         assert "tilt_reset_triggered" in events
 
+    async def test_drift_retry_inherits_ineligibility(self):
+        """Issue #1234: the bounded drift-retry re-send must inherit the
+        primary send's ineligibility instead of silently re-defaulting to
+        True one frame deeper — otherwise a scope-ineligible send that drifts
+        still fires a full reset cycle via the issue-#500 retry path.
+        """
+        buf = EventBuffer(maxlen=100)
+        _, seq = _build_sequencer(
+            get_tilt_reset_threshold=lambda: 1,
+            get_current_tilt_position=lambda _eid: 38,
+            event_buffer=buf,
+        )
+        await seq.update_tilt_only(
+            "cover.x",
+            tilt_target=30,
+            current_position=0,
+            reason="solar",
+            drift_reset_eligible=False,
+        )
+        events = [e["event"] for e in buf.snapshot()]
+        assert not any(ev.startswith("tilt_reset_") for ev in events)
+        assert seq._accumulated_tilt.get("cover.x", 0) == 0
+        # Issue #500 regression guard: the bounded retry itself must still
+        # fire — only its drift *accumulation* is gated, not the retry.
+        assert "tilt_command_drift_retry" in events
+
+    async def test_drift_retry_keeps_eligibility_when_eligible(self):
+        """Regression guard: an eligible send's retry still accumulates and
+        can trigger a reset — pins the `all_tilt_commands` default so the
+        ineligibility fix above cannot silently widen into option B
+        (hard-coding the retry to always be ineligible).
+        """
+        buf = EventBuffer(maxlen=100)
+        _, seq = _build_sequencer(
+            get_tilt_reset_threshold=lambda: 1,
+            get_current_tilt_position=lambda _eid: 38,
+            event_buffer=buf,
+        )
+        await seq.update_tilt_only(
+            "cover.x",
+            tilt_target=30,
+            current_position=0,
+            reason="solar",
+            drift_reset_eligible=True,
+        )
+        events = [e["event"] for e in buf.snapshot()]
+        assert "tilt_reset_triggered" in events
+
+    async def test_user_tilt_ineligible_under_sun_tracking_only(self):
+        """Issue #1234 (#684 leak): a user-requested tilt is not a
+        solar-tracking win, so under sun_tracking_only it must not trigger a
+        drift reset either.
+        """
+        hass, policy, buf = _attach_venetian_policy(
+            scope=VENETIAN_TILT_RESET_SCOPE_SOLAR, threshold=1
+        )
+        policy.sequencer._tilt_targets["cover.x"] = 0
+        await policy.apply_user_tilt("cover.x", tilt=60, reason="user_tilt")
+        events = [e["event"] for e in buf.snapshot()]
+        assert not any(ev.startswith("tilt_reset_") for ev in events)
+
+    async def test_user_tilt_eligible_under_all_scope(self):
+        """all_tilt_commands (default): a user-requested tilt still resets —
+        pins the default so the fix above cannot silently widen to suppress
+        resets for everyone.
+        """
+        hass, policy, buf = _attach_venetian_policy(
+            scope=VENETIAN_TILT_RESET_SCOPE_ALL, threshold=1
+        )
+        policy.sequencer._tilt_targets["cover.x"] = 0
+        await policy.apply_user_tilt("cover.x", tilt=60, reason="user_tilt")
+        events = [e["event"] for e in buf.snapshot()]
+        assert "tilt_reset_triggered" in events
+
 
 @pytest.mark.unit
 class TestPositionContextControlMethod:


### PR DESCRIPTION
## Summary
The `sun_tracking_only` drift-reset scope gate works correctly on the primary tilt send, but the
#500 drift-retry re-send inside `_verify_and_record_tilt` called `_send_tilt_command` without
threading `drift_reset_eligible`. The flag fell back to its `True` default and re-armed drift
accumulation on a send the scope had already ruled ineligible, so a DEFAULT-controlled venetian
tilt ran a full reset cycle.

`_verify_and_record_tilt` now takes `drift_reset_eligible` keyword-only and forwards it on the
retry. Both verify call sites pass the raw parameter rather than the derived `drift_reset_enabled`,
because the retry's own `_send_tilt_command` re-derives the `_reset_in_progress` and threshold folds
itself. `apply_user_tilt` leaked the same flag and now passes `_drift_reset_eligible(None)`.

The retry still fires; only its accumulation is gated. No-op under the default `all_tilt_commands`
scope and for every non-venetian cover type. No new config option, no migration, no translations.

Reachable on stable: `main` carries the `#808` scope feature but the identical retry gap, so the
reporter (on 2026.8.1) can hit this today.

## Testing
- ✅ 12567 tests passing on `main` (4 skipped, 17 xfailed, 0 failed)

## Related Issues
Refs #1234

Cherry-picked from #1246 for a hotfix release.
