### PR TITLE
fix: expose sun-tracking min position in set_position_limits (#1242) (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -262,6 +262,16 @@ set_position_limits:
       description: "If true, min_position applies only while sun is tracked."
       selector:
         boolean:
+    min_position_sun_tracking:
+      name: Min position during sun tracking
+      description: "Optional separate minimum floor that applies only during sun tracking (0–99%). When set, overrides min_position for sun-tracking paths only. Leave unset to use min_position for all paths."
+      selector:
+        number:
+          min: 0
+          max: 99
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
     max_position:
       name: Maximum position
       description: "Maximum position the cover may move to (0–100%; 0 = always closed)."

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1886,6 +1886,10 @@
           "description": "Wenn wahr, wird min_position nur während Sonnenverfolgung angewendet.",
           "name": "Minimum-Position nur während Verfolgung aktivieren"
         },
+        "enable_position_matching": {
+          "description": "Wenn wahr, sendet der Abgleichdurchlauf das Ziel erneut, bis die Beschattung es erreicht. Wenn falsch (Standard), wird die Beschattung einmal angesteuert, und ein Ruhezustand jenseits der Positionstoleranz wird zu einer manuellen Übersteuerung.",
+          "name": "Positionsabgleich aktivieren"
+        },
         "min_position_sun_tracking": {
           "name": "Min. Position während Sonnennachführung",
           "description": "Optionale separate Minimalgrenze, die nur während der Sonnennachführung gilt (0–99%). Wenn gesetzt, überschreibt sie min_position nur für Sonnennachführungs-Pfade. Leer lassen, um min_position für alle Pfade zu verwenden."

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1583,6 +1583,10 @@
           "name": "Open/close threshold",
           "description": "Position below which open/close-only covers are closed (1–99%)."
         },
+        "enable_position_matching": {
+          "name": "Enable position matching",
+          "description": "If true, the reconciliation pass resends the target until the cover reaches it. If false (the default), the cover is commanded once and a settle past the position tolerance becomes a manual override."
+        },
         "inverse_state": {
           "name": "Inverse state",
           "description": "Invert position for covers that report state inversely."

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1886,6 +1886,10 @@
           "description": "Si vrai, min_position s'applique uniquement lors du suivi du soleil.",
           "name": "Activer la position min uniquement pendant le suivi"
         },
+        "enable_position_matching": {
+          "description": "Si vrai, la passe de réconciliation renvoie la cible jusqu'à ce que la protection l'atteigne. Si faux (par défaut), la protection est commandée une seule fois et une stabilisation au-delà de la tolérance de position devient une prise de contrôle manuelle.",
+          "name": "Activer la correspondance de position"
+        },
         "min_position_sun_tracking": {
           "name": "Position minimale pendant le suivi solaire",
           "description": "Limite minimale facultative qui s'applique uniquement pendant le suivi solaire (0–99%). Lorsqu'elle est définie, elle remplace min_position pour les chemins de suivi solaire uniquement. Laissez vide pour utiliser min_position pour tous les chemins."

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -232,3 +232,49 @@ def test_set_position_limits_field_is_default_percentage_not_default_height():
     fields = _load()["set_position_limits"]["fields"]
     assert "default_percentage" in fields
     assert "default_height" not in fields
+
+
+def test_set_position_limits_min_position_sun_tracking_field_exists_with_correct_range():
+    """Issue #1242: min_position_sun_tracking must be a set_position_limits field —
+    the option key is already wired into FIELD_VALIDATORS and
+    _SECTION_POSITION_LIMITS (options_service.py), and translations/en.json already
+    carries a services.set_position_limits.fields.min_position_sun_tracking entry;
+    only services.yaml was missing the field the UI actually renders from.
+    """
+    fields = _load()["set_position_limits"]["fields"]
+    assert "min_position_sun_tracking" in fields
+    sel = fields["min_position_sun_tracking"]["selector"]["number"]
+    assert sel["min"] == 0
+    assert sel["max"] == 99
+    assert sel["step"] == 1
+    assert sel["mode"] == "slider"
+    assert sel["unit_of_measurement"] == "%"
+
+
+def test_set_position_limits_en_json_fields_match_services_yaml():
+    """services.yaml and en.json set_position_limits fields must match 1:1 — mirrors
+    test_set_blind_spot_en_json_fields_match_services_yaml (issue #247's guard).
+    Without this lock, a yaml field can ship with no translation (silently falls back
+    to raw English in the Actions UI, confirmed in issue #1242's screenshot for
+    enable_position_matching) or a translation entry can exist with no yaml field
+    behind it (silently invisible in the Actions UI — issue #1242's root cause for
+    min_position_sun_tracking).
+    """
+    import json
+
+    yaml_fields = set(_load()["set_position_limits"]["fields"])
+    en_path = (
+        Path(__file__).parent.parent
+        / "custom_components"
+        / "adaptive_cover_pro"
+        / "translations"
+        / "en.json"
+    )
+    with en_path.open(encoding="utf-8") as fh:
+        en = json.load(fh)
+    en_fields = set(en["services"]["set_position_limits"]["fields"])
+    assert en_fields == yaml_fields, (
+        "services.yaml and en.json set_position_limits fields disagree: "
+        f"only in yaml={sorted(yaml_fields - en_fields)}, "
+        f"only in en.json={sorted(en_fields - yaml_fields)}"
+    )


### PR DESCRIPTION
## Summary
`min_position_sun_tracking` was already wired into `FIELD_VALIDATORS` and the `_SECTION_POSITION_LIMITS` frozenset that `set_position_limits` is registered with, and it had translation entries in all three languages, but `services.yaml` never declared the field. Home Assistant builds the Actions form strictly from `services.yaml`, so the option was invisible in the `set_position_limits` action even though calling the service with it worked.

Confirmed live on `main`: the option is present in `en.json` there but absent from `services.yaml`, which is the state the reporter hit on 2026.8.1.

This adds the field block with a selector matching the backend range (0-99, step 1, slider, %), and closes the mirror-image gap where `enable_position_matching` was declared in `services.yaml` but had no translation entry in any language. Both directions are locked by a parity test mirroring the `set_blind_spot` guard from #247.

## Testing
- ✅ 11538 tests passing on main

## Related Issues
Refs #1242

Follow-up (NOT fixed here): issue #1251 tracks the same drift in five other services.

Cherry-picked from #1252 for a hotfix release.