### PR TITLE
fix: occupancy timeout end time, countdown and after expiry (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -61,6 +61,7 @@ class MotionManager:
 
         self._timer = TimeoutController(logger, label="motion timeout")
         self._last_motion_time: float | None = None
+        self._timeout_started_at: float | None = None
         self._motion_timeout_active: bool = False
 
     # --- Internal helpers ---
@@ -182,6 +183,25 @@ class MotionManager:
         return self._timer.is_running
 
     @property
+    def timeout_end_time(self) -> dt.datetime | None:
+        """Return when the running no-motion timer will expire, or None.
+
+        Computed from when the timer actually *started* (the clear edge,
+        ``start_motion_timeout``), not from ``last_motion_time`` (the
+        detection edge). Occupancy commonly outlasts the configured
+        timeout, so measuring from detection instead of timer-start
+        publishes an end time that is already in the past the instant the
+        timer starts (issue #1266). Single owner of this formula — callers
+        must not recompute it from ``last_motion_time`` and
+        ``_timeout_seconds``.
+        """
+        if self._timeout_started_at is None:
+            return None
+        return dt.datetime.fromtimestamp(
+            self._timeout_started_at + self._timeout_seconds, dt.UTC
+        )
+
+    @property
     def last_motion_time(self) -> float | None:
         """Return UNIX timestamp of the most recent motion detection, or None."""
         return self._last_motion_time
@@ -214,6 +234,7 @@ class MotionManager:
         had_active = self._motion_timeout_active
         self.cancel_motion_timeout()
         self._last_motion_time = self._now().timestamp()
+        self._timeout_started_at = None
         self._motion_timeout_active = False
         return had_active or had_pending
 
@@ -246,6 +267,7 @@ class MotionManager:
         async def _on_expire() -> None:
             await self._on_motion_timeout_expired(timeout_seconds, refresh_callback)
 
+        self._timeout_started_at = self._now().timestamp()
         self._timer.start(timeout_seconds, _on_expire)
 
     async def _on_motion_timeout_expired(
@@ -279,3 +301,4 @@ class MotionManager:
         if self._timer.is_running:
             self._events.record("motion_timeout_canceled")
         self._timer.cancel()
+        self._timeout_started_at = None

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -194,6 +194,14 @@ class MotionManager:
         timer starts (issue #1266). Single owner of this formula — callers
         must not recompute it from ``last_motion_time`` and
         ``_timeout_seconds``.
+
+        The backing stamp (``_timeout_started_at``) is live only while a
+        timer is actually counting down. All four exits from that state —
+        ``record_motion_detected``, ``cancel_motion_timeout``,
+        ``set_no_motion``, and the timer firing naturally
+        (``_on_motion_timeout_expired``) — clear it, so this property
+        returns ``None`` rather than a stale past timestamp once the timer
+        is gone, whichever way it left.
         """
         if self._timeout_started_at is None:
             return None
@@ -288,6 +296,11 @@ class MotionManager:
             return
 
         self._motion_timeout_active = True
+        # Timer has fired; nothing is counting down. Clear the stamp like the
+        # other three exits from "timer counting" (record_motion_detected,
+        # cancel_motion_timeout, set_no_motion) so timeout_end_time honors its
+        # own contract instead of returning a past timestamp forever (#1266).
+        self._timeout_started_at = None
         self._logger.info(
             "Motion timeout expired (%s seconds) - using default position",
             timeout_seconds,

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -840,12 +840,11 @@ def _motion_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
         "motion_timeout_seconds": mgr._timeout_seconds
     }  # noqa: SLF001
 
+    end = mgr.timeout_end_time
+    if end is not None:
+        attrs["motion_timeout_end_time"] = end.isoformat()
+
     if mgr.last_motion_time is not None:
-        if mgr.has_pending_timeout or mgr.is_motion_timeout_active:
-            end_ts = mgr.last_motion_time + mgr._timeout_seconds  # noqa: SLF001
-            attrs["motion_timeout_end_time"] = dt_util.utc_from_timestamp(
-                end_ts
-            ).isoformat()
         attrs["last_motion_time"] = dt_util.utc_from_timestamp(
             mgr.last_motion_time
         ).isoformat()

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1000,6 +1000,52 @@ def test_motion_timeout_end_time_absent_when_no_timer_started():
     assert "motion_timeout_end_time" not in attrs
 
 
+@pytest.mark.asyncio
+async def test_motion_timeout_end_time_absent_after_timer_expires():
+    """No motion_timeout_end_time once the real expiry handler has fired.
+
+    Regression for issue #1266 Part B. Unlike ``_make_motion_mgr``'s
+    ``timeout_active=True`` path (which reaches the active state via
+    ``set_no_motion()``, a *different* code path that already clears the
+    stamp), this test drives the real ``_on_motion_timeout_expired`` body —
+    the seam no existing test crosses. ``start_motion_timeout`` stamps
+    ``_timeout_started_at``; the expiry handler must clear it the same way
+    ``record_motion_detected``, ``cancel_motion_timeout``, and
+    ``set_no_motion`` already do, or ``timeout_end_time`` keeps returning a
+    timestamp in the past forever — the sensor attribute publishes an
+    already-expired end time indefinitely ("expires in expired").
+
+    Also guards #122/#75: the ``motion_status`` value string must not move
+    as a side effect of this fix.
+    """
+    hass = MagicMock()
+    state = MagicMock()
+    state.state = "off"
+    hass.states.get.return_value = state
+    logger = MagicMock()
+
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=30)
+
+    mgr.start_motion_timeout(AsyncMock())
+    assert mgr.timeout_end_time is not None  # timer really is pending
+
+    await mgr._on_motion_timeout_expired(30, AsyncMock())
+
+    assert mgr.is_motion_timeout_active is True
+    assert mgr.timeout_end_time is None
+
+    coordinator = MagicMock()
+    coordinator._motion_mgr = mgr
+    type(coordinator).is_motion_detected = property(lambda self: False)
+    sensor = _make_motion_status_sensor(coordinator)
+
+    assert sensor.native_value == "no_motion"
+    assert "motion_timeout_end_time" not in sensor.extra_state_attributes
+
+    mgr.cancel_motion_timeout()  # tear down the still-sleeping background task
+
+
 def test_motion_status_sensor_no_timestamp_device_class():
     """Sensor does not use TIMESTAMP device class (regression for issue #75)."""
     from homeassistant.components.sensor import SensorDeviceClass

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1,6 +1,7 @@
 """Tests for motion-based automatic control feature."""
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -920,6 +921,83 @@ def test_motion_status_sensor_attributes_no_data():
     assert attrs == {"motion_timeout_seconds": 300}
     assert "motion_timeout_end_time" not in attrs
     assert "last_motion_time" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_motion_timeout_end_time_measures_from_timer_start():
+    """motion_timeout_end_time is timer-start + timeout, not detection + timeout.
+
+    Regression for issue #1266: ``last_motion_time`` is stamped when occupancy
+    is *detected*, but the no-motion timer starts later, on the *clear* edge.
+    When occupancy outlasts the configured timeout, ``last_motion_time +
+    timeout_seconds`` lands in the past the instant the timer starts, so any
+    consumer deriving "expires in" from it reads "expired" for the whole live
+    countdown. Here occupancy was held for 120s against a 30s timeout, so the
+    old formula would publish an end time 90s in the past; the correct end
+    time is ~30s in the future from when the timer actually started.
+    """
+    mgr = _make_motion_mgr(timeout_seconds=30)
+    now = datetime.now(UTC)
+    mgr._last_motion_time = (now - timedelta(seconds=120)).timestamp()
+
+    mgr.start_motion_timeout(AsyncMock())
+
+    coordinator = MagicMock()
+    coordinator._motion_mgr = mgr
+    sensor = _make_motion_status_sensor(coordinator)
+    attrs = sensor.extra_state_attributes
+
+    end_time = datetime.fromisoformat(attrs["motion_timeout_end_time"])
+    assert end_time > now
+    assert abs((end_time - (now + timedelta(seconds=30))).total_seconds()) < 1
+
+    mgr.cancel_motion_timeout()
+
+
+@pytest.mark.asyncio
+async def test_motion_timeout_end_time_published_without_last_motion_time():
+    """A running timer publishes motion_timeout_end_time even with no detection stamp.
+
+    Regression for issue #1266: today the two attributes share one gate keyed
+    off ``last_motion_time`` (sensor.py:876), so an in-flight timer with no
+    detection stamp on record silently drops the end-time attribute despite
+    the timer being real. The two attributes must be independently gated.
+    """
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=None,
+        timeout_pending=True,
+        timeout_seconds=30,
+    )
+
+    sensor = _make_motion_status_sensor(coordinator)
+    attrs = sensor.extra_state_attributes
+
+    assert "motion_timeout_end_time" in attrs
+    assert "last_motion_time" not in attrs
+
+    coordinator._motion_mgr.cancel_motion_timeout()
+
+
+def test_motion_timeout_end_time_absent_when_no_timer_started():
+    """No motion_timeout_end_time when set_no_motion() fires without ever starting a timer.
+
+    Guards the startup path (no occupancy at HA start): ``set_no_motion()``
+    sets the no-motion flag directly with no timer ever having started, so
+    there is no timer-start timestamp to report an end time from.
+    """
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=None,
+        timeout_active=True,
+        timeout_seconds=30,
+    )
+
+    sensor = _make_motion_status_sensor(coordinator)
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["motion_timeout_seconds"] == 30
+    assert "motion_timeout_end_time" not in attrs
 
 
 def test_motion_status_sensor_no_timestamp_device_class():


### PR DESCRIPTION
## Summary

Two commits, both parts of the same defect in `MotionManager`'s no-motion timer. Stable needs both: the first alone leaves the reporter's symptom visible, which is exactly what happened when they tested the develop alpha.

**Part A (`c4168bd7`, cherry-picked from #1268).** The sensor computed `motion_timeout_end_time` as `last_motion_time + timeout`, but `last_motion_time` is stamped when occupancy is *detected* while the timer starts when occupancy *clears*. With a 300 second timeout, anyone present longer than five minutes pushed the end time into the past the moment the timer started. `MotionManager` now stamps the timer start and owns the end time; the sensor publishes it verbatim.

**Part B (`60acbb2d`, cherry-picked from #1288).** Part A fixed the countdown window but not the state after it ends. `_on_motion_timeout_expired` set `_motion_timeout_active` without clearing `_timeout_started_at`, so `timeout_end_time` kept returning a past timestamp for the whole no-occupancy state and the card rendered a permanent "expires in expired". The other three exits from "timer counting" (`record_motion_detected`, `cancel_motion_timeout`, `set_no_motion`) already clear the stamp; the expiry path now agrees with them.

The attribute name and shape are unchanged, and the card already renders nothing when the attribute is absent, so no card release is needed.

## Testing
- ✅ 11556 tests passing on main

## Related Issues
Refs #1266