### PR TITLE
fix: measure occupancy timeout expiry from timer start (#1266)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -61,6 +61,7 @@ class MotionManager:
 
         self._timer = TimeoutController(logger, label="motion timeout")
         self._last_motion_time: float | None = None
+        self._timeout_started_at: float | None = None
         self._motion_timeout_active: bool = False
 
     # --- Internal helpers ---
@@ -182,6 +183,25 @@ class MotionManager:
         return self._timer.is_running
 
     @property
+    def timeout_end_time(self) -> dt.datetime | None:
+        """Return when the running no-motion timer will expire, or None.
+
+        Computed from when the timer actually *started* (the clear edge,
+        ``start_motion_timeout``), not from ``last_motion_time`` (the
+        detection edge). Occupancy commonly outlasts the configured
+        timeout, so measuring from detection instead of timer-start
+        publishes an end time that is already in the past the instant the
+        timer starts (issue #1266). Single owner of this formula — callers
+        must not recompute it from ``last_motion_time`` and
+        ``_timeout_seconds``.
+        """
+        if self._timeout_started_at is None:
+            return None
+        return dt.datetime.fromtimestamp(
+            self._timeout_started_at + self._timeout_seconds, dt.UTC
+        )
+
+    @property
     def last_motion_time(self) -> float | None:
         """Return UNIX timestamp of the most recent motion detection, or None."""
         return self._last_motion_time
@@ -214,6 +234,7 @@ class MotionManager:
         had_active = self._motion_timeout_active
         self.cancel_motion_timeout()
         self._last_motion_time = self._now().timestamp()
+        self._timeout_started_at = None
         self._motion_timeout_active = False
         return had_active or had_pending
 
@@ -246,6 +267,7 @@ class MotionManager:
         async def _on_expire() -> None:
             await self._on_motion_timeout_expired(timeout_seconds, refresh_callback)
 
+        self._timeout_started_at = self._now().timestamp()
         self._timer.start(timeout_seconds, _on_expire)
 
     async def _on_motion_timeout_expired(
@@ -279,3 +301,4 @@ class MotionManager:
         if self._timer.is_running:
             self._events.record("motion_timeout_canceled")
         self._timer.cancel()
+        self._timeout_started_at = None

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -873,12 +873,11 @@ def _motion_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
         "motion_timeout_seconds": mgr._timeout_seconds
     }  # noqa: SLF001
 
+    end = mgr.timeout_end_time
+    if end is not None:
+        attrs["motion_timeout_end_time"] = end.isoformat()
+
     if mgr.last_motion_time is not None:
-        if mgr.has_pending_timeout or mgr.is_motion_timeout_active:
-            end_ts = mgr.last_motion_time + mgr._timeout_seconds  # noqa: SLF001
-            attrs["motion_timeout_end_time"] = dt_util.utc_from_timestamp(
-                end_ts
-            ).isoformat()
         attrs["last_motion_time"] = dt_util.utc_from_timestamp(
             mgr.last_motion_time
         ).isoformat()

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1,6 +1,7 @@
 """Tests for motion-based automatic control feature."""
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -920,6 +921,83 @@ def test_motion_status_sensor_attributes_no_data():
     assert attrs == {"motion_timeout_seconds": 300}
     assert "motion_timeout_end_time" not in attrs
     assert "last_motion_time" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_motion_timeout_end_time_measures_from_timer_start():
+    """motion_timeout_end_time is timer-start + timeout, not detection + timeout.
+
+    Regression for issue #1266: ``last_motion_time`` is stamped when occupancy
+    is *detected*, but the no-motion timer starts later, on the *clear* edge.
+    When occupancy outlasts the configured timeout, ``last_motion_time +
+    timeout_seconds`` lands in the past the instant the timer starts, so any
+    consumer deriving "expires in" from it reads "expired" for the whole live
+    countdown. Here occupancy was held for 120s against a 30s timeout, so the
+    old formula would publish an end time 90s in the past; the correct end
+    time is ~30s in the future from when the timer actually started.
+    """
+    mgr = _make_motion_mgr(timeout_seconds=30)
+    now = datetime.now(UTC)
+    mgr._last_motion_time = (now - timedelta(seconds=120)).timestamp()
+
+    mgr.start_motion_timeout(AsyncMock())
+
+    coordinator = MagicMock()
+    coordinator._motion_mgr = mgr
+    sensor = _make_motion_status_sensor(coordinator)
+    attrs = sensor.extra_state_attributes
+
+    end_time = datetime.fromisoformat(attrs["motion_timeout_end_time"])
+    assert end_time > now
+    assert abs((end_time - (now + timedelta(seconds=30))).total_seconds()) < 1
+
+    mgr.cancel_motion_timeout()
+
+
+@pytest.mark.asyncio
+async def test_motion_timeout_end_time_published_without_last_motion_time():
+    """A running timer publishes motion_timeout_end_time even with no detection stamp.
+
+    Regression for issue #1266: today the two attributes share one gate keyed
+    off ``last_motion_time`` (sensor.py:876), so an in-flight timer with no
+    detection stamp on record silently drops the end-time attribute despite
+    the timer being real. The two attributes must be independently gated.
+    """
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=None,
+        timeout_pending=True,
+        timeout_seconds=30,
+    )
+
+    sensor = _make_motion_status_sensor(coordinator)
+    attrs = sensor.extra_state_attributes
+
+    assert "motion_timeout_end_time" in attrs
+    assert "last_motion_time" not in attrs
+
+    coordinator._motion_mgr.cancel_motion_timeout()
+
+
+def test_motion_timeout_end_time_absent_when_no_timer_started():
+    """No motion_timeout_end_time when set_no_motion() fires without ever starting a timer.
+
+    Guards the startup path (no occupancy at HA start): ``set_no_motion()``
+    sets the no-motion flag directly with no timer ever having started, so
+    there is no timer-start timestamp to report an end time from.
+    """
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=None,
+        timeout_active=True,
+        timeout_seconds=30,
+    )
+
+    sensor = _make_motion_status_sensor(coordinator)
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["motion_timeout_seconds"] == 30
+    assert "motion_timeout_end_time" not in attrs
 
 
 def test_motion_status_sensor_no_timestamp_device_class():


