### PR TITLE
feat: guard the forward-merge and stale-checkout releases

### DIFF
--- a/.github/workflows/forward-merge-check.yml
+++ b/.github/workflows/forward-merge-check.yml
@@ -1,0 +1,79 @@
+name: Forward-Merge Check
+
+# Standalone CI task that fails when `main` holds commits that never made it
+# back to `develop` — i.e. the post-release forward-merge was skipped.
+#
+# Every stable release and every hotfix leaves `main` one or more commits ahead
+# (the version bump at minimum). `git checkout develop && git merge main` is the
+# step that resolves it, and it is the step most easily forgotten: the fix or
+# the release already shipped, so nothing else complains. When it lapses, the
+# next stable cut hits a phantom version-bump conflict, and any hotfix that was
+# written directly on `main` is silently absent from ongoing work.
+#
+# The assertion: `origin/main` must be an ancestor of `origin/develop`.
+#
+# Two triggers, because the lapse has two shapes:
+#   - push to develop — fires the moment you resume work on develop after a
+#     release without forward-merging. No false positive during a release: the
+#     forward-merge is itself a push to develop and satisfies the assertion.
+#   - daily schedule — catches release-then-walk-away, where develop is never
+#     pushed at all. GitHub emails the maintainer on scheduled-workflow failure.
+#
+# Kept separate from tests.yml so a missed forward-merge surfaces as its own
+# check rather than a failing unit test (same rationale as
+# deprecated-ha-helpers.yml).
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+  schedule:
+    # 13:00 UTC daily — well after a typical evening release, so an overnight
+    # lapse is reported the next morning rather than a full cycle later.
+    - cron: "0 13 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: main is contained in develop
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # Full history: `merge-base --is-ancestor` needs the real graph, and a
+          # shallow clone reports false negatives.
+          fetch-depth: 0
+
+      - name: Assert origin/main is an ancestor of origin/develop
+        run: |
+          set -euo pipefail
+          git fetch origin main develop --quiet
+
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "✅ origin/main is fully contained in origin/develop."
+            exit 0
+          fi
+
+          BEHIND=$(git rev-list --count origin/develop..origin/main)
+          echo "::error::main has $BEHIND commit(s) that are not on develop — the forward-merge was skipped."
+          echo ""
+          echo "Missing from develop:"
+          git log --oneline origin/develop..origin/main
+          echo ""
+          echo "Fix with:"
+          echo "  git checkout develop && git pull --ff-only"
+          echo "  git merge main -m 'Forward-merge main into develop'"
+          echo "  git push"
+          echo ""
+          echo "Resolve any conflict in the merge — never duplicate the commits"
+          echo "as fresh commits on develop (that conflicts on the next release)."
+          exit 1

--- a/scripts/release
+++ b/scripts/release
@@ -130,7 +130,8 @@ OPTIONS:
     --editor, -e        Open editor for release notes
     --notes FILE        Read release notes from file
     --auto-notes        Use auto-generated notes only
-    --force-branch      Skip branch validation
+    --force-branch      Skip the branch-name check (does NOT skip the
+                        up-to-date check — a stale checkout is always fatal)
     --help, -h          Show this help text
 
 EXAMPLES:
@@ -366,14 +367,68 @@ validate_environment() {
     log_success "Manifest file exists"
 }
 
