### PR TITLE
fix: let cleared optional config fields round-trip (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1252,6 +1252,12 @@ INTERPOLATION_OPTIONS = vol.Schema(
     }
 )
 
+# Keys in INTERPOLATION_OPTIONS with no schema default. Voluptuous omits them
+# from user_input when cleared, so the flow handler must call
+# optional_entities() with this list before dict.update() -- otherwise the
+# prior custom range survives a clear (issue #1267).
+_INTERP_OPTIONAL_KEYS: list[str] = [CONF_INTERP_START, CONF_INTERP_END]
+
 
 def _get_azimuth_edges(data) -> int:
     """Return the total azimuth sun-acceptance-angle span (fov_left + fov_right)."""
@@ -5747,6 +5753,16 @@ class OptionsFlowHandler(OptionsFlow):
                         "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Blindspot",
                     },
                 )
+            # Fill cleared optional (no-default) fields so a clear round-trips
+            # (issue #1267). left_gamma always carries a schema default= and
+            # is excluded on purpose.
+            self.optional_entities(
+                [
+                    BLIND_SPOT_FORM_KEYS["right_gamma"],
+                    BLIND_SPOT_FORM_KEYS["elevation"],
+                ],
+                user_input,
+            )
             mapped = {
                 slot_keys[sub]: user_input[form_key]
                 for sub, form_key in BLIND_SPOT_FORM_KEYS.items()
@@ -5951,6 +5967,7 @@ class OptionsFlowHandler(OptionsFlow):
     ):
         """Manage motion/occupancy-based control."""
         if user_input is not None:
+            self.optional_entities([CONF_MOTION_TEMPLATE], user_input)
             self.options.update(user_input)
             return await self.async_step_init()
         return self.async_show_form(
@@ -6755,6 +6772,7 @@ class OptionsFlowHandler(OptionsFlow):
                         "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Position"
                     },
                 )
+            self.optional_entities(_INTERP_OPTIONAL_KEYS, user_input)
             self.options.update(user_input)
             return await self.async_step_calibration()
         return self.async_show_form(

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -2577,6 +2577,140 @@ async def test_options_flow_position_step_clears_sunset_pos_when_omitted(
 
 
 # ---------------------------------------------------------------------------
+# Regression: clearing motion template / interp start-end (issue #1267)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_options_flow_motion_override_clears_motion_template(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing the motion template in options flow must set the key to None.
+
+    Regression for issue #1267: submitting an empty motion_override form while
+    a previously-saved CONF_MOTION_TEMPLATE exists must overwrite it with None,
+    not leave the old template in place. Same class of bug as #323/#377 —
+    async_step_motion_override never called optional_entities() at all.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_MOTION_TEMPLATE
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    pre_options = dict(VERTICAL_OPTIONS)
+    pre_options[CONF_MOTION_TEMPLATE] = "{{ true }}"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Motion Template Clear", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=pre_options,
+        entry_id="motion_template_clear_01",
+        title="Motion Template Clear",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "motion_override"}
+    )
+
+    # Submit motion_override form with no template key — simulates the user
+    # clearing the field (voluptuous drops a bare Optional with no default).
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    assert result["type"] in ("form", "menu")
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    assert result["type"] == "create_entry"
+
+    assert (
+        result["data"].get(CONF_MOTION_TEMPLATE) is None
+    ), "CONF_MOTION_TEMPLATE should be None after clearing, not '{{ true }}'"
+
+
+@pytest.mark.integration
+async def test_options_flow_interp_clears_start_end(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing interp start/end in options flow must set both keys to None.
+
+    Regression for issue #1267: submitting the interp form without
+    CONF_INTERP_START/CONF_INTERP_END while prior values are stored must
+    overwrite them with None, not leave the old custom range in place —
+    position_utils.interpolate_position() gates the custom-range remap on
+    both being not-None, so a stranded stale value keeps a custom
+    interpolation range silently active after the user believes it's off.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_INTERP,
+        CONF_INTERP_END,
+        CONF_INTERP_LIST,
+        CONF_INTERP_LIST_NEW,
+        CONF_INTERP_START,
+    )
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    pre_options = dict(VERTICAL_OPTIONS)
+    pre_options[CONF_INTERP] = True
+    pre_options[CONF_INTERP_START] = 10
+    pre_options[CONF_INTERP_END] = 90
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Interp Clear", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=pre_options,
+        entry_id="interp_clear_01",
+        title="Interp Clear",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "calibration"}
+    )
+    assert result["type"] == "menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "interp"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "interp"
+
+    # Submit without CONF_INTERP_START/CONF_INTERP_END — simulates the user
+    # clearing both fields (bare Optionals with no default).
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_INTERP_LIST: [], CONF_INTERP_LIST_NEW: []},
+    )
+    assert result["type"] == "menu"  # async_step_interp forwards to calibration
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "init"}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    assert result["type"] == "create_entry"
+
+    saved = result["data"]
+    assert (
+        saved.get(CONF_INTERP_START) is None
+    ), f"CONF_INTERP_START should be None after clearing, got {saved.get(CONF_INTERP_START)!r}"
+    assert (
+        saved.get(CONF_INTERP_END) is None
+    ), f"CONF_INTERP_END should be None after clearing, got {saved.get(CONF_INTERP_END)!r}"
+
+
+# ---------------------------------------------------------------------------
 # Regression tests for issue #565 — create-flow persistence drop (Defect A & B)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_per_slot_config_pages.py
