### PR TITLE
docs: drop the HANDOFF read from live-diagnose startup

### DIFF
--- a/.claude/skills/acp-live-diagnose/SKILL.md
+++ b/.claude/skills/acp-live-diagnose/SKILL.md
@@ -21,13 +21,11 @@ The distinguishing value here is that the install is live: the recorder can be q
 
 ## Step 0 — Session Startup
 
-`CLAUDE.md` requires it before anything else:
-
 ```bash
-cat HANDOFF.md && git status && git log --oneline -5
+git status && git log --oneline -5
 ```
 
-The handoff often names recent work in the same subsystem, which is exactly the context that turns "this looks wrong" into "this regressed in #NNNN."
+Recent commits often name work in the same subsystem, which is exactly the context that turns "this looks wrong" into "this regressed in #NNNN." When a symptom looks like a known trap rather than a new defect, `HANDOFF.md` is worth a read — it carries the unfiled gotchas and the "not hotfixable to main" table, and nothing else.
 
 ---
 
@@ -239,7 +237,7 @@ After creation, replace the trailing question with the issue URL and the Step 9 
 - **Never claim a mechanism that was not executed.** A repro that was written but not run is not evidence.
 - **Read-only against Home Assistant.** This skill queries; it does not call services, change options, or move covers. If moving a cover would confirm a hypothesis, ask the user to do it.
 - **Leave the working tree clean.** Delete every scratch test and verify with `git status --short`.
-- **Do not edit `HANDOFF.md` or `CLAUDE.md` as part of this workflow** — both are locally untracked and managed outside the repo.
+- **Do not edit `HANDOFF.md` or `CLAUDE.md` as part of this workflow** — both are excluded from the repo and synced from a source of truth outside it, so an edit to the copy here is silently discarded. `HANDOFF.md` is written only by `~/.claude/references/handoff-update.md`, after a merged run.
 - **Report contradictions rather than smoothing them.** If the recorder disagrees with the diagnostics, that gap is the finding.
 
 ---


### PR DESCRIPTION
## Summary

`HANDOFF.md` no longer carries version, issue, or release state — it holds only unfiled gotchas, the "not hotfixable to main" table, durable lessons, and pending upstream PRs. Reading it unconditionally at session start cost ~15k tokens for content `git log` answers better and more accurately.

`acp-live-diagnose`'s Step 0 now matches the updated `CLAUDE.md`:

```bash
git status && git log --oneline -5
```

The pointer to `HANDOFF.md` stays — it is still the right read when a symptom looks like a known trap rather than a new defect — it is just no longer mandatory.

Also sharpens the "do not edit it" note. The real reason is not that the file is unmanaged, but the opposite: the repo copy is synced from a source of truth outside the repo, so an edit here is silently discarded.

The rest of this change lives outside the repo (`CLAUDE.md`, `Build_and_Release.md`, `.claude/settings.json` and the shared skill playbooks are all env-sync files). This skill is the only repo-tracked file involved.

## Testing

- ✅ 12,261 passed, 4 skipped, 1 xfailed (`./scripts/test unit`) — documentation-only, no `custom_components/` or `tests/` changes