### PR TITLE
feat: offer the companion card install in the options flow

### DIFF
--- a/custom_components/adaptive_cover_pro/companion_card.py
+++ b/custom_components/adaptive_cover_pro/companion_card.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from urllib.parse import parse_qs, urlsplit
 
 from homeassistant.core import HomeAssistant, callback
 
@@ -49,8 +50,10 @@ LOVELACE_DOMAIN = "lovelace"
 # an object at hass.data["hacs"], but one whose repo list is empty or stale.
 _HACS_STAGE_RUNNING = "running"
 
-# The cache-buster users maintain by hand on a manually registered resource.
-_VERSION_QUERY = "?v="
+# The cache-buster query parameter users maintain by hand on a manually
+# registered resource. HACS stamps its own URLs with ``hacstag`` instead, which
+# is deliberately not read: it is a build tag, not a version.
+_VERSION_PARAM = "v"
 
 # ── Outbound links ──────────────────────────────────────────────────────────
 # ``category`` is load-bearing: HACS's repository dashboard only offers its
@@ -156,14 +159,20 @@ def _status_from_hacs(hacs: object | None) -> CardStatus | None:
 
 
 def _hacs_is_ready(hacs: object | None) -> bool:
-    """Whether HACS is loaded far enough for its repository list to be trusted."""
+    """Whether HACS is loaded far enough for its repository list to be trusted.
+
+    Both attributes are read through ``getattr`` defaults rather than as bare
+    chains. If HACS renames ``system.disabled``, the default says "not
+    disabled" and the stage check still decides — a rename must not silently
+    take the whole HACS rung down and leave every install falling back to
+    resource detection with no version to report.
+    """
     if hacs is None:
         return False
     try:
-        return (
-            getattr(hacs, "stage", None) == _HACS_STAGE_RUNNING
-            and not hacs.system.disabled  # type: ignore[attr-defined]
-        )
+        if getattr(hacs, "stage", None) != _HACS_STAGE_RUNNING:
+            return False
+        return not getattr(getattr(hacs, "system", None), "disabled", False)
     except Exception:
         _LOGGER.debug("Could not read HACS readiness", exc_info=True)
         return False
@@ -172,15 +181,17 @@ def _hacs_is_ready(hacs: object | None) -> bool:
 def _card_resource_url(hass: HomeAssistant) -> str | None:
     """Return the card's registered dashboard-resource URL, if one exists.
 
-    Matches on the bundle filename so both the HACS path
-    (``/hacsfiles/...``) and a hand-registered ``/local/...`` copy are found.
+    Compares the URL's final path segment rather than searching the whole
+    string, so both the HACS path (``/hacsfiles/...``) and a hand-registered
+    ``/local/...`` copy match, while a longer name that merely contains ours
+    (``my-adaptive-cover-pro-card.js``, or a ``.js.map``) does not.
     """
     try:
         resources = getattr(hass.data.get(LOVELACE_DOMAIN), "resources", None)
         items = resources.async_items() if resources is not None else ()
         for item in items:
             url = item.get("url") or ""
-            if CARD_JS_FILENAME in url:
+            if urlsplit(url).path.rsplit("/", 1)[-1] == CARD_JS_FILENAME:
                 return url
     except Exception:
         _LOGGER.debug("Could not read the dashboard resources", exc_info=True)
@@ -188,5 +199,11 @@ def _card_resource_url(hass: HomeAssistant) -> str | None:
 
 
 def _version_from_url(url: str) -> str | None:
-    """Lift the ``?v=`` stamp a manual install carries, when it has one."""
-    return url.partition(_VERSION_QUERY)[2] or None
+    """Lift the ``?v=`` stamp a manual install carries, when it has one.
+
+    Parsed as a query parameter rather than split on the string, so a URL
+    carrying more than one parameter yields the version alone instead of
+    everything trailing it.
+    """
+    values = parse_qs(urlsplit(url).query).get(_VERSION_PARAM)
+    return values[0] if values else None

--- a/custom_components/adaptive_cover_pro/companion_card.py
+++ b/custom_components/adaptive_cover_pro/companion_card.py
@@ -1,0 +1,187 @@
+"""Companion Lovelace card presence detection (issue #1168).
+
+HACS declined the card's `plugin` submission on policy grounds — a card with a
+1:1 dependency on one integration is not catalogued separately — so the card
+ships as a HACS *custom repository*. A user therefore cannot find it by
+searching HACS; they have to register the repository first. That is the gap the
+options-flow "Dashboard Card" screen closes, and this module is the half that
+answers "is it already here?".
+
+The add itself is handed to HACS through a My Home Assistant redirect rather
+than performed here. HACS registers no services — it is websocket-only, and
+`websocket_api` has no in-process invoke — so the only Python route would be
+`hass.data["hacs"].async_register_repository()`, an undocumented private call
+that does blocking GitHub I/O. The redirect makes HACS show its own
+"Add custom repository" confirm dialog instead, which is the supported handoff.
+
+Nothing outside this module knows the card's repository slug.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from homeassistant.core import HomeAssistant, callback
+
+_LOGGER = logging.getLogger(__name__)
+
+# ── Card identity ───────────────────────────────────────────────────────────
+# These stay here rather than in const.py by the architectural-anchor exception
+# in CODING_GUIDELINES.md § No Magic Numbers: this module is the integration's
+# only point of contact with the companion card, and these values are what
+# define that boundary. Centralising them would spread the card's identity into
+# code that has no business knowing it.
+CARD_OWNER = "jrhubott"
+CARD_REPO = "adaptive-cover-pro-card"
+CARD_FULL_NAME = f"{CARD_OWNER}/{CARD_REPO}"
+CARD_JS_FILENAME = "adaptive-cover-pro-card.js"
+
+# HACS's wire value for a Lovelace card is "plugin". ``HacsCategory`` has no
+# ``lovelace`` member and the add handler rejects anything outside the enum.
+CARD_HACS_CATEGORY = "plugin"
+
+HACS_DOMAIN = "hacs"
+LOVELACE_DOMAIN = "lovelace"
+
+# HACS reports this stage once its repository list is populated and queryable.
+# Any earlier stage — or a disabled HACS (rate limit, bad token) — still leaves
+# an object at hass.data["hacs"], but one whose repo list is empty or stale.
+_HACS_STAGE_RUNNING = "running"
+
+# The cache-buster users maintain by hand on a manually registered resource.
+_VERSION_QUERY = "?v="
+
+# ── Outbound links ──────────────────────────────────────────────────────────
+# ``category`` is load-bearing: HACS's repository dashboard only offers its
+# "Add custom repository" confirm dialog for an unknown repo when the parameter
+# is present. Omit it and the user gets "Repository not found" instead.
+CARD_ADD_URL = (
+    "https://my.home-assistant.io/redirect/hacs_repository/"
+    f"?owner={CARD_OWNER}&repository={CARD_REPO}&category={CARD_HACS_CATEGORY}"
+)
+CARD_DOWNLOAD_URL = f"https://github.com/{CARD_FULL_NAME}/releases/latest"
+CARD_WIKI_URL = "https://github.com/jrhubott/adaptive-cover-pro/wiki/Dashboard-Cards"
+HACS_DOWNLOAD_URL = "https://hacs.xyz/docs/use/download/download/"
+
+DETECTED_VIA_HACS = "hacs"
+DETECTED_VIA_RESOURCE = "resource"
+
+
+@dataclass(frozen=True, slots=True)
+class CardStatus:
+    """What this install knows about the companion card.
+
+    The default — every field falsy — is the honest "we found nothing" answer,
+    which is also what every degraded read falls back to.
+    """
+
+    hacs_present: bool = False
+    hacs_ready: bool = False
+    installed: bool = False
+    installed_version: str | None = None
+    available_version: str | None = None
+    detected_via: str | None = None
+
+
+@callback
+def async_get_card_status(hass: HomeAssistant) -> CardStatus:
+    """Report whether the companion card is installed, and how it was found.
+
+    Reads only in-memory state, so this is a callback rather than a coroutine.
+
+    Two rungs: HACS when it is running and knows the repository, then the
+    registered dashboard resources — which is what catches a card installed by
+    hand, so a manual install is never nagged as missing.
+
+    Every read of both is guarded. HACS is itself a custom integration with no
+    versioned public API (and two known upstream bugs in the neighbouring
+    lookups), and a shape change there must degrade this screen, not take the
+    whole options flow down with it.
+    """
+    hacs = hass.data.get(HACS_DOMAIN)
+    from_hacs = _status_from_hacs(hacs)
+    if from_hacs is not None and from_hacs.installed:
+        return from_hacs
+
+    resource_url = _card_resource_url(hass)
+    if resource_url is not None:
+        return CardStatus(
+            hacs_present=hacs is not None,
+            hacs_ready=from_hacs is not None,
+            installed=True,
+            installed_version=_version_from_url(resource_url),
+            detected_via=DETECTED_VIA_RESOURCE,
+        )
+
+    # ``from_hacs`` is None whenever HACS could not be asked at all — absent,
+    # still starting, disabled, or its internals moved. That is deliberately
+    # NOT reported as ``hacs_ready``: the caller offers the one-click add on
+    # the strength of ``hacs_present`` alone, so an unknowable state lands on a
+    # useful screen instead of a false "not installed" claim.
+    return from_hacs or CardStatus(hacs_present=hacs is not None)
+
+
+def _status_from_hacs(hacs: object | None) -> CardStatus | None:
+    """Return what HACS says about the card, or None if it cannot answer."""
+    if not _hacs_is_ready(hacs):
+        return None
+    known = CardStatus(hacs_present=True, hacs_ready=True)
+    try:
+        # ``get_by_full_name`` lowercases its argument; ``is_registered`` does
+        # not, despite storing lowercased — so the latter reports False for a
+        # repository it holds. Use this one.
+        repository = hacs.repositories.get_by_full_name(CARD_FULL_NAME)  # type: ignore[attr-defined]
+        if repository is None:
+            return known
+        data = repository.data
+        if not data.installed:
+            return known  # added as a custom repo, but never downloaded
+        return CardStatus(
+            hacs_present=True,
+            hacs_ready=True,
+            installed=True,
+            installed_version=data.installed_version,
+            available_version=data.available_version,
+            detected_via=DETECTED_VIA_HACS,
+        )
+    except Exception:
+        _LOGGER.debug("Could not read the card's repository from HACS", exc_info=True)
+        return None
+
+
+def _hacs_is_ready(hacs: object | None) -> bool:
+    """Whether HACS is loaded far enough for its repository list to be trusted."""
+    if hacs is None:
+        return False
+    try:
+        return (
+            getattr(hacs, "stage", None) == _HACS_STAGE_RUNNING
+            and not hacs.system.disabled  # type: ignore[attr-defined]
+        )
+    except Exception:
+        _LOGGER.debug("Could not read HACS readiness", exc_info=True)
+        return False
+
+
+def _card_resource_url(hass: HomeAssistant) -> str | None:
+    """Return the card's registered dashboard-resource URL, if one exists.
+
+    Matches on the bundle filename so both the HACS path
+    (``/hacsfiles/...``) and a hand-registered ``/local/...`` copy are found.
+    """
+    try:
+        resources = getattr(hass.data.get(LOVELACE_DOMAIN), "resources", None)
+        items = resources.async_items() if resources is not None else ()
+        for item in items:
+            url = item.get("url") or ""
+            if CARD_JS_FILENAME in url:
+                return url
+    except Exception:
+        _LOGGER.debug("Could not read the dashboard resources", exc_info=True)
+    return None
+
+
+def _version_from_url(url: str) -> str | None:
+    """Lift the ``?v=`` stamp a manual install carries, when it has one."""
+    return url.partition(_VERSION_QUERY)[2] or None

--- a/custom_components/adaptive_cover_pro/companion_card.py
+++ b/custom_components/adaptive_cover_pro/companion_card.py
@@ -100,32 +100,37 @@ def async_get_card_status(hass: HomeAssistant) -> CardStatus:
     whole options flow down with it.
     """
     hacs = hass.data.get(HACS_DOMAIN)
