### PR TITLE
fix: gate climate low-light on the cloud-suppression hold (#1238)

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -748,6 +748,14 @@ class DiagnosticsBuilder:
                 "lux_below_threshold": climate_data.lux_below_threshold,
                 "irradiance_below_threshold": climate_data.irradiance_below_threshold,
                 "cloud_coverage_above_threshold": climate_data.cloud_coverage_above_threshold,
+                # The RESOLVED low-light answer plus its provenance (issue
+                # #1238). The three raw inputs above no longer determine it on
+                # their own — with cloud suppression on, the smoothed
+                # cloud-suppression bool (hysteresis + hold-time) wins — so
+                # without these two keys a support trace cannot tell a held
+                # low-light from a raw one.
+                "is_low_light": climate_data.is_low_light,
+                "low_light_smoothed": climate_data.low_light_active is not None,
                 "tracking_seasons": sorted(climate_data.tracking_seasons),
             }
 

--- a/custom_components/adaptive_cover_pro/managers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/managers/cloud_suppression.py
@@ -185,7 +185,22 @@ class CloudSuppressionManager:
         )
 
     def _reset(self) -> None:
-        """Drop all latch/resolved/pending state and cancel any timer."""
+        """Drop all latch/resolved/pending state and cancel any timer.
+
+        Runs on every cycle with nothing to fold in — not just a config reload
+        that disables the feature, but also a **transient readings outage**
+        (``readings is None`` in :meth:`evaluate`).
+
+        ``seeded=False`` is deliberate on that outage path too. The reset itself
+        is what ends an interrupted hold: it cancels the timer, drops the
+        pending target, and forces ``resolved`` back to False. Re-seeding only
+        decides what the *next* valid reading costs. Seeded, that reading would
+        re-arm a fresh full hold — a one-cycle blip would buy another
+        ``hold_time`` of the wrong state, which is the restart bug issue #1238
+        fixed. Unseeded, it is treated as the world as found and commits
+        in-line; the seed is one-shot, so the transition after it debounces
+        normally again.
+        """
         self._lux_latched = False
         self._irr_latched = False
         self._cloud_latched = False

--- a/custom_components/adaptive_cover_pro/managers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/managers/cloud_suppression.py
@@ -69,7 +69,12 @@ class CloudSuppressionManager:
         self._debouncer = HoldDebouncer(
             logger, label="cloud-suppression hold", on_commit=self._on_commit
         )
-        self._debouncer.reset(False)
+        # seeded=False: the first reading after construction/reload is the world
+        # as found, not a change, so it must not be debounced (issue #1238).
+        # Without it a restart in cloudy weather would leave the resolved bool
+        # False — and the climate LOW_LIGHT branch, which now gates on it, would
+        # sun-track for the whole hold-time before the cover settled.
+        self._debouncer.reset(False, seeded=False)
 
     # --- Configuration ---
 
@@ -184,4 +189,4 @@ class CloudSuppressionManager:
         self._lux_latched = False
         self._irr_latched = False
         self._cloud_latched = False
-        self._debouncer.reset(False)
+        self._debouncer.reset(False, seeded=False)

--- a/custom_components/adaptive_cover_pro/managers/common/smoothing.py
+++ b/custom_components/adaptive_cover_pro/managers/common/smoothing.py
@@ -76,6 +76,10 @@ class HoldDebouncer:
         self._on_commit = on_commit
         self.resolved: Any = None
         self._pending_target: Any = None
+        # Set here rather than via reset() — the constructor assigns ``resolved``
+        # directly, so a caller that never calls reset() would otherwise have no
+        # ``_seeded`` at all. True keeps that caller on the historical path.
+        self._seeded: bool = True
         self._timer = TimeoutController(logger, label=label)
 
     @property
@@ -91,7 +95,19 @@ class HoldDebouncer:
         ``None`` otherwise (including the ``hold_time == 0`` case, which commits
         in-line). A pending target that changes to a further value while a timer
         runs keeps the timer and updates the pending target.
