### PR TITLE
fix: anchor a blank start time to sunrise, not midnight (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1708,6 +1708,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     # --- Timing window ---
     "timing.from_entity": "from {entity}",
     "timing.from_time": "from {time}",
+    "timing.from_sunrise": "from sunrise",
     "timing.until_entity": "until {entity}",
     "timing.until_time": "until {time}",
     "timing.active_daylight": "Active during daylight",
@@ -2902,10 +2903,18 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     sunset_time_entity = config.get(CONF_SUNSET_TIME_ENTITY)
     sunrise_time_entity = config.get(CONF_SUNRISE_TIME_ENTITY)
     timing_parts = []
+    # A blank/unset start no longer means "no lower bound" once an end bound
+    # IS configured — it anchors to astronomical sunrise instead of midnight
+    # (issue #1256), matching the start_time option's documented "leave
+    # blank to start at sunrise". With no end bound either, the window stays
+    # unbounded on both sides and this stays silent, as before.
+    end_bound_configured = bool(end_entity) or bool(end_time and end_time != BLANK_TIME)
     if start_entity:
         timing_parts.append(L["timing.from_entity"].format(entity=start_entity))
     elif start_time and start_time != BLANK_TIME:
         timing_parts.append(L["timing.from_time"].format(time=start_time))
+    elif end_bound_configured:
+        timing_parts.append(L["timing.from_sunrise"])
     if end_entity:
         timing_parts.append(L["timing.until_entity"].format(entity=end_entity))
     elif end_time and end_time != BLANK_TIME:

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -542,6 +542,25 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Cover entity state provider
         self._cover_provider = CoverProvider(hass=self.hass, logger=self.logger)
 
+        def _resolve_blank_start_sunrise() -> dt.datetime | None:
+            """Astronomical sunrise, as naive-local wall-clock time (issue #1256).
+
+            Feeds ``TimeWindowManager.after_start_time`` so a blank start
+            time anchors the window's lower bound to sunrise instead of
+            midnight, once an end bound is configured. Resolved lazily on
+            each call — a fresh ``SunData`` read at evaluation time, not a
+            value captured once at startup — and fails open to ``None`` on
+            any error, which ``after_start_time`` treats identically to "no
+            sunrise available" (stays True, the pre-#1256 behaviour).
+            """
+            try:
+                sun_data = self._sun_provider.create_sun_data(
+                    self.hass.config.time_zone
+                )
+                return dt_util.as_local(sun_data.sunrise()).replace(tzinfo=None)
+            except Exception:  # noqa: BLE001 — fail open to pre-#1256 behaviour
+                return None
+
         # Time window manager (start/end time checks). Built here, ahead of the
         # snapshot builder, because the builder's effective-default fallback
         # reads the live window state off it (issue #1055).
@@ -550,6 +569,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             logger=self.logger,
             event_buffer=self._event_buffer,
             template_variables=self._template_variables,
+            sunrise_provider=_resolve_blank_start_sunrise,
         )
 
         # Pipeline snapshot builder — owns the HA reads + assembly for each

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -23,6 +23,21 @@ from .common import EventRecorder
 from .common.condition_gate import ConditionGate
 
 
+def _bound_is_configured(entity: str | None, static_value: str | None) -> bool:
+    """Whether a start/end time bound has a real (non-blank) value configured.
+
+    True when an entity is wired, or a static value is set and isn't the
+    blank sentinel ``BLANK_TIME``. Single definition of "configured" for a
+    time-window bound, shared so a future symmetric check (e.g. "is the
+    *start* bound configured?" for the blank-end case) delegates here rather
+    than re-deriving the same predicate (CODING_GUIDELINES no-duplication
+    rule). Currently consulted once, from :pyattr:`TimeWindowManager.after_start_time`.
+    """
+    return entity is not None or (
+        static_value is not None and static_value != BLANK_TIME
+    )
+
+
 class TimeWindowManager:
     """Manages operational time window checks.
 
@@ -38,6 +53,7 @@ class TimeWindowManager:
         event_buffer=None,
         clock: Callable[[], float] = time.monotonic,
         template_variables: Mapping[str, Any] | None = None,
+        sunrise_provider: Callable[[], dt.datetime | None] | None = None,
     ) -> None:
         """Initialize time window manager.
 