-    from_hacs = _status_from_hacs(hacs)
+    hacs_present = hacs is not None
+    # Resolved once and reported verbatim, so "HACS is not ready" and "HACS was
+    # ready but the read failed" stay distinguishable — inferring readiness
+    # from a null result would conflate the two.
+    hacs_ready = _hacs_is_ready(hacs)
+
+    from_hacs = _status_from_hacs(hacs) if hacs_ready else None
     if from_hacs is not None and from_hacs.installed:
         return from_hacs
 
     resource_url = _card_resource_url(hass)
     if resource_url is not None:
         return CardStatus(
-            hacs_present=hacs is not None,
-            hacs_ready=from_hacs is not None,
+            hacs_present=hacs_present,
+            hacs_ready=hacs_ready,
             installed=True,
             installed_version=_version_from_url(resource_url),
             detected_via=DETECTED_VIA_RESOURCE,
         )
 
-    # ``from_hacs`` is None whenever HACS could not be asked at all — absent,
-    # still starting, disabled, or its internals moved. That is deliberately
-    # NOT reported as ``hacs_ready``: the caller offers the one-click add on
-    # the strength of ``hacs_present`` alone, so an unknowable state lands on a
-    # useful screen instead of a false "not installed" claim.
-    return from_hacs or CardStatus(hacs_present=hacs is not None)
+    # Nothing found. The caller offers the one-click add on the strength of
+    # ``hacs_present`` alone, so a HACS that could not be asked still lands on
+    # a useful screen instead of a false "not installed" claim.
+    return from_hacs or CardStatus(hacs_present=hacs_present, hacs_ready=hacs_ready)
 
 
 def _status_from_hacs(hacs: object | None) -> CardStatus | None:
-    """Return what HACS says about the card, or None if it cannot answer."""
-    if not _hacs_is_ready(hacs):
-        return None
+    """Return what HACS says about the card, or None if the read failed.
+
+    The caller has already confirmed HACS is ready.
+    """
     known = CardStatus(hacs_present=True, hacs_ready=True)
     try:
         # ``get_by_full_name`` lowercases its argument; ``is_registered`` does

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -5518,9 +5518,12 @@ class OptionsFlowHandler(OptionsFlow):
     ) -> FlowResult:
         """Confirm the card is present, with no version to report.
 
-        Reached when the card was found as a hand-registered dashboard
-        resource carrying no ``?v=`` stamp: it is installed, but which build
-        is anyone's guess.
+        Reached whenever the version is unknowable, which is not the same as
+        "found as a dashboard resource". A hand-registered resource with no
+        ``?v=`` stamp is the common case, but HACS also reports a null
+        ``installed_version`` for a repository tracked from a branch rather
+        than a release. The screen therefore states only what is certain: the
+        card is installed, and which build is anyone's guess.
         """
         if user_input is not None:
             return await self.async_step_init()
@@ -5540,15 +5543,18 @@ class OptionsFlowHandler(OptionsFlow):
 
         ``status`` is threaded from the router so the render path resolves it
         once; HA passes only ``user_input``, so the submit path never needs it.
+        Reached without one, re-enter through the router rather than rendering
+        a screen whose version placeholder would come out empty.
         """
         if user_input is not None:
             return await self.async_step_init()
-        status = status or async_get_card_status(self.hass)
+        if status is None:
+            return await self.async_step_card()
         return self.async_show_form(
             step_id="card_installed_version",
             data_schema=vol.Schema({}),
             description_placeholders={
-                "installed_version": status.installed_version or "",
+                "installed_version": status.installed_version,
                 "learn_more": CARD_WIKI_URL,
             },
         )
@@ -5562,13 +5568,14 @@ class OptionsFlowHandler(OptionsFlow):
         """Report that a newer card version is waiting in HACS."""
         if user_input is not None:
             return await self.async_step_init()
-        status = status or async_get_card_status(self.hass)
+        if status is None:
+            return await self.async_step_card()
         return self.async_show_form(
             step_id="card_installed_update",
             data_schema=vol.Schema({}),
             description_placeholders={
-                "installed_version": status.installed_version or "",
-                "available_version": status.available_version or "",
+                "installed_version": status.installed_version,
+                "available_version": status.available_version,
                 "learn_more": CARD_WIKI_URL,
             },
         )

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -269,6 +269,7 @@ from .companion_card import (
     CARD_DOWNLOAD_URL,
     CARD_WIKI_URL,
     HACS_DOWNLOAD_URL,
+    CardStatus,
     async_get_card_status,
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
@@ -5485,11 +5486,12 @@ class OptionsFlowHandler(OptionsFlow):
     ) -> FlowResult:
         """Route to the companion-card screen this install needs (issue #1168).
 
-        Renders nothing itself. Which of the three leaves applies depends on
-        whether the card is already here and whether HACS is around to add it,
-        and each leaf owns its own translation block — so all the prose stays
-        in ``translations/`` and gets translated the normal way, rather than
-        being assembled in Python and shipped English-only.
+        Renders nothing itself. Which leaf applies depends on whether the card
+        is already here, whether its version is knowable, and whether HACS is
+        around to add it. Every leaf owns its own translation block, so all the
+        prose stays in ``translations/`` and gets translated the normal way —
+        nothing user-visible is assembled from f-strings here, which would ship
+        an English sentence inside an otherwise German or French screen.
 
         HACS present but not yet ready lands on ``card_add`` too: the add link
         is harmless when the repository is already registered (it just opens
@@ -5497,39 +5499,76 @@ class OptionsFlowHandler(OptionsFlow):
         screen rather than to a false "not installed".
         """
         status = async_get_card_status(self.hass)
-        if status.installed:
-            return await self.async_step_card_installed()
-        if status.hacs_present:
-            return await self.async_step_card_add()
-        return await self.async_step_card_manual()
-
-    async def async_step_card_installed(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Confirm the card is present, and report the version it is on."""
-        if user_input is not None:
-            return await self.async_step_init()
-        status = async_get_card_status(self.hass)
-        # A hand-registered resource with no ``?v=`` stamp leaves the version
-        # unknowable — collapse the line rather than rendering "None".
-        version_line = (
-            f"Version **{status.installed_version}**."
-            if status.installed_version
-            else ""
-        )
-        update_line = ""
+        if not status.installed:
+            if status.hacs_present:
+                return await self.async_step_card_add()
+            return await self.async_step_card_manual()
         if (
             status.installed_version
             and status.available_version
             and status.available_version != status.installed_version
         ):
-            update_line = f"⬆️ **{status.available_version}** is available in HACS."
+            return await self.async_step_card_installed_update(status=status)
+        if status.installed_version:
+            return await self.async_step_card_installed_version(status=status)
+        return await self.async_step_card_installed()
+
+    async def async_step_card_installed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the card is present, with no version to report.
+
+        Reached when the card was found as a hand-registered dashboard
+        resource carrying no ``?v=`` stamp: it is installed, but which build
+        is anyone's guess.
+        """
+        if user_input is not None:
+            return await self.async_step_init()
         return self.async_show_form(
             step_id="card_installed",
             data_schema=vol.Schema({}),
+            description_placeholders={"learn_more": CARD_WIKI_URL},
+        )
+
+    async def async_step_card_installed_version(
+        self,
+        user_input: dict[str, Any] | None = None,
+        *,
+        status: CardStatus | None = None,
+    ) -> FlowResult:
+        """Confirm the card is present and up to date, and name its version.
+
+        ``status`` is threaded from the router so the render path resolves it
+        once; HA passes only ``user_input``, so the submit path never needs it.
+        """
+        if user_input is not None:
+            return await self.async_step_init()
+        status = status or async_get_card_status(self.hass)
+        return self.async_show_form(
+            step_id="card_installed_version",
+            data_schema=vol.Schema({}),
             description_placeholders={
-                "version_line": version_line,
-                "update_line": update_line,
+                "installed_version": status.installed_version or "",
+                "learn_more": CARD_WIKI_URL,
+            },
+        )
+
+    async def async_step_card_installed_update(
+        self,
+        user_input: dict[str, Any] | None = None,
+        *,
+        status: CardStatus | None = None,
+    ) -> FlowResult:
+        """Report that a newer card version is waiting in HACS."""
+        if user_input is not None:
+            return await self.async_step_init()
+        status = status or async_get_card_status(self.hass)
+        return self.async_show_form(
+            step_id="card_installed_update",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "installed_version": status.installed_version or "",
+                "available_version": status.available_version or "",
                 "learn_more": CARD_WIKI_URL,
             },
         )

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -264,6 +264,13 @@ from .const import (
     GroupScene,
     TemplateCombineMode,
 )
+from .companion_card import (
+    CARD_ADD_URL,
+    CARD_DOWNLOAD_URL,
+    CARD_WIKI_URL,
+    HACS_DOWNLOAD_URL,
+    async_get_card_status,
+)
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
 from .managers.cover_command.state_store import TravelCalibration
@@ -5395,6 +5402,11 @@ class OptionsFlowHandler(OptionsFlow):
 
         # ── Admin ────────────────────────────────────────────────────
         keys.append("sync")  # Multi-cover management
+        # Companion Lovelace card status, and a one-click add when it is
+        # missing (issue #1168). Offered unconditionally: when the card IS
+        # installed the screen is where a user reads back which version they
+        # are on, so a row that disappeared on success would take that with it.
+        keys.append("card")
         # "troubleshoot" is a read-only diagnostics surface (issue #970) — it
         # sits with the other read-only/diagnostic entries (summary, debug) and
         # is offered on the cover menu ONLY (never the profile or group menus).
@@ -5466,6 +5478,91 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="troubleshoot",
             menu_options=menu_options,
             description_placeholders={"report": result.report},
+        )
+
+    async def async_step_card(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Route to the companion-card screen this install needs (issue #1168).
+
+        Renders nothing itself. Which of the three leaves applies depends on
+        whether the card is already here and whether HACS is around to add it,
+        and each leaf owns its own translation block — so all the prose stays
+        in ``translations/`` and gets translated the normal way, rather than
+        being assembled in Python and shipped English-only.
+
+        HACS present but not yet ready lands on ``card_add`` too: the add link
+        is harmless when the repository is already registered (it just opens
+        the repository's page), so an unknowable state degrades to a useful
+        screen rather than to a false "not installed".
+        """
+        status = async_get_card_status(self.hass)
+        if status.installed:
+            return await self.async_step_card_installed()
+        if status.hacs_present:
+            return await self.async_step_card_add()
+        return await self.async_step_card_manual()
+
+    async def async_step_card_installed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the card is present, and report the version it is on."""
+        if user_input is not None:
+            return await self.async_step_init()
+        status = async_get_card_status(self.hass)
+        # A hand-registered resource with no ``?v=`` stamp leaves the version
+        # unknowable — collapse the line rather than rendering "None".
+        version_line = (
+            f"Version **{status.installed_version}**."
+            if status.installed_version
+            else ""
+        )
+        update_line = ""
+        if (
+            status.installed_version
+            and status.available_version
+            and status.available_version != status.installed_version
+        ):
+            update_line = f"⬆️ **{status.available_version}** is available in HACS."
+        return self.async_show_form(
+            step_id="card_installed",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "version_line": version_line,
+                "update_line": update_line,
+                "learn_more": CARD_WIKI_URL,
+            },
+        )
+
+    async def async_step_card_add(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Offer the one-click HACS add for the companion card."""
+        if user_input is not None:
+            return await self.async_step_init()
+        return self.async_show_form(
+            step_id="card_add",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "install_url": CARD_ADD_URL,
+                "learn_more": CARD_WIKI_URL,
+            },
+        )
+
+    async def async_step_card_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Explain the manual route — no HACS on this system to hand off to."""
+        if user_input is not None:
+            return await self.async_step_init()
+        return self.async_show_form(
+            step_id="card_manual",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "hacs_url": HACS_DOWNLOAD_URL,
+                "download_url": CARD_DOWNLOAD_URL,
+                "learn_more": CARD_WIKI_URL,
+            },
         )
 
     async def async_step_cover_entities(self, user_input: dict[str, Any] | None = None):

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -5547,7 +5547,9 @@ class OptionsFlowHandler(OptionsFlow):
 
         Deliberately does NOT say "up to date": this leaf is reached whenever
         ``available_version`` is falsy *or* equal to the installed one, and an
-        unknown available version is not evidence of being current.
+        unknown available version is not evidence of being current. Like
+        ``card_installed`` it must also not mention HACS, being equally
+        reachable on a system that has none.
 
         ``status`` is threaded from the router so the render path resolves it
         once; HA passes only ``user_input``, so the submit path never needs it.

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -5522,8 +5522,12 @@ class OptionsFlowHandler(OptionsFlow):
         "found as a dashboard resource". A hand-registered resource with no
         ``?v=`` stamp is the common case, but HACS also reports a null
         ``installed_version`` for a repository tracked from a branch rather
-        than a release. The screen therefore states only what is certain: the
-        card is installed, and which build is anyone's guess.
+        than a release.
+
+        The screen therefore claims exactly two things, both of which the
+        router established: the card is installed, and its version is unknown.
+        In particular it must not mention HACS — this leaf is reachable with
+        HACS absent, where ``card_manual`` is busy saying the opposite.
         """
         if user_input is not None:
             return await self.async_step_init()
@@ -5539,7 +5543,11 @@ class OptionsFlowHandler(OptionsFlow):
         *,
         status: CardStatus | None = None,
     ) -> FlowResult:
-        """Confirm the card is present and up to date, and name its version.
+        """Confirm the card is present and name the version it is on.
+
+        Deliberately does NOT say "up to date": this leaf is reached whenever
+        ``available_version`` is falsy *or* equal to the installed one, and an
+        unknown available version is not evidence of being current.
 
         ``status`` is threaded from the router so the render path resolves it
         once; HA passes only ``user_input``, so the submit path never needs it.

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1170,7 +1170,7 @@
       },
       "card_add": {
         "title": "Dashboard-Karte",
-        "description": "Die Begleit-**Adaptive Cover Pro Card** wandelt die Sensoren dieser Integration in ein Dashboard um, das du auf einen Blick lesen kannst — Sonnen- und Fenstergeometrie, die Entscheidungsspur und aktuelle Beschattungspositionen mit Inline-Steuerelementen.\n\nSie ist auf diesem System nicht installiert.\n\n➕ [Karte zu HACS hinzufügen]({install_url})\n\nHACS öffnet die Seite der Karte und lässt dich das Repository zuvor bestätigen, falls es noch nicht bekannt ist. Lade sie dort herunter und aktualisiere anschließend den Browser — die Karten erscheinen dann in der Kartenauswahl unter **Adaptive Cover Pro**.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten."
+        "description": "Die Begleit-**Adaptive Cover Pro Card** wandelt die Sensoren dieser Integration in ein Dashboard um, das du auf einen Blick lesen kannst — Sonnen- und Fenstergeometrie, die Entscheidungsspur und aktuelle Beschattungspositionen mit Inline-Steuerelementen.\n\nSie ist auf diesem System nicht installiert.\n\n➕ [Karte zu HACS hinzufügen]({install_url})\n\nHACS öffnet die Seite der Karte und bittet dich zunächst, das Repository zu bestätigen, falls es noch nicht bekannt ist. Lade sie dort herunter und aktualisiere anschließend den Browser — die Karten erscheinen dann in der Kartenauswahl unter **Adaptive Cover Pro**.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten."
       },
       "card_manual": {
         "title": "Dashboard-Karte",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1170,7 +1170,7 @@
       },
       "card_add": {
         "title": "Dashboard-Karte",
-        "description": "Die Begleit-**Adaptive Cover Pro Card** wandelt die Sensoren dieser Integration in ein Dashboard um, das du auf einen Blick lesen kannst — Sonnen- und Fenstergeometrie, die Entscheidungsspur und aktuelle Beschattungspositionen mit Inline-Steuerelementen.\n\nSie ist auf diesem System nicht installiert.\n\n➕ [Karte zu HACS hinzufügen]({install_url})\n\nHACS bittet dich, das Hinzufügen des Repositorys zu bestätigen, und bietet es dann zum Download an. Aktualisiere danach den Browser — die Karten erscheinen dann in der Kartenauswahl unter **Adaptive Cover Pro**.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten."
+        "description": "Die Begleit-**Adaptive Cover Pro Card** wandelt die Sensoren dieser Integration in ein Dashboard um, das du auf einen Blick lesen kannst — Sonnen- und Fenstergeometrie, die Entscheidungsspur und aktuelle Beschattungspositionen mit Inline-Steuerelementen.\n\nSie ist auf diesem System nicht installiert.\n\n➕ [Karte zu HACS hinzufügen]({install_url})\n\nHACS öffnet die Seite der Karte und lässt dich das Repository zuvor bestätigen, falls es noch nicht bekannt ist. Lade sie dort herunter und aktualisiere anschließend den Browser — die Karten erscheinen dann in der Kartenauswahl unter **Adaptive Cover Pro**.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten."
       },
       "card_manual": {
         "title": "Dashboard-Karte",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -338,7 +338,8 @@
           "change_cover_type": "🔁 Beschattungstyp ändern",
           "calibration": "📐 Kalibrierung",
           "queue_settings": "🚦 Warteschlangen-Einstellungen",
-          "queue_overview": "🚦 Warteschlangen-Übersicht"
+          "queue_overview": "🚦 Warteschlangen-Übersicht",
+          "card": "🖼️ Dashboard-Karte"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1162,6 +1163,18 @@
       "queue_overview": {
         "title": "Warteschlangen-Übersicht",
         "description": "{overview}"
+      },
+      "card_installed": {
+        "title": "Dashboard-Karte",
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert. {version_line}\n\n{update_line}\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+      },
+      "card_add": {
+        "title": "Dashboard-Karte",
+        "description": "Die Begleit-**Adaptive Cover Pro Card** wandelt die Sensoren dieser Integration in ein Dashboard um, das du auf einen Blick lesen kannst — Sonnen- und Fenstergeometrie, die Entscheidungsspur und aktuelle Beschattungspositionen mit Inline-Steuerelementen.\n\nSie ist auf diesem System nicht installiert.\n\n➕ [Karte zu HACS hinzufügen]({install_url})\n\nHACS bittet dich, das Hinzufügen des Repositorys zu bestätigen, und bietet es dann zum Download an. Aktualisiere danach den Browser — die Karten erscheinen dann in der Kartenauswahl unter **Adaptive Cover Pro**.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten."
+      },
+      "card_manual": {
+        "title": "Dashboard-Karte",
+        "description": "Die Begleit-**Adaptive Cover Pro Card** ist nicht installiert, und HACS wurde auf diesem System nicht gefunden.\n\nInstalliere [HACS]({hacs_url}) und öffne diese Seite erneut für ein One-Click-Add — das ist der empfehlenswerte Weg, da HACS auch Updates verwaltet.\n\nUm es stattdessen von Hand zu tun: [lade die Karte herunter]({download_url}), platziere `adaptive-cover-pro-card.js` in `www/community/adaptive-cover-pro-card/`, und registriere es dann unter **Einstellungen → Dashboards → ⋮ → Ressourcen** als JavaScript-Modul.\n\nSiehe [Dashboard-Karten]({learn_more}) für die vollständigen Anweisungen."
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1166,7 +1166,7 @@
       },
       "card_installed": {
         "title": "Dashboard-Karte",
-        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert. Die Version ist nicht verfügbar, da die Karte als Dashboard-Ressource erkannt wurde.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, aber die installierte Version konnte nicht bestimmt werden. Öffne HACS, um sie zu überprüfen.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
       },
       "card_add": {
         "title": "Dashboard-Karte",
@@ -1182,7 +1182,7 @@
       },
       "card_installed_update": {
         "title": "Dashboard-Karte",
-        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, Version **{installed_version}**.\n\n⬆️ Version **{available_version}** ist verfügbar. Öffne HACS zum Download.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach dem Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, Version **{installed_version}**.\n\n⬆️ Version **{available_version}** ist verfügbar. Öffne HACS zum Download.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach dem Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1166,7 +1166,7 @@
       },
       "card_installed": {
         "title": "Dashboard-Karte",
-        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, aber die installierte Version konnte nicht bestimmt werden. Öffne HACS, um sie zu überprüfen.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, aber die installierte Version konnte nicht bestimmt werden.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
       },
       "card_add": {
         "title": "Dashboard-Karte",
@@ -1178,7 +1178,7 @@
       },
       "card_installed_version": {
         "title": "Dashboard-Karte",
-        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert und auf dem neuesten Stand, Version **{installed_version}**.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, Version **{installed_version}**.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
       },
       "card_installed_update": {
         "title": "Dashboard-Karte",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1166,7 +1166,7 @@
       },
       "card_installed": {
         "title": "Dashboard-Karte",
-        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert. {version_line}\n\n{update_line}\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert. Die Version ist nicht verfügbar, da die Karte als Dashboard-Ressource erkannt wurde.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
       },
       "card_add": {
         "title": "Dashboard-Karte",
@@ -1175,6 +1175,14 @@
       "card_manual": {
         "title": "Dashboard-Karte",
         "description": "Die Begleit-**Adaptive Cover Pro Card** ist nicht installiert, und HACS wurde auf diesem System nicht gefunden.\n\nInstalliere [HACS]({hacs_url}) und öffne diese Seite erneut für ein One-Click-Add — das ist der empfehlenswerte Weg, da HACS auch Updates verwaltet.\n\nUm es stattdessen von Hand zu tun: [lade die Karte herunter]({download_url}), platziere `adaptive-cover-pro-card.js` in `www/community/adaptive-cover-pro-card/`, und registriere es dann unter **Einstellungen → Dashboards → ⋮ → Ressourcen** als JavaScript-Modul.\n\nSiehe [Dashboard-Karten]({learn_more}) für die vollständigen Anweisungen."
+      },
+      "card_installed_version": {
+        "title": "Dashboard-Karte",
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert und auf dem neuesten Stand, Version **{installed_version}**.\n\nDie Karten lesen die Entitäten dieser Integration direkt ein, daher gibt es hier nichts zu konfigurieren. Siehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach einem Karten-Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
+      },
+      "card_installed_update": {
+        "title": "Dashboard-Karte",
+        "description": "✅ Die Begleit-**Adaptive Cover Pro Card** ist installiert, Version **{installed_version}**.\n\n⬆️ Version **{available_version}** ist verfügbar. Öffne HACS zum Download.\n\nSiehe [Dashboard-Karten]({learn_more}) für eine Übersicht der einzelnen Karten und wie sie zu einem Dashboard hinzugefügt werden.\n\nNach dem Update führe die Aktion `lovelace.reload_resources` aus und lade den Browser vollständig neu — Home Assistant cached Dashboard-Module so stark, dass ein normales Reload die alte Version weiter bereitstellt."
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -345,11 +345,11 @@
       },
       "card_installed": {
         "title": "Dashboard Card",
-        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, but which version could not be determined. Open HACS to check it.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, but the version could not be determined.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
       },
       "card_installed_version": {
         "title": "Dashboard Card",
-        "description": "✅ The companion **Adaptive Cover Pro Card** is installed and up to date, on version **{installed_version}**.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, on version **{installed_version}**.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
       },
       "card_installed_update": {
         "title": "Dashboard Card",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -327,6 +327,7 @@
           "summary": "📋 Configuration Summary",
           "troubleshoot": "🩺 Troubleshoot",
           "sync": "🔄 Copy to Other Covers",
+          "card": "🖼️ Dashboard Card",
           "debug": "🔍 Debug & Diagnostics",
           "done": "✅ Save & Close",
           "light_cloud": "☁️ Weather, Light & Cloud",
@@ -341,6 +342,18 @@
           "queue_settings": "🚦 Queue Settings",
           "queue_overview": "🚦 Queue Overview"
         }
+      },
+      "card_installed": {
+        "title": "Dashboard Card",
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed. {version_line}\n\n{update_line}\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+      },
+      "card_add": {
+        "title": "Dashboard Card",
+        "description": "The companion **Adaptive Cover Pro Card** turns this integration's sensors into a dashboard you can read at a glance — sun and window geometry, the decision trace, and live cover positions with inline controls.\n\nIt is not installed on this system.\n\n➕ [Add the card to HACS]({install_url})\n\nHACS will ask you to confirm adding the repository, then offer it for download. Refresh the browser afterwards and the cards appear in the card picker under **Adaptive Cover Pro**.\n\nSee [Dashboard Cards]({learn_more}) for what each card shows."
+      },
+      "card_manual": {
+        "title": "Dashboard Card",
+        "description": "The companion **Adaptive Cover Pro Card** is not installed, and HACS was not found on this system.\n\nInstall [HACS]({hacs_url}) and reopen this page for a one-click add — that is the route worth taking, because HACS also handles upgrades.\n\nTo do it by hand instead: [download the card]({download_url}), place `adaptive-cover-pro-card.js` in `www/community/adaptive-cover-pro-card/`, then register it under **Settings → Dashboards → ⋮ → Resources** as a JavaScript module.\n\nSee [Dashboard Cards]({learn_more}) for the full instructions."
       },
       "pipeline_priorities": {
         "title": "Handler Priorities",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -345,7 +345,15 @@
       },
       "card_installed": {
         "title": "Dashboard Card",
-        "description": "✅ The companion **Adaptive Cover Pro Card** is installed. {version_line}\n\n{update_line}\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed. It was found as a dashboard resource, so its version is not reported here.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+      },
+      "card_installed_version": {
+        "title": "Dashboard Card",
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed and up to date, on version **{installed_version}**.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+      },
+      "card_installed_update": {
+        "title": "Dashboard Card",
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, on version **{installed_version}**.\n\n⬆️ Version **{available_version}** is available. Open HACS to download it.\n\nSee [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter the upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
       },
       "card_add": {
         "title": "Dashboard Card",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -345,7 +345,7 @@
       },
       "card_installed": {
         "title": "Dashboard Card",
-        "description": "✅ The companion **Adaptive Cover Pro Card** is installed. It was found as a dashboard resource, so its version is not reported here.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, but which version could not be determined. Open HACS to check it.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter a card upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
       },
       "card_installed_version": {
         "title": "Dashboard Card",
@@ -353,7 +353,7 @@
       },
       "card_installed_update": {
         "title": "Dashboard Card",
-        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, on version **{installed_version}**.\n\n⬆️ Version **{available_version}** is available. Open HACS to download it.\n\nSee [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter the upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
+        "description": "✅ The companion **Adaptive Cover Pro Card** is installed, on version **{installed_version}**.\n\n⬆️ Version **{available_version}** is available. Open HACS to download it.\n\nThe cards read this integration's entities directly, so there is nothing to configure here. See [Dashboard Cards]({learn_more}) for what each card shows and how to add one to a dashboard.\n\nAfter the upgrade, run the `lovelace.reload_resources` action and hard-refresh the browser — Home Assistant caches dashboard modules hard enough that a plain reload keeps serving the old one."
       },
       "card_add": {
         "title": "Dashboard Card",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -357,7 +357,7 @@
       },
       "card_add": {
         "title": "Dashboard Card",
-        "description": "The companion **Adaptive Cover Pro Card** turns this integration's sensors into a dashboard you can read at a glance — sun and window geometry, the decision trace, and live cover positions with inline controls.\n\nIt is not installed on this system.\n\n➕ [Add the card to HACS]({install_url})\n\nHACS will ask you to confirm adding the repository, then offer it for download. Refresh the browser afterwards and the cards appear in the card picker under **Adaptive Cover Pro**.\n\nSee [Dashboard Cards]({learn_more}) for what each card shows."
+        "description": "The companion **Adaptive Cover Pro Card** turns this integration's sensors into a dashboard you can read at a glance — sun and window geometry, the decision trace, and live cover positions with inline controls.\n\nIt is not installed on this system.\n\n➕ [Add the card to HACS]({install_url})\n\nHACS opens the card's page, asking you to confirm the repository first if it is not already tracked. Download it there, then refresh the browser and the cards appear in the card picker under **Adaptive Cover Pro**.\n\nSee [Dashboard Cards]({learn_more}) for what each card shows."
       },
       "card_manual": {
         "title": "Dashboard Card",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1166,7 +1166,7 @@
       },
       "card_installed": {
         "title": "Carte de tableau de bord",
-        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, mais impossible de déterminer sa version. Ouvrez HACS pour la vérifier.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, mais impossible de déterminer sa version.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
       },
       "card_add": {
         "title": "Carte de tableau de bord",
@@ -1178,7 +1178,7 @@
       },
       "card_installed_version": {
         "title": "Carte de tableau de bord",
-        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée et à jour, version **{installed_version}**.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, version **{installed_version}**.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
       },
       "card_installed_update": {
         "title": "Carte de tableau de bord",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -338,7 +338,8 @@
           "change_cover_type": "🔁 Modifier le type de store",
           "calibration": "📐 Étalonnage",
           "queue_settings": "🚦 Paramètres de la file d'attente",
-          "queue_overview": "🚦 Aperçu de la file d'attente"
+          "queue_overview": "🚦 Aperçu de la file d'attente",
+          "card": "🖼️ Carte de tableau de bord"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1162,6 +1163,18 @@
       "queue_overview": {
         "title": "Aperçu de la file d'attente",
         "description": "{overview}"
+      },
+      "card_installed": {
+        "title": "Carte de tableau de bord",
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée. {version_line}\n\n{update_line}\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
+      },
+      "card_add": {
+        "title": "Carte de tableau de bord",
+        "description": "La carte de tableau de bord compagnon **Adaptive Cover Pro Card** transforme les capteurs de cette intégration en un tableau de bord que vous pouvez consulter d'un coup d'œil — géométrie du soleil et de la fenêtre, trace de décision, et positions de protection actualisées en direct avec des contrôles intégrés.\n\nElle n'est pas installée sur ce système.\n\n➕ [Ajouter la carte à HACS]({install_url})\n\nHACS vous demandera de confirmer l'ajout du dépôt, puis vous proposera de le télécharger. Actualisez le navigateur ensuite et les cartes apparaissent dans le sélecteur de cartes sous **Adaptive Cover Pro**.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche."
+      },
+      "card_manual": {
+        "title": "Carte de tableau de bord",
+        "description": "La carte de tableau de bord compagnon **Adaptive Cover Pro Card** n'est pas installée, et HACS n'a pas été trouvé sur ce système.\n\nInstallez [HACS]({hacs_url}) et rouvrez cette page pour un ajout en un clic — c'est la voie à suivre, car HACS gère également les mises à jour.\n\nPour le faire manuellement à la place : [téléchargez la carte]({download_url}), placez `adaptive-cover-pro-card.js` dans `www/community/adaptive-cover-pro-card/`, puis enregistrez-la sous **Paramètres → Tableaux de bord → ⋮ → Ressources** en tant que module JavaScript.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour les instructions complètes."
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1166,7 +1166,7 @@
       },
       "card_installed": {
         "title": "Carte de tableau de bord",
-        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée. {version_line}\n\n{update_line}\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée. La version n'est pas disponible car la carte a été détectée en tant que ressource de tableau de bord.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
       },
       "card_add": {
         "title": "Carte de tableau de bord",
@@ -1175,6 +1175,14 @@
       "card_manual": {
         "title": "Carte de tableau de bord",
         "description": "La carte de tableau de bord compagnon **Adaptive Cover Pro Card** n'est pas installée, et HACS n'a pas été trouvé sur ce système.\n\nInstallez [HACS]({hacs_url}) et rouvrez cette page pour un ajout en un clic — c'est la voie à suivre, car HACS gère également les mises à jour.\n\nPour le faire manuellement à la place : [téléchargez la carte]({download_url}), placez `adaptive-cover-pro-card.js` dans `www/community/adaptive-cover-pro-card/`, puis enregistrez-la sous **Paramètres → Tableaux de bord → ⋮ → Ressources** en tant que module JavaScript.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour les instructions complètes."
+      },
+      "card_installed_version": {
+        "title": "Carte de tableau de bord",
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée et à jour, version **{installed_version}**.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
+      },
+      "card_installed_update": {
+        "title": "Carte de tableau de bord",
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, version **{installed_version}**.\n\n⬆️ La version **{available_version}** est disponible. Ouvrez HACS pour la télécharger.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès la mise à jour, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1166,7 +1166,7 @@
       },
       "card_installed": {
         "title": "Carte de tableau de bord",
-        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée. La version n'est pas disponible car la carte a été détectée en tant que ressource de tableau de bord.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, mais impossible de déterminer sa version. Ouvrez HACS pour la vérifier.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
       },
       "card_add": {
         "title": "Carte de tableau de bord",
@@ -1178,11 +1178,11 @@
       },
       "card_installed_version": {
         "title": "Carte de tableau de bord",
-        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée et à jour, version **{installed_version}**.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée et à jour, version **{installed_version}**.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès une mise à jour de la carte, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
       },
       "card_installed_update": {
         "title": "Carte de tableau de bord",
-        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, version **{installed_version}**.\n\n⬆️ La version **{available_version}** est disponible. Ouvrez HACS pour la télécharger.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès la mise à jour, exécutez l'action `lovelace.reload_resources` et actualisez le navigateur en forçant le cache — Home Assistant met en cache les modules de tableau de bord suffisamment fortement qu'un simple rechargement continue à servir l'ancien."
+        "description": "✅ La carte de tableau de bord compagnon **Adaptive Cover Pro Card** est installée, version **{installed_version}**.\n\n⬆️ La version **{available_version}** est disponible. Ouvrez HACS pour la télécharger.\n\nLes cartes lisent directement les entités de cette intégration, il n'y a donc rien à configurer ici. Consultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche et comment en ajouter une à un tableau de bord.\n\nAprès la mise à jour, exécutez l'action `lovelace.reload_resources` et forcez l'actualisation du navigateur — Home Assistant met en cache les modules de tableau de bord de façon si agressive qu'un simple rechargement continue de servir l'ancien."
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1170,7 +1170,7 @@
       },
       "card_add": {
         "title": "Carte de tableau de bord",
-        "description": "La carte de tableau de bord compagnon **Adaptive Cover Pro Card** transforme les capteurs de cette intégration en un tableau de bord que vous pouvez consulter d'un coup d'œil — géométrie du soleil et de la fenêtre, trace de décision, et positions de protection actualisées en direct avec des contrôles intégrés.\n\nElle n'est pas installée sur ce système.\n\n➕ [Ajouter la carte à HACS]({install_url})\n\nHACS vous demandera de confirmer l'ajout du dépôt, puis vous proposera de le télécharger. Actualisez le navigateur ensuite et les cartes apparaissent dans le sélecteur de cartes sous **Adaptive Cover Pro**.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche."
+        "description": "La carte de tableau de bord compagnon **Adaptive Cover Pro Card** transforme les capteurs de cette intégration en un tableau de bord que vous pouvez consulter d'un coup d'œil — géométrie du soleil et de la fenêtre, trace de décision, et positions de protection actualisées en direct avec des contrôles intégrés.\n\nElle n'est pas installée sur ce système.\n\n➕ [Ajouter la carte à HACS]({install_url})\n\nHACS ouvre la page de la carte, en vous demandant d'abord de confirmer le dépôt s'il n'est pas déjà suivi. Téléchargez-la depuis cette page, puis actualisez le navigateur et les cartes apparaissent dans le sélecteur de cartes sous **Adaptive Cover Pro**.\n\nConsultez [Cartes de tableau de bord]({learn_more}) pour voir ce que chaque carte affiche."
       },
       "card_manual": {
         "title": "Carte de tableau de bord",

--- a/tests/test_config_flow_companion_card.py
+++ b/tests/test_config_flow_companion_card.py
@@ -8,9 +8,12 @@ Three concerns:
   internals, and none of it may break the options flow.
 - ``card`` is offered in the cover options menu and NEVER in the profile,
   group, or queue menus.
-- ``async_step_card`` routes to one of three leaf screens, each of which
-  receives its URLs through ``description_placeholders`` (hassfest forbids
-  literal URLs in the translation strings) and returns to ``init`` on submit.
+- ``async_step_card`` routes to one of five leaf screens, each of which owns a
+  full translation block and receives only bare data through
+  ``description_placeholders`` — URLs (hassfest forbids literal URLs in the
+  translation strings) and bare version numbers, never an assembled English
+  sentence that would render inside a German or French body. Every leaf
+  returns to ``init`` on submit.
 """
 
 from __future__ import annotations
@@ -401,11 +404,32 @@ def test_card_menu_entry_has_an_en_json_label() -> None:
 @pytest.mark.parametrize(
     ("status", "expected_step"),
     [
-        (CardStatus(installed=True, detected_via="hacs"), "card_installed"),
+        (CardStatus(installed=True, detected_via="resource"), "card_installed"),
+        (
+            CardStatus(
+                installed=True, installed_version="v2.17.0", detected_via="hacs"
+            ),
+            "card_installed_version",
+        ),
+        (
+            CardStatus(
+                installed=True,
+                installed_version="v2.16.0",
+                available_version="v2.17.0",
+                detected_via="hacs",
+            ),
+            "card_installed_update",
+        ),
         (CardStatus(hacs_present=True, hacs_ready=True), "card_add"),
         (CardStatus(), "card_manual"),
     ],
-    ids=["installed", "hacs-no-card", "no-hacs"],
+    ids=[
+        "installed-no-version",
+        "installed",
+        "update-available",
+        "hacs-no-card",
+        "no-hacs",
+    ],
 )
 async def test_card_routes_on_status(
     hass: HomeAssistant, status: CardStatus, expected_step: str
@@ -414,6 +438,22 @@ async def test_card_routes_on_status(
         result = await _cover_flow(hass).async_step_card()
     assert result["type"] == "form"
     assert result["step_id"] == expected_step
+
+
+async def test_matching_installed_and_available_is_not_an_update(
+    hass: HomeAssistant,
+) -> None:
+    status = CardStatus(
+        hacs_present=True,
+        hacs_ready=True,
+        installed=True,
+        installed_version="v2.17.0",
+        available_version="v2.17.0",
+        detected_via="hacs",
+    )
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["step_id"] == "card_installed_version"
 
 
 async def test_hacs_present_but_not_ready_offers_the_add_screen(
@@ -467,11 +507,10 @@ async def test_installed_screen_reports_the_version(hass: HomeAssistant) -> None
     )
     with patch(_CARD_STATUS_SEAM, return_value=status):
         result = await _cover_flow(hass).async_step_card()
-    assert "v2.17.0" in result["description_placeholders"]["version_line"]
-    assert result["description_placeholders"]["update_line"] == ""
+    assert result["description_placeholders"]["installed_version"] == "v2.17.0"
 
 
-async def test_installed_screen_flags_a_pending_update(hass: HomeAssistant) -> None:
+async def test_update_screen_names_both_versions(hass: HomeAssistant) -> None:
     status = CardStatus(
         hacs_present=True,
         hacs_ready=True,
@@ -482,41 +521,71 @@ async def test_installed_screen_flags_a_pending_update(hass: HomeAssistant) -> N
     )
     with patch(_CARD_STATUS_SEAM, return_value=status):
         result = await _cover_flow(hass).async_step_card()
-    assert "v2.17.0" in result["description_placeholders"]["update_line"]
+    placeholders = result["description_placeholders"]
+    assert placeholders["installed_version"] == "v2.16.0"
+    assert placeholders["available_version"] == "v2.17.0"
 
 
-async def test_installed_screen_without_a_known_version_is_blank_not_none(
+async def test_no_leaf_assembles_user_visible_prose_in_python(
     hass: HomeAssistant,
 ) -> None:
-    status = CardStatus(installed=True, detected_via="resource")
-    with patch(_CARD_STATUS_SEAM, return_value=status):
-        result = await _cover_flow(hass).async_step_card()
-    placeholders = result["description_placeholders"]
-    assert "None" not in placeholders["version_line"]
-    assert placeholders["update_line"] == ""
+    """Placeholders carry bare data, never English sentences.
+
+    A Python-built sentence would render untranslated inside an otherwise
+    German or French screen, which is the whole reason each state has its own
+    translation block instead of one block with a ``{version_line}`` hole.
+    """
+    statuses = [
+        CardStatus(installed=True, detected_via="resource"),
+        CardStatus(installed=True, installed_version="v2.17.0", detected_via="hacs"),
+        CardStatus(
+            installed=True,
+            installed_version="v2.16.0",
+            available_version="v2.17.0",
+            detected_via="hacs",
+        ),
+        CardStatus(hacs_present=True, hacs_ready=True),
+        CardStatus(),
+    ]
+    for status in statuses:
+        with patch(_CARD_STATUS_SEAM, return_value=status):
+            result = await _cover_flow(hass).async_step_card()
+        for name, value in result["description_placeholders"].items():
+            if name == "learn_more" or name.endswith("_url"):
+                continue
+            # A bare version or an empty string: no spaces, no markdown.
+            assert " " not in value, f"{result['step_id']}/{name} carries prose"
+            assert "*" not in value, f"{result['step_id']}/{name} carries markdown"
 
 
-@pytest.mark.parametrize(
-    "step_id", ["card_installed", "card_add", "card_manual"], ids=lambda s: s
-)
+_LEAF_STATUS = {
+    "card_installed": CardStatus(installed=True, detected_via="resource"),
+    "card_installed_version": CardStatus(
+        installed=True, installed_version="v2.17.0", detected_via="hacs"
+    ),
+    "card_installed_update": CardStatus(
+        installed=True,
+        installed_version="v2.16.0",
+        available_version="v2.17.0",
+        detected_via="hacs",
+    ),
+    "card_add": CardStatus(hacs_present=True, hacs_ready=True),
+    "card_manual": CardStatus(),
+}
+
+
+@pytest.mark.parametrize("step_id", sorted(_LEAF_STATUS), ids=lambda s: s)
 async def test_every_leaf_has_an_empty_schema_and_a_learn_more(
     hass: HomeAssistant, step_id: str
 ) -> None:
-    status = {
-        "card_installed": CardStatus(installed=True, detected_via="resource"),
-        "card_add": CardStatus(hacs_present=True, hacs_ready=True),
-        "card_manual": CardStatus(),
-    }[step_id]
-    with patch(_CARD_STATUS_SEAM, return_value=status):
+    with patch(_CARD_STATUS_SEAM, return_value=_LEAF_STATUS[step_id]):
         result = await _cover_flow(hass).async_step_card()
     assert result["step_id"] == step_id
     assert result["data_schema"]({}) == {}
     assert result["description_placeholders"]["learn_more"].startswith("https://")
 
 
-@pytest.mark.parametrize(
-    "step_id", ["card_installed", "card_add", "card_manual"], ids=lambda s: s
-)
+@pytest.mark.parametrize("step_id", sorted(_LEAF_STATUS), ids=lambda s: s)
 async def test_every_leaf_returns_to_the_menu_on_submit(
     hass: HomeAssistant, step_id: str
 ) -> None:
@@ -526,14 +595,26 @@ async def test_every_leaf_returns_to_the_menu_on_submit(
     assert result["step_id"] == "init"
 
 
+@pytest.mark.parametrize(
+    "step_id",
+    ["card_installed_version", "card_installed_update"],
+    ids=["version", "update"],
+)
+async def test_version_leaves_resolve_status_when_called_directly(
+    hass: HomeAssistant, step_id: str
+) -> None:
+    """HA can route to a leaf without the router threading ``status`` in."""
+    _install_hacs(hass, _hacs(repo=_repo(installed_version="v2.17.0")))
+    result = await getattr(_cover_flow(hass), f"async_step_{step_id}")()
+    assert result["description_placeholders"]["installed_version"] == "v2.17.0"
+
+
 # ---------------------------------------------------------------------------
 # Translation blocks
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "step_id", ["card_installed", "card_add", "card_manual"], ids=lambda s: s
-)
+@pytest.mark.parametrize("step_id", sorted(_LEAF_STATUS), ids=lambda s: s)
 def test_every_leaf_has_a_translation_block(step_id: str) -> None:
     block = _en_step(step_id)
     assert block["title"]
@@ -543,11 +624,16 @@ def test_every_leaf_has_a_translation_block(step_id: str) -> None:
 @pytest.mark.parametrize(
     ("step_id", "placeholders"),
     [
-        ("card_installed", {"version_line", "update_line", "learn_more"}),
+        ("card_installed", {"learn_more"}),
+        ("card_installed_version", {"installed_version", "learn_more"}),
+        (
+            "card_installed_update",
+            {"installed_version", "available_version", "learn_more"},
+        ),
         ("card_add", {"install_url", "learn_more"}),
         ("card_manual", {"hacs_url", "download_url", "learn_more"}),
     ],
-    ids=["installed", "add", "manual"],
+    ids=["installed", "version", "update", "add", "manual"],
 )
 def test_description_placeholders_match_the_translation(
     step_id: str, placeholders: set[str]

--- a/tests/test_config_flow_companion_card.py
+++ b/tests/test_config_flow_companion_card.py
@@ -376,9 +376,25 @@ def test_a_renamed_disabled_attribute_does_not_kill_the_hacs_rung(
     assert status.detected_via == "hacs"
 
 
-def test_hacs_without_a_system_object_is_not_ready(hass: HomeAssistant) -> None:
-    _install_hacs(hass, SimpleNamespace(stage="startup"))
-    assert async_get_card_status(hass).hacs_ready is False
+def test_hacs_without_a_system_object_is_still_ready_when_running(
+    hass: HomeAssistant,
+) -> None:
+    """Losing ``system`` entirely must not be read as "disabled".
+
+    The stage check is what decides; a missing or renamed ``system`` defaults
+    to not-disabled. Asserting False here instead would pass with the nested
+    getattr deleted, which is the opposite of a guard.
+    """
+    _install_hacs(
+        hass,
+        SimpleNamespace(
+            stage="running",
+            repositories=SimpleNamespace(get_by_full_name=lambda _n: _repo()),
+        ),
+    )
+    status = async_get_card_status(hass)
+    assert status.hacs_ready is True
+    assert status.detected_via == "hacs"
 
 
 def test_exploding_lovelace_resources_degrade(hass: HomeAssistant) -> None:
@@ -711,8 +727,8 @@ def test_installed_screens_never_mention_hacs(step_id: str, language: str) -> No
 # "mise à jour" (update) contains it.
 _CURRENCY_CLAIMS = {
     "en": ("up to date", "latest version", "is current"),
-    "de": ("auf dem neuesten Stand", "ist aktuell"),
-    "fr": ("est à jour", "sont à jour", "dernière version"),
+    "de": ("auf dem neuesten Stand", "ist aktuell", "neueste Version"),
+    "fr": ("est à jour", "sont à jour", "êtes à jour", "dernière version"),
 }
 
 

--- a/tests/test_config_flow_companion_card.py
+++ b/tests/test_config_flow_companion_card.py
@@ -560,6 +560,24 @@ async def test_update_screen_names_both_versions(hass: HomeAssistant) -> None:
     assert placeholders["available_version"] == "v2.17.0"
 
 
+_LEAF_STATUS = {
+    "card_installed": CardStatus(installed=True, detected_via="resource"),
+    "card_installed_version": CardStatus(
+        installed=True, installed_version="v2.17.0", detected_via="hacs"
+    ),
+    "card_installed_update": CardStatus(
+        installed=True,
+        installed_version="v2.16.0",
+        available_version="v2.17.0",
+        detected_via="hacs",
+    ),
+    "card_add": CardStatus(hacs_present=True, hacs_ready=True),
+    "card_manual": CardStatus(),
+}
+
+_MISSING = object()
+
+
 async def test_no_leaf_assembles_user_visible_prose_in_python(
     hass: HomeAssistant,
 ) -> None:
@@ -580,9 +598,12 @@ async def test_no_leaf_assembles_user_visible_prose_in_python(
         for name, value in result["description_placeholders"].items():
             if name == "learn_more" or name.endswith("_url"):
                 continue
-            assert value == getattr(status, name), (
+            # Sentinel rather than a bare getattr: a placeholder renamed to
+            # something CardStatus has no field for must fail as this
+            # assertion, not as an AttributeError raised before it.
+            assert value == getattr(status, name, _MISSING), (
                 f"{result['step_id']}/{name} is not the bare CardStatus field: "
-                f"{value!r} != {getattr(status, name)!r}"
+                f"{value!r} != {getattr(status, name, _MISSING)!r}"
             )
             checked += 1
     # Guard the guard: three data placeholders exist across the five leaves
@@ -593,20 +614,48 @@ async def test_no_leaf_assembles_user_visible_prose_in_python(
     ), f"expected 3 data placeholders across the leaves, saw {checked}"
 
 
-_LEAF_STATUS = {
-    "card_installed": CardStatus(installed=True, detected_via="resource"),
-    "card_installed_version": CardStatus(
-        installed=True, installed_version="v2.17.0", detected_via="hacs"
-    ),
-    "card_installed_update": CardStatus(
+@pytest.mark.parametrize(
+    "step_id",
+    ["card_installed", "card_installed_version"],
+    ids=["versionless", "version"],
+)
+@pytest.mark.parametrize("language", ["en", "de", "fr"], ids=lambda s: s)
+def test_installed_screens_never_mention_hacs(step_id: str, language: str) -> None:
+    """Both are reachable with HACS absent, where ``card_manual`` says so.
+
+    Telling a HACS-less install to "open HACS" is the same fault as claiming a
+    detection method the router never checked: the screen asserting more than
+    the state it was routed on.
+    """
+    path = _EN_JSON.parent / f"{language}.json"
+    block = json.loads(path.read_text(encoding="utf-8"))["options"]["step"][step_id]
+    assert "HACS" not in block["description"]
+
+
+def test_version_screen_does_not_claim_to_be_up_to_date() -> None:
+    """It is reached when ``available_version`` is unknown, not just equal.
+
+    ``async_step_card`` routes here on ``installed_version`` alone once the
+    update branch declines, so an install whose available version was never
+    reported would be told it is current on no evidence.
+    """
+    description = _en_step("card_installed_version")["description"]
+    assert "up to date" not in description
+
+
+async def test_unknown_available_version_is_not_reported_as_current(
+    hass: HomeAssistant,
+) -> None:
+    status = CardStatus(
         installed=True,
-        installed_version="v2.16.0",
-        available_version="v2.17.0",
-        detected_via="hacs",
-    ),
-    "card_add": CardStatus(hacs_present=True, hacs_ready=True),
-    "card_manual": CardStatus(),
-}
+        installed_version="2.10.0",
+        available_version=None,
+        detected_via="resource",
+    )
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["step_id"] == "card_installed_version"
+    assert result["description_placeholders"]["installed_version"] == "2.10.0"
 
 
 @pytest.mark.parametrize("step_id", sorted(_LEAF_STATUS), ids=lambda s: s)

--- a/tests/test_config_flow_companion_card.py
+++ b/tests/test_config_flow_companion_card.py
@@ -440,6 +440,40 @@ async def test_card_routes_on_status(
     assert result["step_id"] == expected_step
 
 
+async def test_hacs_install_without_a_version_does_not_claim_a_resource(
+    hass: HomeAssistant,
+) -> None:
+    """HACS reports a null ``installed_version`` for a branch-tracked repo.
+
+    That reaches the same versionless leaf a hand-registered resource does, so
+    the screen must not name a detection method the router never checked. It
+    asserts only what is certain: installed, version unknown.
+    """
+    status = CardStatus(
+        hacs_present=True,
+        hacs_ready=True,
+        installed=True,
+        installed_version=None,
+        available_version="v2.17.0",
+        detected_via="hacs",
+    )
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["step_id"] == "card_installed"
+    description = _en_step("card_installed")["description"]
+    assert "dashboard resource" not in description
+    assert "could not be determined" in description
+
+
+async def test_versionless_leaf_names_no_detection_method(hass: HomeAssistant) -> None:
+    """The same leaf serves a resource install and a versionless HACS install."""
+    for detected_via in ("resource", "hacs"):
+        status = CardStatus(installed=True, detected_via=detected_via)
+        with patch(_CARD_STATUS_SEAM, return_value=status):
+            result = await _cover_flow(hass).async_step_card()
+        assert result["step_id"] == "card_installed"
+
+
 async def test_matching_installed_and_available_is_not_an_update(
     hass: HomeAssistant,
 ) -> None:
@@ -529,33 +563,34 @@ async def test_update_screen_names_both_versions(hass: HomeAssistant) -> None:
 async def test_no_leaf_assembles_user_visible_prose_in_python(
     hass: HomeAssistant,
 ) -> None:
-    """Placeholders carry bare data, never English sentences.
+    """Every non-URL placeholder is a verbatim ``CardStatus`` field.
 
     A Python-built sentence would render untranslated inside an otherwise
     German or French screen, which is the whole reason each state has its own
     translation block instead of one block with a ``{version_line}`` hole.
+
+    Asserting equality with the source field rather than merely "contains no
+    space" is what keeps this from passing on ``⬆️v2.17.0`` or a single
+    English word.
     """
-    statuses = [
-        CardStatus(installed=True, detected_via="resource"),
-        CardStatus(installed=True, installed_version="v2.17.0", detected_via="hacs"),
-        CardStatus(
-            installed=True,
-            installed_version="v2.16.0",
-            available_version="v2.17.0",
-            detected_via="hacs",
-        ),
-        CardStatus(hacs_present=True, hacs_ready=True),
-        CardStatus(),
-    ]
-    for status in statuses:
+    checked = 0
+    for status in _LEAF_STATUS.values():
         with patch(_CARD_STATUS_SEAM, return_value=status):
             result = await _cover_flow(hass).async_step_card()
         for name, value in result["description_placeholders"].items():
             if name == "learn_more" or name.endswith("_url"):
                 continue
-            # A bare version or an empty string: no spaces, no markdown.
-            assert " " not in value, f"{result['step_id']}/{name} carries prose"
-            assert "*" not in value, f"{result['step_id']}/{name} carries markdown"
+            assert value == getattr(status, name), (
+                f"{result['step_id']}/{name} is not the bare CardStatus field: "
+                f"{value!r} != {getattr(status, name)!r}"
+            )
+            checked += 1
+    # Guard the guard: three data placeholders exist across the five leaves
+    # (installed_version twice, available_version once). A refactor that
+    # renames them must not silently turn this test into a no-op.
+    assert (
+        checked == 3
+    ), f"expected 3 data placeholders across the leaves, saw {checked}"
 
 
 _LEAF_STATUS = {
@@ -600,12 +635,17 @@ async def test_every_leaf_returns_to_the_menu_on_submit(
     ["card_installed_version", "card_installed_update"],
     ids=["version", "update"],
 )
-async def test_version_leaves_resolve_status_when_called_directly(
+async def test_version_leaves_reroute_when_reached_without_a_status(
     hass: HomeAssistant, step_id: str
 ) -> None:
-    """HA can route to a leaf without the router threading ``status`` in."""
+    """Reached with no ``status``, a version leaf re-enters through the router.
+
+    Rendering anyway would put an empty string in the version placeholder and
+    show "on version ****" to the user.
+    """
     _install_hacs(hass, _hacs(repo=_repo(installed_version="v2.17.0")))
     result = await getattr(_cover_flow(hass), f"async_step_{step_id}")()
+    assert result["step_id"] == "card_installed_version"
     assert result["description_placeholders"]["installed_version"] == "v2.17.0"
 
 

--- a/tests/test_config_flow_companion_card.py
+++ b/tests/test_config_flow_companion_card.py
@@ -142,6 +142,16 @@ def _en_step(step_id: str) -> dict:
     return json.loads(_EN_JSON.read_text(encoding="utf-8"))["options"]["step"][step_id]
 
 
+# Discovered, not hardcoded, so a language added via `acp-translate` is covered
+# by the prose guards below the day it lands rather than silently skipped.
+_LANGUAGES = sorted(p.stem for p in _EN_JSON.parent.glob("*.json"))
+
+
+def _step(language: str, step_id: str) -> dict:
+    path = _EN_JSON.parent / f"{language}.json"
+    return json.loads(path.read_text(encoding="utf-8"))["options"]["step"][step_id]
+
+
 # ---------------------------------------------------------------------------
 # Detection — companion_card.async_get_card_status
 # ---------------------------------------------------------------------------
@@ -241,6 +251,44 @@ def test_unrelated_resource_is_not_mistaken_for_the_card(hass: HomeAssistant) ->
     assert async_get_card_status(hass).installed is False
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"/hacsfiles/x/my-{CARD_JS_FILENAME}",
+        f"/hacsfiles/x/{CARD_JS_FILENAME}.map",
+        f"/hacsfiles/x/{CARD_JS_FILENAME}.bak",
+    ],
+    ids=["longer-name", "sourcemap", "backup"],
+)
+def test_a_url_merely_containing_the_filename_is_not_the_card(
+    hass: HomeAssistant, url: str
+) -> None:
+    """Matching is on the final path segment, not a substring of the whole URL."""
+    _install_resource(hass, url)
+    assert async_get_card_status(hass).installed is False
+
+
+def test_version_is_parsed_as_a_query_parameter_not_a_string_split(
+    hass: HomeAssistant,
+) -> None:
+    """A second parameter must not end up glued to the version."""
+    _install_resource(hass, f"/hacsfiles/x/{CARD_JS_FILENAME}?v=1.2&cachebust=9")
+    assert async_get_card_status(hass).installed_version == "1.2"
+
+
+def test_version_survives_a_parameter_ordered_before_it(hass: HomeAssistant) -> None:
+    _install_resource(hass, f"/hacsfiles/x/{CARD_JS_FILENAME}?cachebust=9&v=1.2")
+    assert async_get_card_status(hass).installed_version == "1.2"
+
+
+def test_hacstag_is_not_read_as_a_version(hass: HomeAssistant) -> None:
+    """HACS stamps a build tag, not a version. Reporting it would mislead."""
+    _install_resource(hass, f"/hacsfiles/x/{CARD_JS_FILENAME}?hacstag=1217318442217")
+    status = async_get_card_status(hass)
+    assert status.installed is True
+    assert status.installed_version is None
+
+
 def test_hacs_wins_over_resource_when_both_present(hass: HomeAssistant) -> None:
     _install_hacs(hass, _hacs(repo=_repo(installed_version="v2.17.0")))
     _install_resource(hass, f"/hacsfiles/x/{CARD_JS_FILENAME}?v=1.0.0")
@@ -304,6 +352,33 @@ def test_hacs_object_missing_expected_attributes_degrades(hass: HomeAssistant) -
     status = async_get_card_status(hass)
     assert status.hacs_present is True
     assert status.hacs_ready is False
+
+
+def test_a_renamed_disabled_attribute_does_not_kill_the_hacs_rung(
+    hass: HomeAssistant,
+) -> None:
+    """HACS carries ``disabled_reason`` too; ``disabled`` could go away.
+
+    Losing it must not silently drop every install to resource detection with
+    no version to report — the stage check still decides.
+    """
+    _install_hacs(
+        hass,
+        SimpleNamespace(
+            stage="running",
+            system=SimpleNamespace(disabled_reason=None),
+            repositories=SimpleNamespace(get_by_full_name=lambda _n: _repo()),
+        ),
+    )
+    status = async_get_card_status(hass)
+    assert status.hacs_ready is True
+    assert status.installed is True
+    assert status.detected_via == "hacs"
+
+
+def test_hacs_without_a_system_object_is_not_ready(hass: HomeAssistant) -> None:
+    _install_hacs(hass, SimpleNamespace(stage="startup"))
+    assert async_get_card_status(hass).hacs_ready is False
 
 
 def test_exploding_lovelace_resources_degrade(hass: HomeAssistant) -> None:
@@ -619,33 +694,50 @@ async def test_no_leaf_assembles_user_visible_prose_in_python(
     ["card_installed", "card_installed_version"],
     ids=["versionless", "version"],
 )
-@pytest.mark.parametrize("language", ["en", "de", "fr"], ids=lambda s: s)
+@pytest.mark.parametrize("language", _LANGUAGES, ids=lambda s: s)
 def test_installed_screens_never_mention_hacs(step_id: str, language: str) -> None:
     """Both are reachable with HACS absent, where ``card_manual`` says so.
 
     Telling a HACS-less install to "open HACS" is the same fault as claiming a
     detection method the router never checked: the screen asserting more than
-    the state it was routed on.
+    the state it was routed on. The language list is discovered, so a new
+    translation is covered the day it lands.
     """
-    path = _EN_JSON.parent / f"{language}.json"
-    block = json.loads(path.read_text(encoding="utf-8"))["options"]["step"][step_id]
-    assert "HACS" not in block["description"]
+    assert "HACS" not in _step(language, step_id)["description"]
 
 
-def test_version_screen_does_not_claim_to_be_up_to_date() -> None:
+# Phrases that would assert the install is current. Per-language because the
+# claim is prose, not a token: French "à jour" cannot be matched directly, as
+# "mise à jour" (update) contains it.
+_CURRENCY_CLAIMS = {
+    "en": ("up to date", "latest version", "is current"),
+    "de": ("auf dem neuesten Stand", "ist aktuell"),
+    "fr": ("est à jour", "sont à jour", "dernière version"),
+}
+
+
+def test_currency_claim_phrases_cover_every_shipped_language() -> None:
+    """A new language must declare its phrases, or the guard below goes blind."""
+    assert set(_LANGUAGES) == set(_CURRENCY_CLAIMS)
+
+
+@pytest.mark.parametrize("language", _LANGUAGES, ids=lambda s: s)
+def test_version_screen_does_not_claim_to_be_up_to_date(language: str) -> None:
     """It is reached when ``available_version`` is unknown, not just equal.
 
     ``async_step_card`` routes here on ``installed_version`` alone once the
     update branch declines, so an install whose available version was never
     reported would be told it is current on no evidence.
     """
-    description = _en_step("card_installed_version")["description"]
-    assert "up to date" not in description
+    description = _step(language, "card_installed_version")["description"]
+    for phrase in _CURRENCY_CLAIMS[language]:
+        assert phrase not in description, f"{language} claims currency: {phrase!r}"
 
 
-async def test_unknown_available_version_is_not_reported_as_current(
+async def test_unknown_available_version_still_routes_to_the_version_screen(
     hass: HomeAssistant,
 ) -> None:
+    """Routing only. The prose half is asserted by the guard above."""
     status = CardStatus(
         installed=True,
         installed_version="2.10.0",

--- a/tests/test_config_flow_companion_card.py
+++ b/tests/test_config_flow_companion_card.py
@@ -1,0 +1,564 @@
+"""Companion Lovelace card presence check in the options flow (issue #1168).
+
+Three concerns:
+- ``companion_card.async_get_card_status`` answers "is the card here, and how"
+  from HACS when HACS is running, falling back to a registered Lovelace
+  resource so a hand-installed card is never reported as missing. It duck-types
+  every HACS read — HACS is itself a custom integration with unversioned
+  internals, and none of it may break the options flow.
+- ``card`` is offered in the cover options menu and NEVER in the profile,
+  group, or queue menus.
+- ``async_step_card`` routes to one of three leaf screens, each of which
+  receives its URLs through ``description_placeholders`` (hassfest forbids
+  literal URLs in the translation strings) and returns to ``init`` on submit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.companion_card import (
+    CARD_ADD_URL,
+    CARD_FULL_NAME,
+    CARD_HACS_CATEGORY,
+    CARD_JS_FILENAME,
+    HACS_DOMAIN,
+    CardStatus,
+    async_get_card_status,
+)
+from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+
+pytestmark = pytest.mark.integration
+
+_CARD_STATUS_SEAM = (
+    "custom_components.adaptive_cover_pro.config_flow.async_get_card_status"
+)
+
+_EN_JSON = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "translations"
+    / "en.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cover_flow(hass, entry_id: str = "cover_1") -> OptionsFlowHandler:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: []},
+        entry_id=entry_id,
+        title="Kitchen Blind",
+    )
+    entry.add_to_hass(hass)
+    flow = OptionsFlowHandler(entry)
+    flow.hass = hass
+    flow.context = {}
+    # HA's OptionsFlow.config_entry property resolves via self.handler (entry_id).
+    flow.handler = entry.entry_id
+    return flow
+
+
+def _virtual_flow(hass, sensor_type, entry_id: str) -> OptionsFlowHandler:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: sensor_type},
+        options={},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    flow = OptionsFlowHandler(entry)
+    flow.hass = hass
+    flow.context = {}
+    flow.handler = entry.entry_id
+    return flow
+
+
+def _repo(
+    *,
+    installed: bool = True,
+    installed_version: str | None = "v2.17.0",
+    available_version: str | None = "v2.17.0",
+):
+    """Build a duck-typed stand-in for a HACS ``HacsRepository``."""
+    return SimpleNamespace(
+        data=SimpleNamespace(
+            installed=installed,
+            installed_version=installed_version,
+            available_version=available_version,
+        )
+    )
+
+
+def _hacs(*, repo=None, stage: str = "running", disabled: bool = False):
+    """Build a duck-typed stand-in for the ``HacsBase`` at ``hass.data["hacs"]``."""
+    return SimpleNamespace(
+        stage=stage,
+        system=SimpleNamespace(disabled=disabled),
+        repositories=SimpleNamespace(get_by_full_name=lambda _name: repo),
+    )
+
+
+def _install_hacs(hass, hacs) -> None:
+    hass.data[HACS_DOMAIN] = hacs
+
+
+def _install_resource(hass, url: str) -> None:
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(async_items=lambda: [{"url": url, "type": "module"}])
+    )
+
+
+def _en_menu_labels() -> dict:
+    return json.loads(_EN_JSON.read_text(encoding="utf-8"))["options"]["step"]["init"][
+        "menu_options"
+    ]
+
+
+def _en_step(step_id: str) -> dict:
+    return json.loads(_EN_JSON.read_text(encoding="utf-8"))["options"]["step"][step_id]
+
+
+# ---------------------------------------------------------------------------
+# Detection — companion_card.async_get_card_status
+# ---------------------------------------------------------------------------
+
+
+def test_no_hacs_and_no_resource_reports_nothing(hass: HomeAssistant) -> None:
+    status = async_get_card_status(hass)
+    assert status == CardStatus()
+    assert status.hacs_present is False
+    assert status.installed is False
+    assert status.detected_via is None
+
+
+def test_hacs_with_downloaded_repo_reports_installed(hass: HomeAssistant) -> None:
+    _install_hacs(hass, _hacs(repo=_repo(installed_version="v2.17.0")))
+    status = async_get_card_status(hass)
+    assert status.hacs_present is True
+    assert status.hacs_ready is True
+    assert status.installed is True
+    assert status.installed_version == "v2.17.0"
+    assert status.detected_via == "hacs"
+
+
+def test_hacs_running_but_repo_unknown_reports_not_installed(
+    hass: HomeAssistant,
+) -> None:
+    _install_hacs(hass, _hacs(repo=None))
+    status = async_get_card_status(hass)
+    assert status.hacs_present is True
+    assert status.hacs_ready is True
+    assert status.installed is False
+    assert status.detected_via is None
+
+
+def test_hacs_repo_added_but_not_downloaded_reports_not_installed(
+    hass: HomeAssistant,
+) -> None:
+    _install_hacs(hass, _hacs(repo=_repo(installed=False, installed_version=None)))
+    status = async_get_card_status(hass)
+    assert status.installed is False
+    assert status.installed_version is None
+
+
+def test_pending_update_surfaces_available_version(hass: HomeAssistant) -> None:
+    _install_hacs(
+        hass,
+        _hacs(repo=_repo(installed_version="v2.16.0", available_version="v2.17.0")),
+    )
+    status = async_get_card_status(hass)
+    assert status.installed_version == "v2.16.0"
+    assert status.available_version == "v2.17.0"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"stage": "startup"}, {"stage": "setup"}, {"disabled": True}],
+    ids=["startup", "setup", "disabled"],
+)
+def test_hacs_not_ready_is_present_but_not_queried(hass: HomeAssistant, kwargs) -> None:
+    """A rate-limited or still-starting HACS serves a stale/empty repo list.
+
+    It must read as *present* (so the flow offers the one-click add rather than
+    manual instructions) but never as an authoritative "not installed".
+    """
+    _install_hacs(hass, _hacs(repo=_repo(), **kwargs))
+    status = async_get_card_status(hass)
+    assert status.hacs_present is True
+    assert status.hacs_ready is False
+    assert status.installed is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        f"/hacsfiles/adaptive-cover-pro-card/{CARD_JS_FILENAME}?v=2.17.0",
+        f"/local/community/adaptive-cover-pro-card/{CARD_JS_FILENAME}",
+    ],
+    ids=["hacsfiles", "local"],
+)
+def test_manual_install_detected_from_lovelace_resource(
+    hass: HomeAssistant, url: str
+) -> None:
+    _install_resource(hass, url)
+    status = async_get_card_status(hass)
+    assert status.installed is True
+    assert status.detected_via == "resource"
+    assert status.hacs_present is False
+
+
+def test_resource_version_stamp_is_lifted_when_present(hass: HomeAssistant) -> None:
+    _install_resource(hass, f"/hacsfiles/x/{CARD_JS_FILENAME}?v=2.17.0")
+    assert async_get_card_status(hass).installed_version == "2.17.0"
+
+
+def test_unrelated_resource_is_not_mistaken_for_the_card(hass: HomeAssistant) -> None:
+    _install_resource(hass, "/hacsfiles/button-card/button-card.js")
+    assert async_get_card_status(hass).installed is False
+
+
+def test_hacs_wins_over_resource_when_both_present(hass: HomeAssistant) -> None:
+    _install_hacs(hass, _hacs(repo=_repo(installed_version="v2.17.0")))
+    _install_resource(hass, f"/hacsfiles/x/{CARD_JS_FILENAME}?v=1.0.0")
+    status = async_get_card_status(hass)
+    assert status.detected_via == "hacs"
+    assert status.installed_version == "v2.17.0"
+
+
+def test_repo_is_looked_up_by_full_name(hass: HomeAssistant) -> None:
+    """``get_by_full_name`` is the lookup — ``is_registered`` is case-broken upstream."""
+    seen: list[str] = []
+
+    def _lookup(name):
+        seen.append(name)
+        return _repo()
+
+    _install_hacs(
+        hass,
+        SimpleNamespace(
+            stage="running",
+            system=SimpleNamespace(disabled=False),
+            repositories=SimpleNamespace(get_by_full_name=_lookup),
+        ),
+    )
+    async_get_card_status(hass)
+    assert seen == [CARD_FULL_NAME]
+
+
+# --- Resilience: HACS internals are unversioned and must never break the flow
+
+
+def test_exploding_hacs_object_degrades_to_not_installed(hass: HomeAssistant) -> None:
+    class _Exploding:
+        @property
+        def stage(self):
+            raise RuntimeError("HACS changed shape under us")
+
+    _install_hacs(hass, _Exploding())
+    status = async_get_card_status(hass)
+    assert status.hacs_present is True
+    assert status.installed is False
+
+
+def test_exploding_repositories_lookup_degrades(hass: HomeAssistant) -> None:
+    def _boom(_name):
+        raise AttributeError("no such attribute")
+
+    _install_hacs(
+        hass,
+        SimpleNamespace(
+            stage="running",
+            system=SimpleNamespace(disabled=False),
+            repositories=SimpleNamespace(get_by_full_name=_boom),
+        ),
+    )
+    assert async_get_card_status(hass).installed is False
+
+
+def test_hacs_object_missing_expected_attributes_degrades(hass: HomeAssistant) -> None:
+    _install_hacs(hass, SimpleNamespace())
+    status = async_get_card_status(hass)
+    assert status.hacs_present is True
+    assert status.hacs_ready is False
+
+
+def test_exploding_lovelace_resources_degrade(hass: HomeAssistant) -> None:
+    def _boom():
+        raise RuntimeError("resources not loaded yet")
+
+    hass.data["lovelace"] = SimpleNamespace(
+        resources=SimpleNamespace(async_items=_boom)
+    )
+    assert async_get_card_status(hass).installed is False
+
+
+def test_lovelace_without_resources_degrades(hass: HomeAssistant) -> None:
+    hass.data["lovelace"] = SimpleNamespace()
+    assert async_get_card_status(hass).installed is False
+
+
+# ---------------------------------------------------------------------------
+# The My Home Assistant add link
+# ---------------------------------------------------------------------------
+
+
+def test_add_url_is_a_my_hacs_repository_redirect() -> None:
+    assert CARD_ADD_URL.startswith(
+        "https://my.home-assistant.io/redirect/hacs_repository/?"
+    )
+
+
+def test_add_url_carries_owner_repository_and_category() -> None:
+    """All three params are load-bearing.
+
+    HACS's repository dashboard only offers the "Add custom repository" confirm
+    dialog for an unknown repo when ``category`` is present; without it the user
+    gets "Repository not found".
+    """
+    owner, _, repo = CARD_FULL_NAME.partition("/")
+    assert f"owner={owner}" in CARD_ADD_URL
+    assert f"repository={repo}" in CARD_ADD_URL
+    assert f"category={CARD_HACS_CATEGORY}" in CARD_ADD_URL
+
+
+def test_hacs_category_is_plugin_not_lovelace() -> None:
+    """``HacsCategory`` has no ``lovelace`` member; ``plugin`` is the wire value."""
+    assert CARD_HACS_CATEGORY == "plugin"
+
+
+# ---------------------------------------------------------------------------
+# Menu wiring — card is cover-only, and always present
+# ---------------------------------------------------------------------------
+
+
+async def test_cover_init_menu_contains_card(hass: HomeAssistant) -> None:
+    result = await _cover_flow(hass).async_step_init()
+    assert result["type"] == "menu"
+    assert isinstance(result["menu_options"], list)
+    assert "card" in result["menu_options"]
+
+
+async def test_card_row_is_present_even_when_card_is_installed(
+    hass: HomeAssistant,
+) -> None:
+    _install_hacs(hass, _hacs(repo=_repo()))
+    result = await _cover_flow(hass).async_step_init()
+    assert "card" in result["menu_options"]
+
+
+async def test_card_sits_between_sync_and_summary(hass: HomeAssistant) -> None:
+    menu = (await _cover_flow(hass).async_step_init())["menu_options"]
+    assert menu.index("sync") < menu.index("card") < menu.index("summary")
+
+
+@pytest.mark.parametrize(
+    ("sensor_type", "entry_id"),
+    [
+        (CoverType.BUILDING_PROFILE, "profile_1"),
+        (CoverType.GROUP, "group_1"),
+        (CoverType.COMMAND_QUEUE, "queue_1"),
+    ],
+    ids=["profile", "group", "queue"],
+)
+async def test_virtual_entry_menus_omit_card(
+    hass: HomeAssistant, sensor_type, entry_id: str
+) -> None:
+    result = await _virtual_flow(hass, sensor_type, entry_id).async_step_init()
+    assert result["type"] == "menu"
+    assert "card" not in result["menu_options"]
+
+
+def test_card_menu_entry_has_an_en_json_label() -> None:
+    assert "card" in _en_menu_labels()
+
+
+# ---------------------------------------------------------------------------
+# async_step_card — routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_step"),
+    [
+        (CardStatus(installed=True, detected_via="hacs"), "card_installed"),
+        (CardStatus(hacs_present=True, hacs_ready=True), "card_add"),
+        (CardStatus(), "card_manual"),
+    ],
+    ids=["installed", "hacs-no-card", "no-hacs"],
+)
+async def test_card_routes_on_status(
+    hass: HomeAssistant, status: CardStatus, expected_step: str
+) -> None:
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["type"] == "form"
+    assert result["step_id"] == expected_step
+
+
+async def test_hacs_present_but_not_ready_offers_the_add_screen(
+    hass: HomeAssistant,
+) -> None:
+    status = CardStatus(hacs_present=True, hacs_ready=False)
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["step_id"] == "card_add"
+
+
+async def test_manual_install_routes_to_installed_without_hacs(
+    hass: HomeAssistant,
+) -> None:
+    status = CardStatus(installed=True, detected_via="resource")
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["step_id"] == "card_installed"
+
+
+# ---------------------------------------------------------------------------
+# The three leaf screens
+# ---------------------------------------------------------------------------
+
+
+async def test_add_screen_supplies_the_install_url(hass: HomeAssistant) -> None:
+    status = CardStatus(hacs_present=True, hacs_ready=True)
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["description_placeholders"]["install_url"] == CARD_ADD_URL
+
+
+async def test_manual_screen_supplies_hacs_and_download_urls(
+    hass: HomeAssistant,
+) -> None:
+    with patch(_CARD_STATUS_SEAM, return_value=CardStatus()):
+        result = await _cover_flow(hass).async_step_card()
+    placeholders = result["description_placeholders"]
+    assert placeholders["hacs_url"].startswith("https://")
+    assert placeholders["download_url"].startswith("https://")
+
+
+async def test_installed_screen_reports_the_version(hass: HomeAssistant) -> None:
+    status = CardStatus(
+        hacs_present=True,
+        hacs_ready=True,
+        installed=True,
+        installed_version="v2.17.0",
+        available_version="v2.17.0",
+        detected_via="hacs",
+    )
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert "v2.17.0" in result["description_placeholders"]["version_line"]
+    assert result["description_placeholders"]["update_line"] == ""
+
+
+async def test_installed_screen_flags_a_pending_update(hass: HomeAssistant) -> None:
+    status = CardStatus(
+        hacs_present=True,
+        hacs_ready=True,
+        installed=True,
+        installed_version="v2.16.0",
+        available_version="v2.17.0",
+        detected_via="hacs",
+    )
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert "v2.17.0" in result["description_placeholders"]["update_line"]
+
+
+async def test_installed_screen_without_a_known_version_is_blank_not_none(
+    hass: HomeAssistant,
+) -> None:
+    status = CardStatus(installed=True, detected_via="resource")
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    placeholders = result["description_placeholders"]
+    assert "None" not in placeholders["version_line"]
+    assert placeholders["update_line"] == ""
+
+
+@pytest.mark.parametrize(
+    "step_id", ["card_installed", "card_add", "card_manual"], ids=lambda s: s
+)
+async def test_every_leaf_has_an_empty_schema_and_a_learn_more(
+    hass: HomeAssistant, step_id: str
+) -> None:
+    status = {
+        "card_installed": CardStatus(installed=True, detected_via="resource"),
+        "card_add": CardStatus(hacs_present=True, hacs_ready=True),
+        "card_manual": CardStatus(),
+    }[step_id]
+    with patch(_CARD_STATUS_SEAM, return_value=status):
+        result = await _cover_flow(hass).async_step_card()
+    assert result["step_id"] == step_id
+    assert result["data_schema"]({}) == {}
+    assert result["description_placeholders"]["learn_more"].startswith("https://")
+
+
+@pytest.mark.parametrize(
+    "step_id", ["card_installed", "card_add", "card_manual"], ids=lambda s: s
+)
+async def test_every_leaf_returns_to_the_menu_on_submit(
+    hass: HomeAssistant, step_id: str
+) -> None:
+    flow = _cover_flow(hass)
+    result = await getattr(flow, f"async_step_{step_id}")({})
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+
+
+# ---------------------------------------------------------------------------
+# Translation blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "step_id", ["card_installed", "card_add", "card_manual"], ids=lambda s: s
+)
+def test_every_leaf_has_a_translation_block(step_id: str) -> None:
+    block = _en_step(step_id)
+    assert block["title"]
+    assert block["description"]
+
+
+@pytest.mark.parametrize(
+    ("step_id", "placeholders"),
+    [
+        ("card_installed", {"version_line", "update_line", "learn_more"}),
+        ("card_add", {"install_url", "learn_more"}),
+        ("card_manual", {"hacs_url", "download_url", "learn_more"}),
+    ],
+    ids=["installed", "add", "manual"],
+)
+def test_description_placeholders_match_the_translation(
+    step_id: str, placeholders: set[str]
+) -> None:
+    """Every ``{name}`` in the string must be supplied, or HA drops the key."""
+    import string
+
+    description = _en_step(step_id)["description"]
+    used = {
+        field
+        for _, field, _, _ in string.Formatter().parse(description)
+        if field is not None
+    }
+    assert used == placeholders


### PR DESCRIPTION
## Summary

HACS declined the companion card's `plugin` catalog submission on policy grounds ([hacs/default#8550](https://github.com/hacs/default/pull/8550)), so [`adaptive-cover-pro-card`](https://github.com/jrhubott/adaptive-cover-pro-card) ships as a HACS **custom repository**. Users cannot find it by searching HACS, and until now the integration never mentioned the card at all.

This adds a **🖼️ Dashboard Card** row to the cover options menu. It reports whether the card is installed and which version, and when it is missing it hands the add off to HACS through a My Home Assistant redirect: HACS shows its own "Add custom repository" confirm dialog, then offers the download.

I chose the redirect over calling `hass.data["hacs"].async_register_repository()` from the flow. HACS registers no services (it is websocket-only, and `websocket_api` has no in-process invoke), so the only Python route is an undocumented private call doing blocking GitHub I/O inside a config flow. Two details are load-bearing: the category is `plugin`, not `lovelace` (`HacsCategory` has no `lovelace` member), and it must be present or HACS reports "Repository not found" instead of offering to add.

**A different direction than #1168 proposed.** That issue asked to vendor the card into `custom_components/` and auto-register a Lovelace resource. This solves the same user problem, discovery and easy install, without coupling card releases to integration releases or taking on cache-busting and double-install migration. See [my comment on the issue](https://github.com/jrhubott/adaptive-cover-pro/issues/1168) for the full reasoning.

### How it works

New `companion_card.py` owns every fact about the card; nothing else knows its repository slug. Detection reads HACS when it is running, then falls back to the registered Lovelace resources, so a hand-installed card is never nagged as missing. Every read of both is guarded: HACS is itself a custom integration with no versioned public API, and a shape change there must degrade this one screen rather than take the options flow down.

`async_step_card` renders nothing; it routes to one of five leaf screens (installed / installed with version / update available / add / manual). Five leaves rather than one body with holes, so all prose lives in `translations/` and gets translated normally. Placeholders carry bare data only, never assembled sentences.

Cover entries only, matching the `troubleshoot` precedent. The row stays visible once the card is installed, since that is where a user reads back their version.

## Testing

- ✅ 13431 tests passing (4 skipped, 1 xfailed)
- ✅ 85 new tests in `tests/test_config_flow_companion_card.py`
- ✅ 100% patch coverage on `companion_card.py` (78/78 statements)
- ✅ `./scripts/validate_translations.py --ci` clean; DE/FR at full key parity with placeholder sets verified identical

Three audit rounds ran against this branch. They caught four instances of one fault: a screen asserting more than the router that reached it had established. The versionless screen claimed the card "was found as a dashboard resource" when the router only knew the version was unknown; it later told a HACS-less install to "open HACS"; the version screen claimed "up to date" when the available version was merely unknown; and `card_add` promised a confirm-add step that does not happen when HACS already tracks the repo. All four are fixed, and guards now assert per-language that these screens make no claim the routing predicate does not support.

## Related Issues

Refs #1168