+
+        An UNSEEDED debouncer (``reset(..., seeded=False)``) commits its very
+        first observation in-line, whatever it is: a debounce guards *changes*,
+        and the first reading after construction or a config reload is the world
+        as found, not a change (issue #1238). ``_commit`` fires ``on_commit``
+        only on an actual difference, so a startup that agrees with the reset
+        value records no spurious event.
         """
+        if not self._seeded:
+            self._seeded = True
+            self._commit(instantaneous)
+            return None
+
         if instantaneous == self.resolved:
             # No transition needed. A timer counting toward a now-abandoned
             # transition is cancelled (the condition reverted → true debounce).
@@ -137,10 +153,17 @@ class HoldDebouncer:
         """Cancel the running hold-time timer, if any."""
         self._timer.cancel()
 
-    def reset(self, initial: Any) -> None:
-        """Restore the resolved value to ``initial`` and drop pending state."""
+    def reset(self, initial: Any, *, seeded: bool = True) -> None:
+        """Restore the resolved value to ``initial`` and drop pending state.
+
+        ``seeded=False`` marks ``initial`` as a placeholder rather than an
+        observation, so the next :meth:`evaluate` commits in-line instead of
+        debouncing the first reading. Opt-in — the default keeps every existing
+        caller byte-identical.
+        """
         self.resolved = initial
         self._pending_target = None
+        self._seeded = seeded
         self.cancel()
 
     def _commit(self, target: Any) -> None:

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -91,6 +91,14 @@ class ClimateCoverData:
     summer_warm_active: bool | None = None
     outside_high_active: bool | None = None
     extreme_heat_active: bool | None = None
+    # Smoothed LIGHT-threshold flag (issue #1238) — the same seam, a different
+    # family of thresholds, so it is deliberately not folded into the season
+    # block above. The resolved cloud-suppression bool already carries the
+    # per-trigger Schmitt latches AND the hold-time debounce the user configured
+    # (issue #864); the LOW_LIGHT branch is the second consumer of those very
+    # readings and reads that answer instead of recomputing it raw. None =
+    # cloud suppression off / not threaded → the raw OR fallback.
+    low_light_active: bool | None = None
 
     @property
     def get_current_temperature(self) -> float | None:
@@ -158,6 +166,21 @@ class ClimateCoverData:
         return extreme_heat_crossing(
             self.outside_temperature, self.temp_extreme_heat, None
         )[0]
+
+    @property
+    def is_low_light(self) -> bool:
+        """True when there is no real sun to manage (issue #1238).
+
+        Returns the smoothed flag (``low_light_active``) when the coordinator has
+        resolved one — that is ``cloud_suppression_active``, already carrying the
+        hysteresis latches and the ``cloud_suppression_hold_time`` debounce.
+        Otherwise falls back to the raw single-crossing OR, so every install with
+        cloud suppression off and every direct-constructor test behaves
+        byte-identically to before the smoothing existed.
+        """
+        if self.low_light_active is not None:
+            return self.low_light_active
+        return bool(self.lux or self.irradiance or not self.is_sunny)
 
     @property
     def lux(self) -> bool:
@@ -531,6 +554,14 @@ class ClimateHandler(OverrideHandler):
             summer_warm_active=flags.summer_warm if flags is not None else None,
             outside_high_active=flags.outside_high if flags is not None else None,
             extreme_heat_active=flags.extreme_heat if flags is not None else None,
+            # Smoothed light thresholds (issue #1238). The resolved
+            # cloud-suppression bool is only meaningful when the feature is on;
+            # otherwise None keeps the raw OR fallback.
+            low_light_active=(
+                snapshot.cloud_suppression_active
+                if opts.cloud_suppression_enabled
+                else None
+            ),
         )
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
@@ -105,8 +105,14 @@ class ClimateContext:
 
     @property
     def is_low_light(self) -> bool:
-        """Whether lux/irradiance/no-sun indicates there's no real sun to manage."""
-        return bool(self.data.lux or self.data.irradiance or not self.data.is_sunny)
+        """Whether lux/irradiance/no-sun indicates there's no real sun to manage.
+
+        The predicate itself lives on ``ClimateCoverData.is_low_light``, which
+        prefers the smoothed ``low_light_active`` flag (the resolved
+        cloud-suppression bool, carrying the user's hold-time) over the raw
+        single-crossing OR — issue #1238.
+        """
+        return bool(self.data.is_low_light)
 
     @property
     def is_winter_insulation(self) -> bool:

--- a/tests/test_climate_cover_data.py
+++ b/tests/test_climate_cover_data.py
@@ -84,6 +84,44 @@ class TestSmoothedFlagPrecedence:
         d = _make_climate(temp_switch=True, outside_temperature="10.0")
         assert d.is_winter is True  # raw: 10 < temp_low 20
 
+    # -- light thresholds (issue #1238) -------------------------------------
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("lux", [False, True])
+    @pytest.mark.parametrize("irradiance", [False, True])
+    @pytest.mark.parametrize("is_sunny", [False, True])
+    def test_low_light_none_reproduces_the_raw_or(self, lux, irradiance, is_sunny):
+        """``low_light_active=None`` is byte-identical to the pre-#1238 predicate."""
+        d = _make_climate(
+            lux_below_threshold=lux,
+            irradiance_below_threshold=irradiance,
+            is_sunny=is_sunny,
+        )
+        assert d.low_light_active is None
+        assert d.is_low_light is (lux or irradiance or not is_sunny)
+
+    @pytest.mark.unit
+    def test_low_light_flag_false_overrides_raw_true(self):
+        """A resolved False wins over readings that would raise low light."""
+        d = _make_climate(
+            lux_below_threshold=True,
+            irradiance_below_threshold=True,
+            is_sunny=False,
+            low_light_active=False,
+        )
+        assert d.is_low_light is False
+
+    @pytest.mark.unit
+    def test_low_light_flag_true_overrides_raw_false(self):
+        """A resolved True wins over readings that would clear low light."""
+        d = _make_climate(
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            is_sunny=True,
+            low_light_active=True,
+        )
+        assert d.is_low_light is True
+
 
 class TestClimateCoverData:
     """Test ClimateCoverData properties."""

--- a/tests/test_climate_modes.py
+++ b/tests/test_climate_modes.py
@@ -42,8 +42,17 @@ def _ctx(
     transparent_blind=False,
     default_position=50,
     is_extreme_heat=False,
+    is_low_light=None,
 ):
-    """Build a ClimateContext over a normal (non-tilt) cover with a mock policy."""
+    """Build a ClimateContext over a normal (non-tilt) cover with a mock policy.
+
+    ``is_low_light`` mirrors how ``is_winter``/``is_summer``/``is_extreme_heat``
+    are already handled here: the context reads a resolved predicate off the
+    data object, so the double supplies one. It defaults to the raw OR the
+    readings imply, which keeps every existing call site meaning what it did,
+    and can be passed explicitly to decouple the predicate from the readings
+    (issue #1238's smoothed ``low_light_active`` seam).
+    """
     policy = MagicMock()
     policy.position_for_intent.side_effect = lambda sun_through: (
         "intent_open" if sun_through else "intent_block"
@@ -54,6 +63,11 @@ def _ctx(
         lux=lux,
         irradiance=irradiance,
         is_sunny=is_sunny,
+        is_low_light=(
+            (lux or irradiance or not is_sunny)
+            if is_low_light is None
+            else is_low_light
+        ),
         winter_close_insulation=winter_close_insulation,
         transparent_blind=transparent_blind,
         policy=policy,
@@ -77,6 +91,17 @@ def test_is_low_light_any_signal():
     assert _ctx(irradiance=True).is_low_light
     assert _ctx(is_sunny=False).is_low_light
     assert not _ctx().is_low_light
+
+
+def test_is_low_light_delegates_to_the_climate_data_predicate():
+    """The context is a pass-through; the smoothing lives on ClimateCoverData.
+
+    Issue #1238 moved the OR onto ``ClimateCoverData.is_low_light`` so the
+    resolved cloud-suppression bool (hysteresis + hold-time) can override it.
+    All four rule tables inherit that through this one delegation.
+    """
+    assert _ctx(lux=True, is_low_light=False).is_low_light is False
+    assert _ctx(is_low_light=True).is_low_light is True
 
 
 def test_is_winter_insulation_requires_both():

--- a/tests/test_cloud_suppression.py
+++ b/tests/test_cloud_suppression.py
@@ -9,8 +9,9 @@ Covers:
 
 from __future__ import annotations
 
+import pytest
 
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import ClimateStrategy, ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     ClimateHandler,
     CustomPositionHandler,
@@ -401,6 +402,101 @@ class TestCloudSuppressionPipelineIntegration:
         result = registry.evaluate(snapshot)
         assert result.control_method == ControlMethod.DEFAULT
         assert result.position == 60
+
+    def test_climate_low_light_wins_on_cloud_coverage_outside_fov(self) -> None:
+        """Issue #1238 behaviour change (b): the low-light trigger set widens.
+
+        ``cloud_suppression_active`` includes ``cloud_coverage_above_threshold``;
+        the raw ``is_low_light`` predicate never read that field. Gating low light
+        on the resolved bool therefore widens the trigger set — shadowed by
+        ``CloudSuppressionHandler`` at priority 60 in every state EXCEPT this
+        one, where the sun sits outside the window's FOV so priority 60 declines
+        (issue #417) and the climate branch is reached.
+
+        The position is the effective default either way; what changes is the
+        winning handler (``default`` → ``climate``) and the strategy.
+        """
+        registry = self._make_registry()
+        snapshot = make_snapshot(
+            direct_sun_valid=False,
+            climate_mode_enabled=True,
+            default_position=60,
+            climate_readings=make_weather_readings(
+                is_sunny=True,
+                lux_below_threshold=False,
+                irradiance_below_threshold=False,
+                cloud_coverage_above_threshold=True,
+            ),
+            climate_options=ClimateOptions(
+                temp_low=None,
+                temp_high=None,
+                temp_switch=True,
+                transparent_blind=False,
+                temp_summer_outside=None,
+                cloud_suppression_enabled=True,
+                winter_close_insulation=False,
+            ),
+        )
+        result = registry.evaluate(snapshot)
+        winner = next(step for step in result.decision_trace if step.matched)
+        assert winner.handler == "climate"
+        assert result.climate_strategy == ClimateStrategy.LOW_LIGHT
+        assert result.control_method == ControlMethod.DEFAULT
+        assert result.position == 60
+
+    @pytest.mark.parametrize(
+        ("is_sunset_active", "expected_tilt"), [(False, 35), (True, 5)]
+    )
+    def test_venetian_cloud_coverage_outside_fov_keeps_the_default_tilt(
+        self, is_sunset_active: bool, expected_tilt: int
+    ) -> None:
+        """The #1214 tilt outcome for the widened branch, pinned explicitly.
+
+        On a venetian the LOW_LIGHT branch has ``position_from_default=True``, so
+        ``ClimateHandler`` calls ``compute_default_tilt`` — where the previous
+        winner, ``DefaultHandler``, called the very same helper. Both must land on
+        the identical slat angle: this branch changes which handler answers, and
+        it must not change what the slats do. Parametrised over the sunset
+        carve-out because that is where the two tilt sources differ.
+        """
+        readings = make_weather_readings(
+            is_sunny=True,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            cloud_coverage_above_threshold=True,
+        )
+        options = ClimateOptions(
+            temp_low=None,
+            temp_high=None,
+            temp_switch=True,
+            transparent_blind=False,
+            temp_summer_outside=None,
+            cloud_suppression_enabled=True,
+            winter_close_insulation=False,
+        )
+        kwargs = {
+            "cover_type": "cover_venetian",
+            "direct_sun_valid": False,
+            "default_position": 60,
+            "default_tilt": 35,
+            "sunset_tilt": 5,
+            "is_sunset_active": is_sunset_active,
+            "climate_readings": readings,
+            "climate_options": options,
+        }
+        # What DefaultHandler answers today, with climate mode off.
+        baseline = DefaultHandler().evaluate(
+            make_snapshot(climate_mode_enabled=False, **kwargs)
+        )
+        result = self._make_registry().evaluate(
+            make_snapshot(climate_mode_enabled=True, **kwargs)
+        )
+
+        winner = next(step for step in result.decision_trace if step.matched)
+        assert winner.handler == "climate"
+        assert result.climate_strategy == ClimateStrategy.LOW_LIGHT
+        assert result.position == baseline.position == 60
+        assert result.tilt == baseline.tilt == expected_tilt
 
     def test_cloud_suppression_overrides_climate(self) -> None:
         """Cloud suppression (priority 60) fires before climate handler (priority 50)."""

--- a/tests/test_cloud_suppression.py
+++ b/tests/test_cloud_suppression.py
@@ -445,10 +445,16 @@ class TestCloudSuppressionPipelineIntegration:
         assert result.position == 60
 
     @pytest.mark.parametrize(
-        ("is_sunset_active", "expected_tilt"), [(False, 35), (True, 5)]
+        ("is_sunset_active", "min_tilt", "max_tilt", "expected_tilt"),
+        [
+            (False, 0, 100, 35),  # unconstrained → default_tilt as configured
+            (True, 0, 100, 5),  # unconstrained → sunset_tilt as configured
+            (False, 10, 30, 30),  # #503 clamp pulls default_tilt down to max
+            (True, 10, 30, 5),  # #128 carve-out: sunset_tilt stays unclamped
+        ],
     )
     def test_venetian_cloud_coverage_outside_fov_keeps_the_default_tilt(
-        self, is_sunset_active: bool, expected_tilt: int
+        self, is_sunset_active: bool, min_tilt: int, max_tilt: int, expected_tilt: int
     ) -> None:
         """The #1214 tilt outcome for the widened branch, pinned explicitly.
 
@@ -457,7 +463,10 @@ class TestCloudSuppressionPipelineIntegration:
         winner, ``DefaultHandler``, called the very same helper. Both must land on
         the identical slat angle: this branch changes which handler answers, and
         it must not change what the slats do. Parametrised over the sunset
-        carve-out because that is where the two tilt sources differ.
+        carve-out (that is where the two tilt sources differ) crossed with the
+        tilt limits, because the two paths through ``compute_default_tilt``
+        disagree about clamping: only the non-sunset ``default_tilt`` honours the
+        #503 min/max, while ``sunset_tilt`` keeps the #128 bypass.
         """
         readings = make_weather_readings(
             is_sunny=True,
@@ -480,6 +489,8 @@ class TestCloudSuppressionPipelineIntegration:
             "default_position": 60,
             "default_tilt": 35,
             "sunset_tilt": 5,
+            "min_tilt": min_tilt,
+            "max_tilt": max_tilt,
             "is_sunset_active": is_sunset_active,
             "climate_readings": readings,
             "climate_options": options,

--- a/tests/test_coordinator_climate_wiring.py
+++ b/tests/test_coordinator_climate_wiring.py
@@ -708,6 +708,20 @@ class TestCloudSuppressionCoordinatorWiring:
         coord._cloud_mgr.update_config(enabled=True, hold_time_seconds=120)
         coord._start_cloud_hold_timeout = MagicMock()
 
+        # First cycle after setup: the manager seeds on the world as found
+        # rather than debouncing it (issue #1238), so a resting sunny read is
+        # needed before the crossing this test is about.
+        coord._reconcile_cloud_suppression(
+            ClimateReadings(
+                outside_temperature=None,
+                inside_temperature=None,
+                is_presence=True,
+                is_sunny=True,
+                lux_below_threshold=False,
+                irradiance_below_threshold=False,
+                cloud_coverage_above_threshold=False,
+            )
+        )
         coord._reconcile_cloud_suppression(
             ClimateReadings(
                 outside_temperature=None,

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 import pytest
 
@@ -835,6 +836,28 @@ class TestClimateDiagnostics:
         pr = _make_pr(control_method=ControlMethod.CLOUD, climate_data=cd)
         diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
         assert diag["climate_conditions"]["cloud_coverage_above_threshold"] is True
+
+    def test_climate_conditions_report_resolved_low_light(
+        self, builder: DiagnosticsBuilder
+    ):
+        """The resolved low-light answer + whether it was smoothed (issue #1238).
+
+        The raw inputs alone stopped determining the branch once the LOW_LIGHT
+        rule started reading the debounced cloud-suppression bool — a trace that
+        shows only the raw values cannot distinguish a held low light from an
+        instantaneous one.
+        """
+        raw = self._make_climate_data()
+        pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=raw)
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        assert diag["climate_conditions"]["is_low_light"] is False
+        assert diag["climate_conditions"]["low_light_smoothed"] is False
+
+        smoothed = replace(self._make_climate_data(), low_light_active=True)
+        pr = _make_pr(control_method=ControlMethod.DEFAULT, climate_data=smoothed)
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        assert diag["climate_conditions"]["is_low_light"] is True
+        assert diag["climate_conditions"]["low_light_smoothed"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_1238_cloud_hold_vs_climate.py
+++ b/tests/test_issue_1238_cloud_hold_vs_climate.py
@@ -1,0 +1,346 @@
+"""Issue #1238 — the cloud-suppression hold time must also gate climate LOW_LIGHT.
+
+``cloud_suppression_hold_time`` (issue #864 / PR #873) debounces exactly one
+boolean: ``PipelineSnapshot.cloud_suppression_active``, read by
+``CloudSuppressionHandler`` at priority 60. ``ClimateHandler`` at priority 50 is
+a **second, independent consumer of the very same raw light readings** and was
+never brought under the smoothing — its LOW_LIGHT branch moved the cover in the
+same update cycle that logged "Cloud-suppression change pending — holding 600
+seconds before it takes effect".
+
+Every test here drives a real :class:`CloudSuppressionManager` and threads its
+resolved bool into the snapshot, which is exactly what the coordinator does. No
+``hass`` is involved: the manager consumes provider booleans and the pipeline is
+pure.
+
+The reporter's install (2026.8.1, vertical blind, ``lux_threshold=30000`` with a
+blank release threshold, ``cloud_suppression_hold_time=600``, effective default
+100 %, ``min_position_sun_tracking=10``) gives the two competing answers used
+throughout: **100 %** (the climate LOW_LIGHT default) and **10 %** (sun
+tracking).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    ClimateStrategy,
+    ControlMethod,
+)
+from custom_components.adaptive_cover_pro.managers.cloud_suppression import (
+    CloudSuppressionManager,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers import (
+    ClimateHandler,
+    DefaultHandler,
+    SolarHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
+    CloudSuppressionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import ClimateOptions
+from custom_components.adaptive_cover_pro.state.climate_provider import ClimateReadings
+from tests.test_pipeline.conftest import make_snapshot
+
+# The reporter's two competing answers.
+DEFAULT_POS = 100
+SOLAR_POS = 10
+
+HOLD = 600
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _readings(
+    *,
+    is_sunny: bool = True,
+    lux_below_threshold: bool = False,
+    lux_release_cleared: bool | None = None,
+    cloud_coverage_above_threshold: bool = False,
+    inside_temperature: float = 22.0,
+) -> ClimateReadings:
+    """Build readings; the blank-release default mirrors ``not activate`` (#864)."""
+    return ClimateReadings(
+        outside_temperature=None,
+        inside_temperature=inside_temperature,
+        is_presence=True,
+        is_sunny=is_sunny,
+        lux_below_threshold=lux_below_threshold,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=cloud_coverage_above_threshold,
+        lux_release_cleared=(
+            (not lux_below_threshold)
+            if lux_release_cleared is None
+            else lux_release_cleared
+        ),
+        cloud_coverage_release_cleared=not cloud_coverage_above_threshold,
+    )
+
+
+def _options(*, cloud_suppression_enabled: bool = True) -> ClimateOptions:
+    """Intermediate-temperature climate options with cloud suppression on."""
+    return ClimateOptions(
+        temp_low=18.0,
+        temp_high=26.0,
+        temp_switch=False,
+        transparent_blind=False,
+        temp_summer_outside=None,
+        cloud_suppression_enabled=cloud_suppression_enabled,
+        winter_close_insulation=False,
+    )
+
+
+def _manager(*, hold_time: int = HOLD) -> CloudSuppressionManager:
+    """Build an enabled manager with the reporter's hold time."""
+    m = CloudSuppressionManager(logger=MagicMock())
+    m.update_config(enabled=True, hold_time_seconds=hold_time)
+    return m
+
+
+def _snapshot(manager: CloudSuppressionManager, readings: ClimateReadings, **kwargs):
+    """Snapshot carrying the manager's RESOLVED bool, as the coordinator builds it."""
+    kwargs.setdefault("direct_sun_valid", True)
+    kwargs.setdefault("calculate_percentage_return", SOLAR_POS)
+    kwargs.setdefault("default_position", DEFAULT_POS)
+    return make_snapshot(
+        climate_mode_enabled=True,
+        climate_readings=readings,
+        climate_options=_options(),
+        cloud_suppression_active=manager.is_suppression_active,
+        **kwargs,
+    )
+
+
+def _winner(result) -> str:
+    """Name of the handler that matched in the decision trace."""
+    return next(step.handler for step in result.decision_trace if step.matched)
+
+
+def _climate_band() -> PipelineRegistry:
+    """Climate → solar → default, WITHOUT ``CloudSuppressionHandler``.
+
+    Priority 60 declines for the whole pending window (that is what "holding"
+    means), so on the ENGAGE edge it never masks anything and the registry
+    answers identically with or without it. It is left out so the assertions
+    speak unambiguously about the priority-50 branch this issue is about — and
+    so the RELEASE edge, where priority 60 *is* still commanding the default,
+    fails honestly instead of passing for the wrong reason.
+    """
+    return PipelineRegistry([ClimateHandler(), SolarHandler(), DefaultHandler()])
+
+
+def _full_pipeline() -> PipelineRegistry:
+    """Build the handler chain the reporter's install runs, in priority order."""
+    return PipelineRegistry(
+        [
+            CloudSuppressionHandler(),
+            ClimateHandler(),
+            SolarHandler(),
+            DefaultHandler(),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# R1 — the reporter's timeline: a pending hold must not let climate move
+# ---------------------------------------------------------------------------
+
+
+class TestPendingHoldGatesClimate:
+    """While the hold is counting down, no handler may act on the crossing."""
+
+    def test_pending_engage_hold_does_not_let_climate_move_the_cover(self) -> None:
+        """08:58:25 — lux drops below; the manager arms 600 s, the cover must not move."""
+        manager = _manager()
+        # Resting state: lux above the threshold, sun tracked at 10 %.
+        manager.evaluate(_readings())
+
+        signal = manager.evaluate(_readings(lux_below_threshold=True))
+        assert signal == "should_start_timeout"
+        assert manager.is_suppression_active is False  # still holding
+
+        result = _climate_band().evaluate(
+            _snapshot(manager, _readings(lux_below_threshold=True))
+        )
+        assert _winner(result) != "climate"
+        assert result.climate_strategy is not ClimateStrategy.LOW_LIGHT
+        assert result.position != DEFAULT_POS
+        assert result.position == SOLAR_POS
+
+    @pytest.mark.asyncio
+    async def test_climate_low_light_engages_once_the_hold_expires(self) -> None:
+        """The fix DELAYS low light, it does not suppress it — 600 s later it fires."""
+        manager = _manager()
+        manager.evaluate(_readings())
+        manager.evaluate(_readings(lux_below_threshold=True))
+
+        await manager._on_hold_timeout_expired(AsyncMock())
+        assert manager.is_suppression_active is True
+
+        result = _climate_band().evaluate(
+            _snapshot(manager, _readings(lux_below_threshold=True))
+        )
+        assert _winner(result) == "climate"
+        assert result.climate_strategy is ClimateStrategy.LOW_LIGHT
+        assert result.control_method is ControlMethod.DEFAULT
+        assert result.position == DEFAULT_POS
+
+
+# ---------------------------------------------------------------------------
+# R2 — the flap property: readings flap, the commanded position must not
+# ---------------------------------------------------------------------------
+
+
+class TestFlapProperty:
+    """The reporter's 08:58 → 09:08 sequence through one manager instance."""
+
+    def test_commanded_position_is_constant_across_the_reported_flap(self) -> None:
+        """08:58:25 → 08:59:24 → 08:59:42 → 09:08:12 produced 100/10/100/10."""
+        manager = _manager()
+        registry = _full_pipeline()
+
+        # Resting state before 08:58:25: lux above the threshold.
+        manager.evaluate(_readings())
+
+        positions: list[int] = []
+        for lux_below in (True, False, True, False):
+            readings = _readings(lux_below_threshold=lux_below)
+            manager.evaluate(readings)
+            positions.append(registry.evaluate(_snapshot(manager, readings)).position)
+
+        assert len(set(positions)) == 1, (
+            "A 600 s hold was configured, yet the commanded position flapped "
+            f"with the raw lux readings: {positions}"
+        )
+        assert positions == [SOLAR_POS] * 4
+
+
+# ---------------------------------------------------------------------------
+# R3 — behaviour change (a): the hold is symmetric, it covers the release edge
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseEdgeIsHeldToo:
+    """After the fix the hold applies to the RELEASE edge of low light as well.
+
+    This is what the reporter described as correct behaviour (their 08:09 →
+    08:19 case) — but until now it only looked correct because the still-pending
+    ``CloudSuppressionHandler`` at priority 60 kept commanding the same default
+    position. The climate branch itself flipped instantly.
+    """
+
+    def test_release_edge_holds_the_default_until_expiry(self) -> None:
+        """Lux rises above threshold: sun tracking must wait out the hold."""
+        manager = _manager()
+        # Resting state: cloudy. The first reading seeds instantly (no restart
+        # regression), so suppression is resolved True before the release edge.
+        manager.evaluate(_readings(lux_below_threshold=True))
+        assert manager.is_suppression_active is True
+
+        # Release edge — the hold arms and the resolved bool stays True.
+        assert manager.evaluate(_readings()) == "should_start_timeout"
+        assert manager.is_suppression_active is True
+
+        pending = _climate_band().evaluate(_snapshot(manager, _readings()))
+        assert _winner(pending) == "climate"
+        assert pending.climate_strategy is ClimateStrategy.LOW_LIGHT
+        assert pending.position == DEFAULT_POS
+
+    @pytest.mark.asyncio
+    async def test_sun_tracking_resumes_after_the_release_hold_expires(self) -> None:
+        """Once the 600 s elapse the climate branch releases and solar takes over."""
+        manager = _manager()
+        manager.evaluate(_readings(lux_below_threshold=True))
+        manager.evaluate(_readings())
+
+        await manager._on_hold_timeout_expired(AsyncMock())
+        assert manager.is_suppression_active is False
+
+        result = _climate_band().evaluate(_snapshot(manager, _readings()))
+        assert _winner(result) == "solar"
+        assert result.position == SOLAR_POS
+
+
+# ---------------------------------------------------------------------------
+# R5 — behaviour change (c): low light inherits the per-trigger Schmitt latch
+# ---------------------------------------------------------------------------
+
+
+class TestHysteresisWidening:
+    """A configured ``lux_release_threshold`` now latches low light too.
+
+    ``cloud_suppression_active`` carries the per-trigger Schmitt latches; the raw
+    ``is_low_light`` predicate only ever read the activate edge. With hold-time 0
+    the debounce is a no-op, so this isolates the hysteresis half of the change.
+    """
+
+    def test_low_light_stays_engaged_inside_the_release_band(self) -> None:
+        manager = _manager(hold_time=0)
+        # Below the activate edge → the lux latch engages, resolved True.
+        manager.evaluate(_readings(lux_below_threshold=True))
+        assert manager.is_suppression_active is True
+
+        # Inside the band: above activate but not yet past the release edge.
+        in_band = _readings(lux_below_threshold=False, lux_release_cleared=False)
+        assert manager.evaluate(in_band) is None
+        assert manager.is_suppression_active is True
+
+        result = _climate_band().evaluate(_snapshot(manager, in_band))
+        assert _winner(result) == "climate"
+        assert result.climate_strategy is ClimateStrategy.LOW_LIGHT
+        assert result.position == DEFAULT_POS
+
+
+# ---------------------------------------------------------------------------
+# R9 — the restart guard: a reload in cloudy weather must not hold for 600 s
+# ---------------------------------------------------------------------------
+
+
+class TestStartupSeed:
+    """The first observation after construction/reload is not a *change*.
+
+    Without the seed, a reload during cloudy weather leaves the resolved bool
+    False for the whole hold time. That was harmless while only the cloud handler
+    read it — the unsmoothed low-light sibling covered the gap. Gating low light
+    on the same bool turns it into 600 s of sun tracking after every restart in
+    cloudy weather, which would be a worse bug than the one being fixed.
+    """
+
+    def test_first_ever_reading_commits_immediately(self) -> None:
+        manager = _manager()
+        cloudy = _readings(lux_below_threshold=True)
+
+        assert manager.evaluate(cloudy) is None
+        assert manager.is_suppression_active is True
+        assert manager.is_timeout_running is False
+
+        result = _full_pipeline().evaluate(_snapshot(manager, cloudy))
+        assert _winner(result) == "cloud_suppression"
+        assert result.position == DEFAULT_POS
+
+    def test_first_ever_sunny_reading_records_no_change_event(self) -> None:
+        """Seeding must not synthesise a ``cloud_suppression_changed`` event."""
+        buffer = MagicMock()
+        manager = CloudSuppressionManager(logger=MagicMock(), event_buffer=buffer)
+        manager.update_config(enabled=True, hold_time_seconds=HOLD)
+
+        assert manager.evaluate(_readings()) is None
+        assert manager.is_suppression_active is False
+        buffer.record.assert_not_called()
+
+    def test_the_second_transition_still_honours_the_hold(self) -> None:
+        """Only the FIRST observation is seeded; real changes still debounce."""
+        manager = _manager()
+        manager.evaluate(_readings())
+
+        assert manager.evaluate(_readings(lux_below_threshold=True)) == (
+            "should_start_timeout"
+        )
+        assert manager.is_suppression_active is False

--- a/tests/test_managers/test_cloud_suppression_manager.py
+++ b/tests/test_managers/test_cloud_suppression_manager.py
@@ -72,6 +72,20 @@ def _readings(
     )
 
 
+def _primed_manager(logger, *, hold_time_seconds: int) -> CloudSuppressionManager:
+    """Build an enabled manager that already observed its resting (sunny) state.
+
+    The FIRST observation after construction or a config reload is seeded in-line
+    (issue #1238): it is the world as found, not a change, so it commits without
+    starting a hold timer. Every test below is about the SECOND reading — the one
+    that is a genuine transition and therefore the one the hold-time governs.
+    """
+    m = CloudSuppressionManager(logger=logger)
+    m.update_config(enabled=True, hold_time_seconds=hold_time_seconds)
+    m.evaluate(_readings())
+    return m
+
+
 # ---------------------------------------------------------------------------
 # (a) Back-compat: hold=0 + blank release ⇒ resolved bool == raw OR
 # ---------------------------------------------------------------------------
@@ -141,8 +155,7 @@ class TestHoldTimeDebounce:
 
     def test_pending_transition_does_not_flip_and_signals_timer(self, logger):
         """Instantaneous flip with hold>0 keeps state and signals start-timer."""
-        m = CloudSuppressionManager(logger=logger)
-        m.update_config(enabled=True, hold_time_seconds=120)
+        m = _primed_manager(logger, hold_time_seconds=120)
 
         signal = m.evaluate(_readings(is_sunny=False))
         assert signal == "should_start_timeout"
@@ -151,8 +164,7 @@ class TestHoldTimeDebounce:
     @pytest.mark.asyncio
     async def test_revert_before_expiry_cancels_timer(self, logger):
         """If instantaneous reverts before the timer fires, it is cancelled."""
-        m = CloudSuppressionManager(logger=logger)
-        m.update_config(enabled=True, hold_time_seconds=120)
+        m = _primed_manager(logger, hold_time_seconds=120)
 
         assert m.evaluate(_readings(is_sunny=False)) == "should_start_timeout"
         m.start_hold_timeout(AsyncMock())
@@ -167,8 +179,7 @@ class TestHoldTimeDebounce:
     @pytest.mark.asyncio
     async def test_second_evaluate_while_timer_running_does_not_resignal(self, logger):
         """A still-pending transition does not ask to start a second timer."""
-        m = CloudSuppressionManager(logger=logger)
-        m.update_config(enabled=True, hold_time_seconds=120)
+        m = _primed_manager(logger, hold_time_seconds=120)
         assert m.evaluate(_readings(is_sunny=False)) == "should_start_timeout"
         m.start_hold_timeout(AsyncMock())
         # Same instantaneous, timer already running → no new signal.
@@ -188,8 +199,7 @@ class TestTimerExpiry:
     @pytest.mark.asyncio
     async def test_expiry_commits_and_calls_refresh(self, logger):
         """Expiry flips the resolved bool and invokes the refresh callback."""
-        m = CloudSuppressionManager(logger=logger)
-        m.update_config(enabled=True, hold_time_seconds=120)
+        m = _primed_manager(logger, hold_time_seconds=120)
         m.evaluate(_readings(is_sunny=False))
         assert m.is_suppression_active is False
 

--- a/tests/test_managers/test_cloud_suppression_manager.py
+++ b/tests/test_managers/test_cloud_suppression_manager.py
@@ -254,3 +254,50 @@ class TestDisabled:
         """No readings → inactive."""
         assert mgr.evaluate(None) is None
         assert mgr.is_suppression_active is False
+
+
+# ---------------------------------------------------------------------------
+# (g) A transient readings outage re-seeds the debounce (issue #1238)
+# ---------------------------------------------------------------------------
+
+
+class TestReadingsOutage:
+    """``readings is None`` resets, so the next reading is a first sighting again."""
+
+    @pytest.mark.asyncio
+    async def test_outage_during_a_pending_hold_recovers_in_line(self, logger):
+        """Outage → the next valid reading commits without re-arming the hold.
+
+        The outage is what ends the pending transition: ``_reset`` cancels the
+        timer, drops the pending target and forces the resolved bool back to
+        False — it did that before issue #1238 too. The seed only decides what
+        the NEXT valid reading costs, and committing it in-line is the intended
+        recovery: re-arming a full hold there would buy another hold-time of the
+        wrong state after a one-cycle blip. Nothing is swallowed — the pending
+        transition still lands, just sooner.
+        """
+        m = _primed_manager(logger, hold_time_seconds=120)
+
+        assert m.evaluate(_readings(is_sunny=False)) == "should_start_timeout"
+        m.start_hold_timeout(AsyncMock())
+        assert m.is_timeout_running is True
+
+        # One cycle without readings: timer cancelled, resolved back to False.
+        assert m.evaluate(None) is None
+        assert m.is_timeout_running is False
+        assert m.is_suppression_active is False
+
+        # The reading that follows is the world as found → commits in-line.
+        assert m.evaluate(_readings(is_sunny=False)) is None
+        assert m.is_suppression_active is True
+        assert m.is_timeout_running is False
+
+    def test_the_transition_after_an_outage_still_debounces(self, logger):
+        """The re-seed is one-shot — the next genuine change holds again."""
+        m = _primed_manager(logger, hold_time_seconds=120)
+        m.evaluate(None)
+        m.evaluate(_readings(is_sunny=False))  # re-seeded → in-line
+        assert m.is_suppression_active is True
+
+        assert m.evaluate(_readings(is_sunny=True)) == "should_start_timeout"
+        assert m.is_suppression_active is True  # release edge held

--- a/tests/test_managers/test_smoothing_primitives.py
+++ b/tests/test_managers/test_smoothing_primitives.py
@@ -179,3 +179,62 @@ class TestHoldDebouncer:
         d.reset(False)
         d.evaluate(False, hold_time=0)  # no transition
         assert commits == []
+
+
+class TestHoldDebouncerStartupSeed:
+    """``reset(..., seeded=False)`` makes the FIRST observation commit in-line.
+
+    A debounce guards *changes*; the first reading after construction or a config
+    reload is not a change, it is the world as found. Without the seed a reload in
+    the held condition leaves ``resolved`` at the reset value for the whole hold
+    time (issue #1238). Opt-in — every caller that does not ask for it keeps the
+    historical behaviour byte-for-byte.
+    """
+
+    def test_unseeded_first_evaluate_commits_without_a_timer(self, logger):
+        d = HoldDebouncer(logger, label="test")
+        d.reset(False, seeded=False)
+
+        assert d.evaluate(True, hold_time=600) is None
+        assert d.resolved is True
+        assert d.is_timeout_running is False
+
+    def test_second_transition_still_debounces(self, logger):
+        d = HoldDebouncer(logger, label="test")
+        d.reset(False, seeded=False)
+        d.evaluate(True, hold_time=600)
+
+        assert d.evaluate(False, hold_time=600) == "should_start_timeout"
+        assert d.resolved is True  # unchanged pending expiry
+        d.cancel()
+
+    def test_seeding_a_matching_value_fires_no_commit_callback(self, logger):
+        """A startup that finds the reset value records no spurious change."""
+        commits: list[tuple] = []
+        d = HoldDebouncer(
+            logger, label="test", on_commit=lambda p, n: commits.append((p, n))
+        )
+        d.reset(False, seeded=False)
+
+        assert d.evaluate(False, hold_time=600) is None
+        assert d.resolved is False
+        assert commits == []
+
+    def test_reset_defaults_to_seeded_and_is_byte_identical(self, logger):
+        """The default ``reset(initial)`` keeps the pre-#1238 first-cycle debounce."""
+        d = HoldDebouncer(logger, label="test")
+        d.reset(False)
+
+        assert d.evaluate(True, hold_time=600) == "should_start_timeout"
+        assert d.resolved is False
+
+    def test_reseeding_via_reset_re_arms_the_seed(self, logger):
+        """A config reload calls ``reset`` again — the next reading seeds again."""
+        d = HoldDebouncer(logger, label="test")
+        d.reset(False, seeded=False)
+        d.evaluate(True, hold_time=600)
+        assert d.resolved is True
+
+        d.reset(False, seeded=False)
+        assert d.evaluate(True, hold_time=600) is None
+        assert d.resolved is True

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -54,6 +54,7 @@ def _make_options(
     temp_extreme_heat=None,
     extreme_heat_position=None,
     tracking_seasons=frozenset(DEFAULT_TRACKING_SEASONS),
+    cloud_suppression_enabled=False,
 ) -> ClimateOptions:
     return ClimateOptions(
         temp_low=temp_low,
@@ -61,7 +62,7 @@ def _make_options(
         temp_switch=temp_switch,
         transparent_blind=transparent_blind,
         temp_summer_outside=temp_summer_outside,
-        cloud_suppression_enabled=False,
+        cloud_suppression_enabled=cloud_suppression_enabled,
         winter_close_insulation=winter_close_insulation,
         temp_extreme_heat=temp_extreme_heat,
         extreme_heat_position=extreme_heat_position,
@@ -190,6 +191,46 @@ class TestClimateHandlerSmoothedFlags:
         result = self.handler.evaluate(snap)
         # Not summer → transparent blind no longer force-closes; defers to glare.
         assert result is None or result.control_method != ControlMethod.SUMMER
+
+
+class TestClimateHandlerSmoothedLowLight:
+    """_build_climate_data threads snapshot.cloud_suppression_active (issue #1238).
+
+    The resolved cloud-suppression bool already carries the hysteresis latches and
+    the hold-time debounce; the climate LOW_LIGHT branch is the second consumer of
+    the same readings and now reads that answer instead of recomputing it raw.
+    ``None`` when the feature is off keeps every non-user byte-identical.
+    """
+
+    handler = ClimateHandler()
+
+    def _snap(self, *, enabled: bool, resolved: bool):
+        return make_snapshot(
+            cover=_make_blind_cover(),
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(inside_temperature=22.0),
+            climate_options=_make_options(cloud_suppression_enabled=enabled),
+            cloud_suppression_active=resolved,
+        )
+
+    def test_threads_the_resolved_bool_when_cloud_suppression_is_on(self) -> None:
+        for resolved in (True, False):
+            data = self.handler._build_climate_data(
+                self._snap(enabled=True, resolved=resolved)
+            )
+            assert data is not None
+            assert data.low_light_active is resolved
+
+    def test_threads_none_when_cloud_suppression_is_off(self) -> None:
+        """Feature off ⇒ the raw fallback, whatever the snapshot bool happens to say."""
+        for resolved in (True, False):
+            data = self.handler._build_climate_data(
+                self._snap(enabled=False, resolved=resolved)
+            )
+            assert data is not None
+            assert data.low_light_active is None
+            # Raw fallback: readings are sunny and above both thresholds.
+            assert data.is_low_light is False
 
 
 class TestClimateHandlerSummerStrategy:

--- a/tests/test_tracking_seasons.py
+++ b/tests/test_tracking_seasons.py
@@ -73,6 +73,10 @@ def _ctx(
         lux=lux,
         irradiance=irradiance,
         is_sunny=is_sunny,
+        # ``ClimateContext.is_low_light`` delegates to the data object so the
+        # smoothed cloud-suppression bool can override the readings (#1238).
+        # These tests never smooth, so the double supplies the raw OR.
+        is_low_light=(lux or irradiance or not is_sunny),
         winter_close_insulation=winter_close_insulation,
         transparent_blind=transparent_blind,
         # Extreme-heat mode is off in these tests; the shared _TOP_OVERRIDES


### PR DESCRIPTION
## Summary
`cloud_suppression_hold_time`'s debounce only gated `snapshot.cloud_suppression_active`, which exactly one handler reads (`CloudSuppressionHandler`, priority 60). The climate handler's LOW_LIGHT branch at priority 50 evaluated the same lux/irradiance/is-sunny readings raw and unsmoothed, so it moved the cover the instant a threshold was crossed, in the very cycle the "holding 600 seconds" line was logged. The reporter's log shows the pair 16ms apart, and the cover oscillating 10% to 100% to 10% to 100% inside ten minutes while a hold was nominally pending.

I reused the smoothing seam issue #917 established for temperature rather than adding a second timer. `ClimateCoverData` gains `low_light_active` plus an `is_low_light` property mirroring `is_winter`, `ClimateContext.is_low_light` delegates to it so all four rule tables inherit one predicate, and `_build_climate_data` threads `snapshot.cloud_suppression_active` when cloud suppression is enabled. Installs with suppression off thread `None` and are byte-identical.

`HoldDebouncer.reset()` grows a `seeded` keyword so `CloudSuppressionManager` commits its first observation in line. Without it, a reload during cloudy weather would sun-track for the whole hold before low-light engaged, which is a worse bug than the one being closed. `ClimateSmoothingManager` keeps the old behaviour, so the #917 guard suite is untouched.

### Three deliberate behaviour changes
1. **Symmetric hold.** It now applies to the release edge too, so a genuine sun return holds the default for the full hold time before sun tracking resumes.
2. **Trigger set widening.** `cloud_coverage_above_threshold` joins the low-light trigger set. Shadowed by priority 60 in every case except sun outside the field of view, which has its own test. A venetian probe confirms `DefaultHandler` and the climate LOW_LIGHT branch produce identical position and tilt in that state across all four sunset and tilt-limit combinations, so no slats move where nothing moved before.
3. **Hysteresis widening.** A configured `lux_release_threshold` now latches low-light across the release band.

Diagnostics `climate_conditions` gains `is_low_light` and `low_light_smoothed`, since today it shows the raw inputs but not the resolved answer.

Reviewed by a pre-merge audit: no MUST-FIX findings. Two optional findings were applied in the second commit.

Not bundled here: the identical latent seed gap in `ClimateSmoothingManager` from #917, and the hardcoded `"solar"` dispatch label in `coordinator.py` that made the reporter's log misattribute every climate decision to the solar handler. Both deserve their own issues.

## Testing
- ✅ 13381 tests passing (baseline 13346, so 35 new)
- #917 guard suite green and byte-identical: `test_climate_smoothing.py` and `test_climate_smoothing_integration.py` do not appear in the diff
- `ruff` and `black` clean

## Related Issues
Refs #1238