+++ b/tests/test_per_slot_config_pages.py
@@ -208,6 +208,46 @@ async def test_blind_spot_slot_saves_only_its_slot():
     assert "blind_spot_left_gamma" not in flow.options  # slot-1 untouched
 
 
+@pytest.mark.asyncio
+async def test_blind_spot_slot_clears_elevation_and_right_gamma_when_omitted():
+    """Clearing elevation (or right_gamma, slots 2/3) must round-trip to None.
+
+    Regression for issue #1267: a field omitted from the POST because the
+    user cleared it was simply excluded from ``mapped``, leaving the stale
+    stored value untouched — worse than #323's "overwritten with the wrong
+    thing", here nothing happens at all. ``elevation`` (None = applies at all
+    elevations, const.py) and slot-2/3 ``right_gamma`` are bare Optionals with
+    no schema default, so voluptuous drops them from user_input when blanked.
+    """
+    flow = _options_flow({"fov_left": 45, "fov_right": 45})
+    flow.async_step_blind_spot = AsyncMock(return_value={"type": "menu"})
+
+    await flow.async_step_blind_spot_slot_2(None)
+    await flow.async_step_blind_spot_slot(
+        {
+            BLIND_SPOT_FORM_KEYS["left_gamma"]: 35,
+            BLIND_SPOT_FORM_KEYS["right_gamma"]: -15,
+            BLIND_SPOT_FORM_KEYS["elevation"]: 45,
+        }
+    )
+    assert flow.options["blind_spot_left_gamma_2"] == 35
+    assert flow.options["blind_spot_right_gamma_2"] == -15
+    assert flow.options["blind_spot_elevation_2"] == 45
+
+    # Re-open the slot and submit again with elevation omitted — simulates
+    # the user clearing that single slider.
+    await flow.async_step_blind_spot_slot_2(None)
+    await flow.async_step_blind_spot_slot(
+        {
+            BLIND_SPOT_FORM_KEYS["left_gamma"]: 35,
+            BLIND_SPOT_FORM_KEYS["right_gamma"]: -15,
+        }
+    )
+    assert (
+        flow.options["blind_spot_elevation_2"] is None
+    ), f"blind_spot_elevation_2 should be None after clearing, got {flow.options['blind_spot_elevation_2']!r}"
+
+
 # ---------------------------------------------------------------------------
 # Slot delete — full-key-map clear (issue #1071)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Emptying the Motion Template field in the options flow did not stick. `optional_entities()` fills in `None` for any key voluptuous dropped from `user_input`, and it has to run before `options.update()` for a clear to overwrite anything. `async_step_motion_override` never called it.

Auditing the rest of the options flow for the same defect class turned up two more paths with no clearing call at all:

- `async_step_interp` — `CONF_INTERP_START` / `CONF_INTERP_END`, so a custom interpolation range could not be removed once set.
- `_render_blind_spot_slot` — its `mapped` comprehension skips any key missing from `user_input`, silently dropping a cleared `right_gamma` (slots 2/3) or `elevation` (all slots). `left_gamma` carries a schema default in every slot and is excluded on purpose.

All three reuse the existing `optional_entities()` helper, inserted after each step's validation early-return so a rejected form clears nothing.

## Testing

- ✅ 12587 tests passing on main

## Related Issues

Refs #1267

Cherry-picked from #1270 for a hotfix release. Follow-up from issue #1266 (not fixed here).