### PR DESCRIPTION
## Summary

The `motion_status` sensor derived `motion_timeout_end_time` from `last_motion_time` (the occupancy *detection* stamp) plus the timeout, but the no-occupancy timer starts on the *clear* edge. The published expiry therefore ran early by however long occupancy was continuously held, and read as already expired for the entire live countdown whenever occupancy outlasted the timeout. Reported against a 300 s timeout, where anyone present for more than five minutes made the end time land in the past the instant the timer started.

`MotionManager` now stamps `_timeout_started_at` when the timer starts and owns the end-time formula behind a new `timeout_end_time` property. `sensor.py` publishes that verbatim and gates `last_motion_time` under its own guard, dropping the private `_timeout_seconds` reach. The attribute name and payload shape are unchanged, so the companion card and the sensor migrations need no change.

The occupancy "inversion" in the report was not reproduced: the reporter's two screenshots are two different covers with different sun geometry, and the occupancy tile matches the sensor in both.

## Testing

- ✅ 12274 tests passing

Three new regression tests in `tests/test_motion_control.py` cover: end time measured from timer start (not detection), end time published when `last_motion_time` is unknown but a timer runs, and no end time when no timer ever started. Guards held: `test_motion_status_sensor_no_timestamp_device_class` (#75) and `tests/test_motion_hold_skip.py` (#335).

## Related Issues

Refs #1266

Follow-up (NOT fixed here): issue #1267 tracks the separate config-flow bug where a cleared Motion Template is not saved.