@@ -50,12 +66,24 @@ class TimeWindowManager:
             template_variables: Opaque render context threaded into the
                 daytime-gate template — the ``acp`` self-reference namespace
                 built once by the coordinator (issue #1159).
+            sunrise_provider: Optional zero-arg closure returning today's
+                astronomical sunrise as naive-local wall-clock time (or
+                ``None`` when unresolvable). Consulted only by
+                :pyattr:`after_start_time`, only when no start time is
+                configured AND an end bound is configured, so a blank start
+                anchors the window's lower bound to sunrise instead of
+                midnight (issue #1256) rather than leaving the window open
+                all night. Injected — like the ``ConditionGate`` readers
+                below — so tests drive it deterministically; omitting it
+                (the default) preserves the pre-#1256 fail-open-to-True
+                behaviour.
 
         """
         self._hass = hass
         self.logger = logger
         self._event_buffer = event_buffer
         self._template_variables = template_variables
+        self._sunrise_provider = sunrise_provider
         self._events = EventRecorder(event_buffer)
         self._last_time_window_state: bool | None = None
 
@@ -299,13 +327,27 @@ class TimeWindowManager:
 
         Returns:
             True if current time is after configured start time (from entity
-            or static config), False otherwise. Returns True if no start time
-            configured (including the blank sentinel) — the active-window logic
-            keys on this meaning "no start restriction".
+            or static config), False otherwise. When no start time is
+            configured (including the blank sentinel) the result depends on
+            whether an end bound is configured: with no end bound the window
+            is unbounded on both sides and this fails open to True — "no
+            start restriction" (unchanged pre-#1256 behaviour). Once an end
+            bound IS configured, a blank start anchors the window's lower
+            bound to astronomical sunrise instead of midnight (issue #1256),
+            via the injected ``sunrise_provider`` — matching the ``start_time``
+            option's documented "leave blank to start at sunrise". Falls back
+            to True (fail-open) when no ``sunrise_provider`` was injected or
+            it returns ``None``.
 
         """
         passed = self._start_has_passed()
-        return True if passed is None else passed
+        if passed is not None:
+            return passed
+        if _bound_is_configured(self._end_time_entity, self._end_time_config):
+            sunrise = self._sunrise_provider() if self._sunrise_provider else None
+            if sunrise is not None:
+                return local_now_naive() >= sunrise
+        return True
 
     @property
     def window_explicitly_started(self) -> bool:

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -165,6 +165,7 @@
   "timing": {
     "from_entity": "von {entity}",
     "from_time": "von {time}",
+    "from_sunrise": "ab Sonnenaufgang",
     "until_entity": "bis {entity}",
     "until_time": "bis {time}",
     "active_daylight": "Aktiv während Tageslicht",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -165,6 +165,7 @@
   "timing": {
     "from_entity": "from {entity}",
     "from_time": "from {time}",
+    "from_sunrise": "from sunrise",
     "until_entity": "until {entity}",
     "until_time": "until {time}",
     "active_daylight": "Active during daylight",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -165,6 +165,7 @@
   "timing": {
     "from_entity": "de {entity}",
     "from_time": "de {time}",
+    "from_sunrise": "du lever du soleil",
     "until_entity": "jusqu'à {entity}",
     "until_time": "jusqu'à {time}",
     "active_daylight": "Actif pendant la lumière du jour",

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -794,6 +794,41 @@ def test_mixed_start_entity_with_static_end_time():
     assert "until 21:30" in summary
 
 
+def test_blank_start_with_configured_end_shows_from_sunrise():
+    """A blank start + configured end now anchors to sunrise, not midnight (#1256).
+
+    The summary must say so — a bare 'until 21:30' with no lower bound would
+    silently misrepresent the window as unbounded-below when it isn't.
+    """
+    cfg = {CONF_END_TIME: "21:30"}
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "from sunrise" in summary
+    assert "until 21:30" in summary
+
+
+def test_blank_start_with_configured_end_entity_shows_from_sunrise():
+    """Same as above, with an end ENTITY instead of a static end time."""
+    cfg = {CONF_END_ENTITY: "sensor.sun_next_setting"}
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "from sunrise" in summary
+    assert "sensor.sun_next_setting" in summary
+
+
+def test_blank_start_with_no_end_does_not_show_from_sunrise():
+    """Both blank (issue #492's shape) stays 'Active during daylight' — unchanged.
+
+    With no end bound configured either, the window is unbounded on both
+    sides and the #1256 sunrise anchor does not apply (out of scope: the
+    blank-end symmetric case is a deliberate follow-up, not this fix).
+    """
+    from custom_components.adaptive_cover_pro.const import BLANK_TIME
+
+    cfg = {CONF_START_TIME: BLANK_TIME, CONF_END_TIME: BLANK_TIME}
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "from sunrise" not in summary
+    assert "Active during daylight" in summary
+
+
 def test_sunset_position_shown():
     """Sunset/end-of-day position appears in timing bullet."""
     cfg = {CONF_SUNSET_POS: 0}

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -398,6 +398,93 @@ async def test_coordinator_injects_time_mgr_into_snapshot_builder(
     assert coordinator._snapshot_builder._time_mgr is coordinator._time_mgr
 
 
+async def test_coordinator_sunrise_provider_resolves_naive_local_sunrise(
+    hass: HomeAssistant,
+) -> None:
+    """The coordinator wires a real ``sunrise_provider`` into TimeWindowManager (#1256).
+
+    ``TimeWindowManager.after_start_time`` anchors a blank start time to
+    sunrise instead of midnight once an end bound is configured — but only
+    if the injected closure actually resolves a sane naive-LOCAL value, the
+    same frame ``local_now_naive()`` reads. Pacific/Auckland (UTC+12) makes a
+    naive-UTC leak obvious: astral's sunrise is UTC-aware, so a fix that
+    forgot the ``dt_util.as_local`` conversion (or stripped tzinfo without
+    converting) would land ~12 hours away from a plausible Auckland morning.
+    """
+    import datetime as dt
+    import zoneinfo
+    from unittest.mock import patch
+
+    from homeassistant import config_entries as ha_config_entries
+
+    auckland = zoneinfo.ZoneInfo("Pacific/Auckland")
+    hass.config.time_zone = "Pacific/Auckland"
+    hass.config.latitude = -36.8485
+    hass.config.longitude = 174.7633
+    hass.config.elevation = 20
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Sunrise Provider Cover", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="sunrise_provider_01",
+        title="Sunrise Provider Cover",
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", auckland):
+        token = ha_config_entries.current_entry.set(entry)
+        try:
+            coordinator = AdaptiveDataUpdateCoordinator(hass)
+        finally:
+            ha_config_entries.current_entry.reset(token)
+
+        sunrise = coordinator._time_mgr._sunrise_provider()
+
+    assert sunrise is not None
+    assert sunrise.tzinfo is None  # naive-local, matching local_now_naive()
+    # A same-instant value stuck in UTC (the bug this guards) would land
+    # many hours off any plausible Auckland sunrise hour.
+    assert dt.time(4, 0) <= sunrise.time() <= dt.time(10, 0)
+
+
+async def test_coordinator_sunrise_provider_fails_open_on_error(
+    hass: HomeAssistant,
+) -> None:
+    """A broken sun-data read must not crash — the sunrise_provider fails open to None.
+
+    Mirrors ``after_start_time``'s own fail-open-to-True contract for "no
+    sunrise available" (issue #1256): any error resolving today's
+    astronomical sunrise degrades gracefully instead of raising out of a
+    property read every coordinator cycle would hit.
+    """
+    from unittest.mock import patch
+
+    from homeassistant import config_entries as ha_config_entries
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Sunrise Error Cover", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="sunrise_provider_err_01",
+        title="Sunrise Error Cover",
+    )
+    entry.add_to_hass(hass)
+
+    token = ha_config_entries.current_entry.set(entry)
+    try:
+        coordinator = AdaptiveDataUpdateCoordinator(hass)
+    finally:
+        ha_config_entries.current_entry.reset(token)
+
+    with patch.object(
+        coordinator._sun_provider,
+        "create_sun_data",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert coordinator._time_mgr._sunrise_provider() is None
+
+
 # ---------------------------------------------------------------------------
 # Venetian mode wiring
 # ---------------------------------------------------------------------------

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -642,6 +642,39 @@ class TestBlankStartTimeNightAfterMidnight:
         assert result == 0
         assert active is True
 
+    def test_blank_start_at_midnight_with_no_sunset_pos_returns_default(self):
+        """No configured sunset_pos short-circuits BEFORE the #492 branch.
+
+        Issue #1256: unlike the case above, this reporter never configured a
+        sunset/night position. ``sunset_pos is None`` returns ``h_def``
+        unconditionally (helpers.py:1210-1211) — the #492/#493
+        ``window_explicitly_started`` signal never gets consulted at all, so
+        it holding ``False`` at midnight makes no difference here. This
+        documents why the fix belongs in the time-window's active/inactive
+        transition (issue #1256) rather than in this function: with no night
+        position configured, the only thing that stops the daytime default
+        from firing at midnight is the window itself staying closed.
+        """
+        sun = _make_sun_data(
+            sunrise_hour=4,
+            sunrise_minute=19,
+            sunset_hour=21,
+            sunset_minute=31,
+        )
+        today = dt.date.today()
+        now = dt.datetime(today.year, today.month, today.day, 0, 1, 0)
+        with _freeze_now(now):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=None,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                window_explicitly_started=False,
+            )
+        assert result == 100
+        assert active is False
+
 
 # ---------------------------------------------------------------------------
 # Timezone regression: entity-override boundaries must respect HA local tz

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -14,14 +14,16 @@ from custom_components.adaptive_cover_pro.const import BLANK_TIME
 from custom_components.adaptive_cover_pro.managers.time_window import TimeWindowManager
 
 
-def _make_manager(mock_hass=None):
+def _make_manager(mock_hass=None, sunrise_provider=None):
     """Build a TimeWindowManager with a MagicMock hass and logger."""
     hass = mock_hass or MagicMock()
     logger = MagicMock()
     logger.debug = MagicMock()
     logger.info = MagicMock()
     logger.error = MagicMock()
-    return TimeWindowManager(hass=hass, logger=logger)
+    return TimeWindowManager(
+        hass=hass, logger=logger, sunrise_provider=sunrise_provider
+    )
 
 
 _TIME_WINDOW = "custom_components.adaptive_cover_pro.managers.time_window"
@@ -168,6 +170,208 @@ def test_after_start_time_static_parse_failure_treats_as_passed():
         result = mgr.after_start_time
 
     assert result is True
+
+
+# ---------------------------------------------------------------------------
+# after_start_time: blank start anchors to sunrise once an end bound is
+# configured (issue #1256) — otherwise the window re-opens at local midnight
+# ---------------------------------------------------------------------------
+
+
+def _sunrise_provider(hour: int, minute: int, day: dt.date = dt.date(2026, 8, 12)):
+    """Build a deterministic ``sunrise_provider`` returning a fixed naive-local time."""
+    sunrise = dt.datetime.combine(day, dt.time(hour, minute))
+    return lambda: sunrise
+
+
+# The reporter's end entity (sensor.sun_next_setting) reads tomorrow's sunset
+# all evening — the parsed value never changes; only _normalize_to_today's
+# comparison against "today" does, as the clock crosses midnight.
+_END_ENTITY_RAW = "2026-08-12T20:07:39"
+_END_ENTITY_PARSED = dt.datetime(2026, 8, 12, 20, 7, 39)
+
+
+@pytest.mark.unit
+def test_blank_start_with_configured_end_stays_closed_before_sunrise():
+    """A blank start + a configured end must NOT open the window at midnight.
+
+    Issue #1256: mapping "no start configured" straight to True puts the
+    window's lower bound at midnight. With a sunrise provider wired and an
+    end bound configured, the lower bound must be sunrise instead.
+    """
+    mgr = _make_manager(sunrise_provider=_sunrise_provider(6, 0))
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity="sensor.sun_next_setting",
+    )
+
+    with (
+        patch(f"{_TIME_WINDOW}.get_safe_state", return_value=_END_ENTITY_RAW),
+        patch(f"{_TIME_WINDOW}.get_datetime_from_str", return_value=_END_ENTITY_PARSED),
+        patch(
+            f"{_TIME_WINDOW}.local_now_naive",
+            return_value=dt.datetime(2026, 8, 12, 0, 5, 0),
+        ),
+    ):
+        assert mgr.after_start_time is False
+        assert mgr.is_active is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_blank_start_with_configured_end_no_midnight_reopen_transition():
+    """No ``on_window_open`` / ``time_window_changed`` event fires at local midnight.
+
+    Reproduces the reporter's timeline end-to-end: window closes at sunset
+    (end time passed), stays closed through midnight, and check_transition
+    never sees inactive→active until sunrise.
+    """
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    event_buffer = EventBuffer(maxlen=50)
+    mgr = TimeWindowManager(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        event_buffer=event_buffer,
+        sunrise_provider=_sunrise_provider(6, 0),
+    )
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity="sensor.sun_next_setting",
+    )
+    on_window_open = AsyncMock()
+    refresh_callback = AsyncMock()
+
+    # Prime at 23:55 Aug 11 local — window CLOSED (end time already passed
+    # today, per _normalize_to_today pinning the entity's Aug-12 reading
+    # back to Aug-11).
+    with (
+        patch(f"{_TIME_WINDOW}.get_safe_state", return_value=_END_ENTITY_RAW),
+        patch(f"{_TIME_WINDOW}.get_datetime_from_str", return_value=_END_ENTITY_PARSED),
+        patch(
+            f"{_TIME_WINDOW}.local_now_naive",
+            return_value=dt.datetime(2026, 8, 11, 23, 55, 0),
+        ),
+    ):
+        await mgr.check_transition(
+            track_end_time=True,
+            refresh_callback=refresh_callback,
+            on_window_open=on_window_open,
+        )
+    assert mgr._last_time_window_state is False
+
+    # Advance to 00:05 Aug 12 local — the date rollover that (pre-fix)
+    # re-opens the window at midnight.
+    with (
+        patch(f"{_TIME_WINDOW}.get_safe_state", return_value=_END_ENTITY_RAW),
+        patch(f"{_TIME_WINDOW}.get_datetime_from_str", return_value=_END_ENTITY_PARSED),
+        patch(
+            f"{_TIME_WINDOW}.local_now_naive",
+            return_value=dt.datetime(2026, 8, 12, 0, 5, 0),
+        ),
+    ):
+        await mgr.check_transition(
+            track_end_time=True,
+            refresh_callback=refresh_callback,
+            on_window_open=on_window_open,
+        )
+
+    on_window_open.assert_not_awaited()
+    assert all(
+        event.get("event") != "time_window_changed" for event in event_buffer.snapshot()
+    )
+
+
+@pytest.mark.unit
+def test_window_explicitly_started_stays_false_across_midnight_and_noon():
+    """window_explicitly_started (#492/#493) must not move.
+
+    Locked separately from after_start_time so the sunrise anchor cannot
+    resurrect the bug #493 fixed: a blank start must never register as an
+    explicit start, at midnight or at any other hour.
+    """
+    mgr = _make_manager(sunrise_provider=_sunrise_provider(6, 0))
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity="sensor.sun_next_setting",
+    )
+
+    for now in (
+        dt.datetime(2026, 8, 12, 0, 5, 0),
+        dt.datetime(2026, 8, 12, 12, 0, 0),
+    ):
+        with patch(f"{_TIME_WINDOW}.local_now_naive", return_value=now):
+            assert mgr.window_explicitly_started is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_blank_start_opens_window_at_sunrise_not_before():
+    """Sunrise, not midnight, is where the blank-start window actually opens.
+
+    check_transition must fire on_window_open exactly once, at the 05:55 →
+    06:05 sunrise crossing.
+    """
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    event_buffer = EventBuffer(maxlen=50)
+    mgr = TimeWindowManager(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        event_buffer=event_buffer,
+        sunrise_provider=_sunrise_provider(6, 0),
+    )
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity="sensor.sun_next_setting",
+    )
+    on_window_open = AsyncMock()
+    refresh_callback = AsyncMock()
+
+    with (
+        patch(f"{_TIME_WINDOW}.get_safe_state", return_value=_END_ENTITY_RAW),
+        patch(f"{_TIME_WINDOW}.get_datetime_from_str", return_value=_END_ENTITY_PARSED),
+        patch(
+            f"{_TIME_WINDOW}.local_now_naive",
+            return_value=dt.datetime(2026, 8, 12, 5, 55, 0),
+        ),
+    ):
+        assert mgr.after_start_time is False
+        await mgr.check_transition(
+            track_end_time=True,
+            refresh_callback=refresh_callback,
+            on_window_open=on_window_open,
+        )
+
+    with (
+        patch(f"{_TIME_WINDOW}.get_safe_state", return_value=_END_ENTITY_RAW),
+        patch(f"{_TIME_WINDOW}.get_datetime_from_str", return_value=_END_ENTITY_PARSED),
+        patch(
+            f"{_TIME_WINDOW}.local_now_naive",
+            return_value=dt.datetime(2026, 8, 12, 6, 5, 0),
+        ),
+    ):
+        assert mgr.after_start_time is True
+        assert mgr.is_active is True
+        await mgr.check_transition(
+            track_end_time=True,
+            refresh_callback=refresh_callback,
+            on_window_open=on_window_open,
+        )
+
+    on_window_open.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
With a blank start time and a configured end time, the operational window re-opened at local midnight. `after_start_time` mapped "no start configured" to `True`, putting the window's lower bound at midnight while `_normalize_to_today` pinned the end onto the new date. `is_active` flipped inactive to active at 00:00, `check_transition` fired `on_window_open`, and with every override handler declining in darkness the priority-0 default handler drove the cover to its daytime default.

`compute_effective_default` short-circuits on `sunset_pos is None`, so the night-hold branch added for #492 never runs for installs that never configured a night position. That is why the earlier fix did not reach the reporter.

`TimeWindowManager` now takes an optional `sunrise_provider`. Only the blank-start branch of `after_start_time` changed: when an end bound is configured it consults sunrise and fails open to `True` when none is available, so the window is `[sunrise, end]` and never flips at midnight. The coordinator wires the provider as a closure over live `SunData`, converting astral's UTC-aware sunrise to naive local. The config summary renders "from sunrise" for that shape, with DE/FR synced.

`_resolve_start_datetime`, `_start_has_passed`, `window_explicitly_started` and `compute_effective_default` are untouched.

Not fixed here: the mirror-image case (a start time set, end time left blank) has the same shape and is tracked separately. The shared `_bound_is_configured` helper prepares for it.

## Testing
- ✅ 12573 tests passing on `main` (4 skipped, 17 xfailed)
- Verified under `TZ=Asia/Kolkata` and `TZ=Pacific/Kiritimati` for the naive-local vs naive-UTC seam

## Related Issues
Refs #1256

Cherry-picked from #1259 for a hotfix release.