### PR TITLE
fix: refresh pipeline before the end-time override guard (#1241)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -5262,6 +5262,24 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         is where ``_pipeline_result`` is first set to ``None``); treating a
         missing attribute the same as ``None`` mirrors real startup, where the
         pipeline hasn't evaluated yet.
+
+        **Freshness precondition (issue #1241):** this reads whatever
+        ``_pipeline_result`` a coordinator update cycle last wrote — it does
+        NOT itself evaluate the pipeline. ``_pipeline_result`` is only
+        reassigned inside ``_calculate_cover_state``, and this coordinator has
+        no periodic update interval, so between ``end_time`` and the tick that
+        notices the window closed, a stale in-window winner (SOLAR/CLIMATE/
+        CLOUD/GLARE_ZONE) can sit here for up to a full reconciliation
+        interval even though that handler would decline the instant it were
+        re-evaluated with the window closed. A caller that needs "is a
+        higher-priority handler winning *right now*" — a true one-shot with no
+        further retry — must refresh the pipeline immediately before calling
+        this method, the way ``_on_window_closed`` does. ``check_sunset_window``
+        does not need that refresh: unlike the end-time edge, its False→True
+        edge is deliberately left unresolved when this guard trips (see its
+        docstring), so a stale True here only delays the sunset dispatch to
+        the next reconciliation tick (≤1 minute) rather than losing it for the
+        day — the edge self-heals without a refresh.
         """
         result = getattr(self, "_pipeline_result", None)
         if result is None:
@@ -5480,6 +5498,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     "skipping return-to-default reposition"
                 )
                 return
+            # Issue #1241: refresh BEFORE consulting the override guard below.
+            # The guard's question is "is a higher-priority handler winning
+            # *now that the window is closed*" — but this tick's
+            # ``_pipeline_result`` was last written by whichever coordinator
+            # cycle happened to run most recently, which may predate
+            # ``end_time`` by up to a full reconciliation interval if no
+            # tracked entity changed state in the gap. A stale in-window
+            # winner (SOLAR/CLIMATE/CLOUD/GLARE_ZONE) would otherwise look
+            # like an active override forever, even though every one of
+            # those handlers declines the instant the clock window closes.
+            # This refresh re-evaluates the pipeline with the window already
+            # closed, so a window-gated handler has already stood down and a
+            # genuinely active override (CUSTOM_POSITION/MANUAL/WEATHER) is
+            # still correctly detected. It cannot itself dispatch anything —
+            # the outside-window invariant blocks reposition — so this is
+            # compute-only.
+            await self.async_refresh()
             if self._pipeline_has_active_override():
                 self.logger.debug(
                     "End time reached but a higher-priority handler (%s) is "
@@ -5553,7 +5588,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     "end_time_default",
                     context=ctx,
                 )
-            # Trigger a normal refresh so sensor state and diagnostics update
+            # Trigger a normal refresh so sensor state and diagnostics reflect
+            # the commands just dispatched above. Distinct from the #1241
+            # refresh earlier in this function: that one runs BEFORE dispatch
+            # to freshen the guard's input; this one runs AFTER dispatch to
+            # publish its result. Neither makes the other redundant.
             await self.async_refresh()
 
         async def _on_window_open() -> None:

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -657,6 +657,207 @@ async def test_window_close_skips_reposition_when_custom_position_active():
     cmd_svc.apply_position.assert_not_called()
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_window_close_sends_when_stale_winner_is_window_gated():
+    """_on_window_closed must refresh the pipeline before trusting the guard.
+
+    Regression for issue #1241: the tick that detects the window close may
+    still carry a stale ``_pipeline_result`` from before ``end_time`` (no
+    coordinator refresh happened in the gap). If that stale winner is a
+    window-gated handler (SOLAR here; CLIMATE/CLOUD/GLARE_ZONE are the same
+    family), ``_pipeline_has_active_override`` must not trust it blindly —
+    those handlers all decline once the clock window is closed, so a fresh
+    evaluation resolves to DEFAULT and the end-time reposition must still
+    fire. Mirrors test_window_close_sends_reposition_when_auto_control_on,
+    but seeds a stale SOLAR result and models the refresh resolving it to
+    DEFAULT, the way a real post-close coordinator cycle would.
+    """
+    import datetime as dt
+    from types import SimpleNamespace
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DEFAULT_HEIGHT,
+        ControlMethod,
+    )
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._toggles = ToggleManager()
+    coord._event_buffer = EventBuffer(maxlen=50)
+    coord.automatic_control = True
+    coord._track_end_time = True
+    coord._inverse_state = False
+    coord.entities = [MagicMock()]
+    coord.hass = (
+        MagicMock()
+    )  # required by _read_time_entity in _compute_current_effective_default
+    # Stale in-window winner: models a tick where no refresh happened in the
+    # gap between end_time and this evaluation, so the pipeline result still
+    # reflects the daytime SOLAR winner.
+    coord._pipeline_result = SimpleNamespace(control_method=ControlMethod.SOLAR)
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
+    cmd_svc.clear_non_safety_targets = MagicMock()
+    coord._cmd_svc = cmd_svc
+
+    def _refresh_resolves_to_default(*_args, **_kwargs):
+        # Models what a real post-close coordinator cycle produces: SOLAR
+        # declines once the clock window is closed, so DEFAULT now wins.
+        coord._pipeline_result = SimpleNamespace(control_method=ControlMethod.DEFAULT)
+
+    coord.async_refresh = AsyncMock(side_effect=_refresh_resolves_to_default)
+
+    options = {CONF_DEFAULT_HEIGHT: 0}
+    config_entry = MagicMock()
+    config_entry.options = options
+    coord.config_entry = config_entry
+
+    cover_data = MagicMock()
+    cover_data.sun_data = MagicMock()
+    coord.get_blind_data = MagicMock(return_value=cover_data)
+    coord._build_position_context = MagicMock(return_value=MagicMock(force=True))
+    coord.manager = MagicMock()
+
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
+    tracker._prev_sunset_active = True
+    coord._window_tracker = tracker
+
+    with patch(
+        "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
+        return_value=(0, False),
+    ):
+        time_mgr = MagicMock()
+
+        coord._policy = get_policy("cover_blind")
+
+        async def _invoke(track_end_time, refresh_callback, on_window_open=None):
+            await refresh_callback()
+
+        time_mgr.check_transition = _invoke
+        coord._time_mgr = time_mgr
+
+        await coord._check_time_window_transition(dt.datetime.now(dt.UTC))
+
+    cmd_svc.apply_position.assert_called_once()
+    assert cmd_svc.apply_position.call_args[0][2] == "end_time_default"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_window_close_still_defers_to_custom_position_after_refresh():
+    """A genuinely active override found by the fresh evaluation still skips.
+
+    Regression for issue #895, re-pinned for #1241: the #1241 fix inserts a
+    pipeline refresh before ``_pipeline_has_active_override`` is consulted.
+    This proves that refresh does not weaken the #895 guard — when the
+    *fresh* (post-refresh) result is a genuine CUSTOM_POSITION winner (a
+    user's sleep-mode floor, priority 77), the end-time default must still
+    be skipped rather than force-overwriting it.
+    """
+    import datetime as dt
+    from types import SimpleNamespace
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DEFAULT_HEIGHT,
+        ControlMethod,
+    )
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._toggles = ToggleManager()
+    coord._event_buffer = EventBuffer(maxlen=50)
+    coord.automatic_control = True
+    coord._track_end_time = True
+    coord._inverse_state = False
+    coord.entities = [MagicMock()]
+    coord.hass = (
+        MagicMock()
+    )  # required by _read_time_entity in _compute_current_effective_default
+    # Same stale starting point as the sibling test above — the guard's
+    # freshness fix must apply uniformly, whatever the fresh result turns
+    # out to be.
+    coord._pipeline_result = SimpleNamespace(control_method=ControlMethod.SOLAR)
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
+    cmd_svc.clear_non_safety_targets = MagicMock()
+    coord._cmd_svc = cmd_svc
+
+    def _refresh_resolves_to_custom_position(*_args, **_kwargs):
+        # Models a fresh evaluation finding a genuinely active override
+        # (e.g. a custom-position sensor that flipped on around end_time).
+        coord._pipeline_result = SimpleNamespace(
+            control_method=ControlMethod.CUSTOM_POSITION
+        )
+
+    coord.async_refresh = AsyncMock(side_effect=_refresh_resolves_to_custom_position)
+
+    options = {CONF_DEFAULT_HEIGHT: 0}
+    config_entry = MagicMock()
+    config_entry.options = options
+    coord.config_entry = config_entry
+
+    cover_data = MagicMock()
+    cover_data.sun_data = MagicMock()
+    coord.get_blind_data = MagicMock(return_value=cover_data)
+    coord._build_position_context = MagicMock(return_value=MagicMock(force=True))
+    coord.manager = MagicMock()
+
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
+    tracker._prev_sunset_active = True
+    coord._window_tracker = tracker
+
+    with patch(
+        "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
+        return_value=(0, False),
+    ):
+        time_mgr = MagicMock()
+
+        coord._policy = get_policy("cover_blind")
+
+        async def _invoke(track_end_time, refresh_callback, on_window_open=None):
+            await refresh_callback()
+
+        time_mgr.check_transition = _invoke
+        coord._time_mgr = time_mgr
+
+        await coord._check_time_window_transition(dt.datetime.now(dt.UTC))
+
+    cmd_svc.apply_position.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _build_pipeline: tilt threaded from options to CustomPositionHandler
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The end-of-window reposition is a one-shot fired from the reconciliation tick, and its `_pipeline_has_active_override()` guard read whatever `_pipeline_result` the last coordinator cycle happened to write. This coordinator has no periodic update interval, so that result can predate `end_time` by up to a full reconciliation interval — and any ordinary in-window winner (`SOLAR`/`SUMMER`/`WINTER`/`CLOUD`/`GLARE_ZONE`/`MOTION`) then looked like an active override, skipping the entire end-time move. `managers/time_window.py` latches the close edge before invoking the callback, so nothing retried, and outside the clock window no other dispatch path will move the cover — the cover stayed put until the window reopened.

I refresh the pipeline immediately before consulting the guard. Re-evaluating with the clock window already closed makes every window-gated handler decline, so the winner is `DEFAULT` and the end-time position is sent. A genuinely active `CUSTOM_POSITION`/`MANUAL`/`WEATHER` slot still wins and is still deferred to, preserving the behaviour added in #895.

Behaviour delta worth naming: one extra compute-only coordinator refresh per instance at the window-close tick. It cannot dispatch anything — the clock window is already closed.

## Testing
- ✅ 13336 tests passing (full suite); `./scripts/test unit` at 12263 passed / 4 skipped / 1 xfailed, exactly the baseline plus the two new tests
- New: `test_window_close_sends_when_stale_winner_is_window_gated` (red before the fix — `apply_position` called 0 times)
- New: `test_window_close_still_defers_to_custom_position_after_refresh` (pins that the #895 skip survives a fresh evaluation)

## Related Issues
Refs #1241