+# Refuse to release from a checkout that is behind origin. The script tags
+# whatever tree is checked out and then pushes it (push_commit_and_tag pushes
+# the current branch), so a stale checkout publishes an old tree under a new
+# version — unrecoverable once HACS has seen the release.
+validate_branch_freshness() {
+    local current_branch="$1"
+    local remote_ref="origin/$current_branch"
+    local behind ahead
+
+    if [[ -z $current_branch ]]; then
+        log_error "Detached HEAD — check out a branch before releasing"
+        exit 1
+    fi
+
+    if ! git fetch origin "$current_branch" --tags --quiet 2> /dev/null; then
+        log_warning "No origin/$current_branch — treating it as a local-only branch"
+        return 0
+    fi
+
+    if ! git rev-parse --verify --quiet "$remote_ref" > /dev/null; then
+        log_warning "No $remote_ref tracking ref — skipping the up-to-date check"
+        return 0
+    fi
+
+    # Compare the named branch, not HEAD — they are the same at the only call
+    # site, but keying on HEAD would silently compare the wrong tree if this is
+    # ever called for a branch that isn't checked out.
+    behind=$(git rev-list --count "$current_branch..$remote_ref")
+    ahead=$(git rev-list --count "$remote_ref..$current_branch")
+
+    if [[ $behind -gt 0 && $ahead -gt 0 ]]; then
+        log_error "Local $current_branch has diverged from $remote_ref ($ahead ahead, $behind behind)"
+        log_info "Reconcile with origin before releasing, then re-run"
+        exit 1
+    fi
+
+    if [[ $behind -gt 0 ]]; then
+        log_error "Local $current_branch is $behind commit(s) behind $remote_ref"
+        log_info "Releasing now would tag a stale tree. Run: git pull --ff-only"
+        exit 1
+    fi
+
+    if [[ $ahead -gt 0 ]]; then
+        log_warning "Local $current_branch is $ahead commit(s) ahead of origin (they will be pushed)"
+    fi
+
+    log_success "Branch up to date with $remote_ref"
+}
+
 validate_branch() {
     local current_branch
     current_branch=$(git branch --show-current)
 
     log_info "Current branch: $current_branch"
 
+    # Freshness is checked before — and independently of — the branch-name
+    # check. Being on an unexpected branch and being out of date with origin are
+    # different failures; --force-branch waives only the first.
+    validate_branch_freshness "$current_branch"
+
     if [[ $FORCE_BRANCH == true ]]; then
-        log_warning "Branch validation skipped (--force-branch)"
+        log_warning "Branch-name validation skipped (--force-branch)"
         return 0
     fi
 


### PR DESCRIPTION
## Summary

Two guardrails for the hotfix/release loop, both replacing a step that was previously only remembered.

**`ci: fail when main holds commits that never reached develop`** — new `forward-merge-check.yml` asserting `origin/main` is an ancestor of `origin/develop`. Every stable release and every hotfix leaves `main` at least one commit ahead (the version bump), and the forward-merge that resolves it is the step most easily skipped, since the release already shipped and nothing else complains. History shows it lapsing: 37 main/develop merges in ten weeks under seven different hand-typed messages, and v2026.8.0's forward-merge was missed at release time and caught two days later.

Two triggers, because the lapse has two shapes — push to `develop` catches resuming work after a release without forward-merging, and the daily cron catches release-then-walk-away where `develop` is never pushed at all. No false positive during a release: the forward-merge is itself a push to `develop` and satisfies the assertion.

**`fix: refuse a release cut from a stale checkout`** — `validate_branch()` checked the branch *name* and nothing else. My local `main` is 177 commits behind `origin/main`, so `./scripts/release` from that checkout would tag a two-month-old tree and push it, which is unrecoverable once HACS has seen the release. The check runs before, and independently of, the branch-name check: being on an unexpected branch and being out of date are different failures, and `--force-branch` should waive only the first.

## Testing

- ✅ 13332 passed, 4 skipped, 1 xfailed
- ✅ `shellcheck -S warning scripts/release` clean; `bash -n` clean
- ✅ Freshness guard exercised against real repo state across four cases — stale `main` (177 behind → exit 1), up-to-date `develop` (exit 0), local-only branch with no origin counterpart (warn, exit 0), detached HEAD (exit 1). Verified against `git rev-list` ground truth.
- ✅ CI assertion verified live: `origin/main` is currently contained in `origin/develop` (passes), and the inverted assertion fails as expected.

## Notes

The hotfix documentation in `CLAUDE.md` / `Build_and_Release.md` and the wiki was updated separately — the two repo copies disagreed on the branch prefix (`hotfix/` vs `fix/<short-slug>`) and both described writing the fix on `main` first, which the history shows we never do. The prefix divergence is mechanical: the release tooling matches head refs starting with `hotfix/`, so the four `fix/*-hotfix` branches on origin are invisible to it.