### PR TITLE
fix: recognise tilt-only custom-position slots as configured

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -337,7 +337,16 @@ def _slot_configured(options: Mapping, keys: Mapping[str, str]) -> bool:
     """Return True when a slot has a trigger AND an axis claim (mirrors helpers.py)."""
     if not _slot_has_trigger(options, keys):
         return False
-    return any(options.get(keys[sub]) is not None for sub in _CLAIM_KEYS)
+    if any(options.get(keys[sub]) is not None for sub in _CLAIM_KEYS):
+        return True
+    # A tilt-only slot claims the tilt axis through its fixed ``tilt`` value
+    # alone (mirrors helpers.custom_position_slot_claims_tilt_only). The
+    # tilt_only default (False) is duplicated for the same HA-free reason as
+    # _CLAIM_KEYS above.
+    return (
+        bool(options.get(keys["tilt_only"], False))
+        and options.get(keys["tilt"]) is not None
+    )
 
 
 def _weather_has_trigger_source(options: Mapping) -> bool:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -355,6 +355,25 @@ CUSTOM_POSITION_CLAIM_KEYS: tuple[str, ...] = (
 )
 
 
+def custom_position_slot_claims_tilt_only(
+    options: Mapping, slot_keys: Mapping[str, str]
+) -> bool:
+    """Return True when a slot claims the tilt axis via a fixed tilt-only tilt.
+
+    A tilt-only slot pins the slat angle through its ``tilt`` value alone and
+    deliberately leaves the position axis for solar to resolve, so it carries no
+    entry from :data:`CUSTOM_POSITION_CLAIM_KEYS`. The pipeline honours exactly
+    this shape — ``gather_tilt_only_contributions`` (``pipeline/tilt_axis.py``)
+    contributes a slot whose ``tilt_only`` flag is set and that has a configured
+    ``tilt`` value — so the participation gate must recognise it too, or the slot
+    is dropped before the pipeline ever sees it.
+    """
+    return (
+        bool(options.get(slot_keys["tilt_only"], DEFAULT_CUSTOM_POSITION_TILT_ONLY))
+        and options.get(slot_keys["tilt"]) is not None
+    )
+
+
 def custom_position_slot_configured(
     options: Mapping, slot_keys: Mapping[str, str]
 ) -> bool:
@@ -362,15 +381,16 @@ def custom_position_slot_configured(
 
     Single source of truth for the "slot participates" gate: a slot needs a
     trigger (at least one sensor, or a condition template) and at least one
-    claim on an axis — a `position`, or one of the axis constraints added by
-    issue #943. A trigger alone still contributes nothing.
+    claim on an axis — a `position`, one of the axis constraints added by
+    issue #943, or a fixed tilt-only slat angle. A trigger alone still
+    contributes nothing.
     """
     has_trigger = bool(
         custom_position_slot_sensors(options, slot_keys)
     ) or is_template_string(options.get(slot_keys["template"]))
     has_claim = any(
         options.get(slot_keys[sub]) is not None for sub in CUSTOM_POSITION_CLAIM_KEYS
-    )
+    ) or custom_position_slot_claims_tilt_only(options, slot_keys)
     return has_trigger and has_claim
 
 

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -223,7 +223,11 @@ from ..const import (
     OPTION_RANGES,
     TIME_STRING_RE,
 )
-from ..helpers import CUSTOM_POSITION_CLAIM_KEYS, custom_position_slot_sensors
+from ..helpers import (
+    CUSTOM_POSITION_CLAIM_KEYS,
+    custom_position_slot_claims_tilt_only,
+    custom_position_slot_sensors,
+)
 from ..templates import is_template_string as _is_template_str
 
 _LOGGER = logging.getLogger(__name__)
@@ -1150,19 +1154,25 @@ def _cross_field_validate(
     # legacy sensor, or template) AND a claim on an axis — or neither. The
     # claim vocabulary is CUSTOM_POSITION_CLAIM_KEYS: a position, or one of the
     # axis constraints (issue #943), so a trigger → "minimum tilt 50%" slot is
-    # complete without a position.
+    # complete without a position. A tilt-only slot also claims the tilt axis
+    # through its fixed ``tilt`` value alone.
     for i in CUSTOM_POSITION_SLOT_NUMBERS if check_slot_completeness else ():
         slot = _CUSTOM_SLOT_KEYS[i]
         trigger_keys = (slot["sensor"], slot["sensors"], slot["template"])
         claim_keys = tuple(slot[sub] for sub in CUSTOM_POSITION_CLAIM_KEYS)
-        if any(k in patch for k in trigger_keys + claim_keys):
+        # A tilt-only tilt claim also completes a slot; touching either the tilt
+        # value or the tilt_only flag must re-run this check.
+        tilt_only_keys = (slot["tilt"], slot["tilt_only"])
+        if any(k in patch for k in trigger_keys + claim_keys + tilt_only_keys):
             has_trigger = bool(
                 custom_position_slot_sensors(merged_active, slot)
             ) or _is_template_str(merged_active.get(slot["template"]))
-            has_claim = any(merged_active.get(k) is not None for k in claim_keys)
+            has_claim = any(
+                merged_active.get(k) is not None for k in claim_keys
+            ) or custom_position_slot_claims_tilt_only(merged_active, slot)
             if has_trigger != has_claim:
                 missing = (
-                    f"{slot['position']} (or an axis constraint)"
+                    f"{slot['position']} (or an axis constraint / tilt-only angle)"
                     if has_trigger
                     else f"{slot['sensors']} or {slot['template']}"
                 )

--- a/tests/test_custom_position_slots.py
+++ b/tests/test_custom_position_slots.py
@@ -337,6 +337,42 @@ class TestSlotConfiguredWithConstraintsOnly:
         }
         assert custom_position_slot_configured(options, keys) is True
 
+    def test_trigger_plus_tilt_only_angle_is_configured(self) -> None:
+        """A tilt-only slot (fixed slat angle, no position) participates.
+
+        gather_tilt_only_contributions honours exactly this shape, so the gate
+        must not drop it. Regression for the window-vent tilt-only slot.
+        """
+        keys = const.CUSTOM_POSITION_SLOTS[1]
+        options = {
+            keys["sensors"]: ["binary_sensor.window"],
+            keys["tilt_only"]: True,
+            keys["tilt"]: 15,
+        }
+        assert custom_position_slot_configured(options, keys) is True
+
+    def test_tilt_value_without_tilt_only_is_not_a_claim(self) -> None:
+        """A bare tilt value on a non-tilt-only slot claims nothing.
+
+        The pipeline only contributes a fixed tilt for tilt_only slots, so the
+        gate must stay precise and not treat every tilt value as a claim.
+        """
+        keys = const.CUSTOM_POSITION_SLOTS[2]
+        options = {
+            keys["sensors"]: ["binary_sensor.window"],
+            keys["tilt"]: 15,
+        }
+        assert custom_position_slot_configured(options, keys) is False
+
+    def test_tilt_only_without_tilt_value_is_not_a_claim(self) -> None:
+        """tilt_only alone, with no tilt angle, contributes nothing."""
+        keys = const.CUSTOM_POSITION_SLOTS[3]
+        options = {
+            keys["sensors"]: ["binary_sensor.window"],
+            keys["tilt_only"]: True,
+        }
+        assert custom_position_slot_configured(options, keys) is False
+
 
 class TestBuildHandlersConstraintOnlySlot:
     """build_handlers must tolerate a slot with no position claim."""
@@ -364,6 +400,36 @@ class TestBuildHandlersConstraintOnlySlot:
             h for h in build_handlers(options) if h.name == "custom_position_7"
         )
         assert handler._position is None  # noqa: SLF001
+
+    def test_tilt_only_slot_builds_handler(self) -> None:
+        """A tilt-only slot (fixed slat angle, no position) gets its handler.
+
+        Regression for the window-vent slot: before recognising the tilt-only
+        claim it never reached build_handlers, so the vent silently never fired.
+        """
+        options = {
+            "custom_position_sensors_8": ["binary_sensor.window"],
+            "custom_position_tilt_only_8": True,
+            "custom_position_tilt_8": 15,
+        }
+        assert "custom_position_8" in [h.name for h in build_handlers(options)]
+
+    def test_tilt_only_slot_carries_tilt_and_no_position_sentinel(self) -> None:
+        """A tilt-only slot forwards its tilt and keeps position None.
+
+        Same phantom-0 hazard as the constraint-only case (audit finding 3):
+        the slot names no position, so it must stay None rather than 0.
+        """
+        options = {
+            "custom_position_sensors_8": ["binary_sensor.window"],
+            "custom_position_tilt_only_8": True,
+            "custom_position_tilt_8": 15,
+        }
+        handler = next(
+            h for h in build_handlers(options) if h.name == "custom_position_8"
+        )
+        assert handler._position is None  # noqa: SLF001
+        assert handler._tilt == 15  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

A custom-position slot in `tilt_only` mode with a fixed `tilt` value (and no position) was treated as **unconfigured**: hidden from the options UI slot list and skipped by the pipeline (`snapshot_builder` / `build_handlers`). The slot silently never fired.

`custom_position_slot_configured()` gates participation on a "claim", built from `CUSTOM_POSITION_CLAIM_KEYS` (`position`, `position_max`, `tilt_min`, `tilt_max`). `tilt` is not in that list — but `pipeline/tilt_axis.py::gather_tilt_only_contributions` *does* contribute a slot whose `tilt_only` flag is set and that carries a `tilt` value. So the participation gate and the pipeline disagreed, and the slot was dropped before the pipeline ever saw it.

This adds a `tilt_only` + `tilt` claim, mirroring the pipeline's own rule (so a stray `tilt` on a non-tilt-only slot stays a non-claim). Kept the three consumers of the claim vocabulary in sync:
- `helpers.custom_position_slot_configured` (new helper `custom_position_slot_claims_tilt_only`)
- `services/options_service.py` cross-field validation (accepts the claim; re-runs the completeness check when `tilt`/`tilt_only` are patched)
- HA-free `diagnostics/triage.py::_slot_configured`

`CUSTOM_POSITION_CLAIM_KEYS` is left unchanged, so no tuple-mirror lock is affected.

## Motivation and Context

Reproducer: a contact-sensor → tilt-only 15% "ventilation" slot on a venetian never activates, because the gate drops it. The pipeline already supports exactly this shape (`gather_tilt_only_contributions`), so this is an internal inconsistency, sibling to the constraint-only slots added in #943.

## How has this been tested?

- 5 new unit tests in `tests/test_custom_position_slots.py`:
  - gate: tilt-only + tilt → configured; bare tilt without `tilt_only` → not a claim; `tilt_only` without a tilt value → not a claim
  - `build_handlers`: a tilt-only slot produces its handler, and its position stays `None` (no phantom-0 close — the audit-finding-3 hazard)
  - 3 of the 5 fail without the fix; all pass with it.
- Full suite green on `develop` (12539 passed / 33 skipped / 17 xfailed), `ruff` + `black` clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.