### PR TITLE
fix: expose sliding-curtain solar calculation trace

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/sliding_curtain.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/sliding_curtain.py
@@ -18,7 +18,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ...config_types import SlidingCurtainConfig
-from ...const import POSITION_CLOSED, POSITION_OPEN, SlideDirection
+from ...const import (
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    TRACE_KEY_GAMMA_DEG,
+    TRACE_KEY_POSITION_PCT,
+    TRACE_KEY_SOL_ELEV_DEG,
+    SlideDirection,
+)
 from ..sun_geometry import ray_x_at_window_plane
 from .base import AdaptiveGeneralCover
 
@@ -36,6 +43,55 @@ class AdaptiveSlidingCurtainCover(AdaptiveGeneralCover):
 
     sc_config: SlidingCurtainConfig | None = None
 
+    @staticmethod
+    def _empty_interval_trace(status: str) -> dict:
+        """Return the stable trace shape for an interval not yet projected."""
+        return {
+            "projected_point1_x_m": None,
+            "projected_point2_x_m": None,
+            "raw_interval_start_m": None,
+            "raw_interval_end_m": None,
+            "covered_interval_start_m": None,
+            "covered_interval_end_m": None,
+            "covered_width_m": None,
+            "interval_status": status,
+        }
+
+    def _build_trace(
+        self,
+        *,
+        calculation_mode: str,
+        result: float,
+        interval_trace: dict,
+        position_basis: float | None = None,
+        unclamped_position_pct: float | None = None,
+    ) -> dict:
+        """Assemble the raw sliding-curtain solar-calculation trace.
+
+        The key set is shared by binary and shade-area paths so the live
+        ``solar_calculation`` sensor and diagnostics download always expose a
+        predictable shape. Values stay unrounded here; ``DiagnosticsBuilder``
+        applies presentation rounding at the boundary.
+        """
+        sc = self.sc_config
+        trace = {
+            TRACE_KEY_SOL_ELEV_DEG: float(self.sol_elev),
+            TRACE_KEY_GAMMA_DEG: float(self.gamma),
+            TRACE_KEY_POSITION_PCT: float(result),
+            "calculation_mode": calculation_mode,
+            "direct_sun_valid": bool(self.direct_sun_valid),
+            "slide_direction": None if sc is None else str(sc.slide_direction),
+            "window_width_m": None if sc is None else float(sc.window_width),
+            "shade_point1_x_m": None if sc is None else float(sc.point1_x),
+            "shade_point1_y_m": None if sc is None else float(sc.point1_y),
+            "shade_point2_x_m": None if sc is None else float(sc.point2_x),
+            "shade_point2_y_m": None if sc is None else float(sc.point2_y),
+            "position_basis_m": position_basis,
+            "unclamped_position_pct": unclamped_position_pct,
+        }
+        trace.update(interval_trace)
+        return trace
+
     def _endpoint(self) -> int:
         """Return the fully-closed endpoint under direct sun, else fully-open.
 
@@ -45,8 +101,10 @@ class AdaptiveSlidingCurtainCover(AdaptiveGeneralCover):
         """
         return POSITION_CLOSED if self.direct_sun_valid else POSITION_OPEN
 
-    def _covered_interval(self) -> tuple[float, float] | None:
-        """Along-wall interval (metres) the fabric must cover for this sun angle.
+    def _covered_interval_with_trace(
+        self,
+    ) -> tuple[tuple[float, float] | None, dict]:
+        """Return the covered interval and its raw projection trace.
 
         Projects both shade-area points onto the window plane at the current
         ``gamma`` and clamps the resulting span to the window half-width. Returns
@@ -57,24 +115,63 @@ class AdaptiveSlidingCurtainCover(AdaptiveGeneralCover):
         """
         sc = self.sc_config
         if sc is None:
-            return None
+            return None, self._empty_interval_trace("no_config")
         half = sc.window_width / 2.0
         if half <= 0:
-            return None
+            return None, self._empty_interval_trace("invalid_window_width")
         if sc.point1_y <= 0 or sc.point2_y <= 0:
-            return None
+            return None, self._empty_interval_trace("invalid_shade_depth")
 
         xw1 = ray_x_at_window_plane(sc.point1_x, sc.point1_y, self.gamma)
         xw2 = ray_x_at_window_plane(sc.point2_x, sc.point2_y, self.gamma)
         raw_a, raw_b = min(xw1, xw2), max(xw1, xw2)
+        trace = self._empty_interval_trace("covered")
+        trace.update(
+            {
+                "projected_point1_x_m": float(xw1),
+                "projected_point2_x_m": float(xw2),
+                "raw_interval_start_m": float(raw_a),
+                "raw_interval_end_m": float(raw_b),
+            }
+        )
 
         # Entire span past one edge → the ray never enters the opening.
         if raw_b < -half or raw_a > half:
-            return None
+            trace["interval_status"] = "outside_window"
+            return None, trace
 
         a = min(max(raw_a, -half), half)
         b = min(max(raw_b, -half), half)
-        return a, b
+        trace.update(
+            {
+                "covered_interval_start_m": float(a),
+                "covered_interval_end_m": float(b),
+                "covered_width_m": float(b - a),
+            }
+        )
+        return (a, b), trace
+
+    def _covered_interval(self) -> tuple[float, float] | None:
+        """Along-wall interval (metres) the fabric must cover for this sun angle."""
+        interval, _trace = self._covered_interval_with_trace()
+        return interval
+
+    def _position_components(self, a: float, b: float) -> tuple[float, float, float]:
+        """Return clamped percentage, width basis, and raw percentage."""
+        sc = self.sc_config
+        assert sc is not None  # guarded by caller
+        width = sc.window_width
+        half = width / 2.0
+
+        if sc.slide_direction == SlideDirection.LEFT:
+            position_basis = half - b
+        elif sc.slide_direction == SlideDirection.RIGHT:
+            position_basis = half + a
+        else:  # BI_PART (default)
+            position_basis = 2.0 * max(0.0, a, -b)
+
+        unclamped_pct = 100.0 * position_basis / width
+        return min(max(unclamped_pct, 0.0), 100.0), position_basis, unclamped_pct
 
     def _position_for_interval(self, a: float, b: float) -> float:
         """Map a covered along-wall interval to an open percentage (0=closed).
@@ -93,18 +190,8 @@ class AdaptiveSlidingCurtainCover(AdaptiveGeneralCover):
         """
         sc = self.sc_config
         assert sc is not None  # guarded by caller
-        width = sc.window_width
-        half = width / 2.0
-
-        if sc.slide_direction == SlideDirection.LEFT:
-            pct = 100.0 * (half - b) / width
-        elif sc.slide_direction == SlideDirection.RIGHT:
-            pct = 100.0 * (half + a) / width
-        else:  # BI_PART (default)
-            d_near = max(0.0, a, -b)
-            pct = 200.0 * d_near / width
-
-        return min(max(pct, 0.0), 100.0)
+        pct, _position_basis, _unclamped_pct = self._position_components(a, b)
+        return pct
 
     def _solve(self) -> float:
         """Resolve the target (0–100) shared by position and percentage.
@@ -116,13 +203,39 @@ class AdaptiveSlidingCurtainCover(AdaptiveGeneralCover):
         """
         sc = self.sc_config
         if sc is None or not sc.is_area_configured:
-            return self._endpoint()
+            result = self._endpoint()
+            self._last_calc_details = self._build_trace(
+                calculation_mode="binary",
+                result=result,
+                interval_trace=self._empty_interval_trace("not_applicable"),
+            )
+            return result
         if not self.direct_sun_valid:
-            return POSITION_OPEN
-        interval = self._covered_interval()
+            result = POSITION_OPEN
+            self._last_calc_details = self._build_trace(
+                calculation_mode="shade_area",
+                result=result,
+                interval_trace=self._empty_interval_trace("sun_not_direct"),
+            )
+            return result
+        interval, interval_trace = self._covered_interval_with_trace()
         if interval is None:
-            return POSITION_OPEN
-        return self._position_for_interval(*interval)
+            result = POSITION_OPEN
+            self._last_calc_details = self._build_trace(
+                calculation_mode="shade_area",
+                result=result,
+                interval_trace=interval_trace,
+            )
+            return result
+        result, position_basis, unclamped_pct = self._position_components(*interval)
+        self._last_calc_details = self._build_trace(
+            calculation_mode="shade_area",
+            result=result,
+            interval_trace=interval_trace,
+            position_basis=position_basis,
+            unclamped_position_pct=unclamped_pct,
+        )
+        return result
 
     def calculate_position(self) -> float:
         """Target position (0–100); continuous when a shade area is configured."""

--- a/tests/test_solar_calc_trace.py
+++ b/tests/test_solar_calc_trace.py
@@ -6,14 +6,21 @@ assert the stable key set per cover type, the guard-branch flags, and that the
 trace is engine-shaped (not borrowed from a super call).
 """
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
+from custom_components.adaptive_cover_pro.config_types import SlidingCurtainConfig
 from custom_components.adaptive_cover_pro.const import (
     TRACE_KEY_GAMMA_DEG,
     TRACE_KEY_POSITION_PCT,
     TRACE_KEY_SOL_ELEV_DEG,
 )
+from custom_components.adaptive_cover_pro.engine.covers import (
+    AdaptiveSlidingCurtainCover,
+)
+from tests.cover_helpers import make_cover_config, make_daytime_sun_data
 
 
 def _check_native_types(obj, path: str = "root") -> list[str]:
@@ -295,6 +302,116 @@ class TestHorizontalTrace:
         horizontal_cover_instance.calculate_position()
         details = horizontal_cover_instance._last_calc_details
         assert details["clamped_to_awn_length"] is True
+
+
+# ---------------------------------------------------------------------------
+# Sliding curtain (cover_sliding_curtain)
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingCurtainTrace:
+    """AdaptiveSlidingCurtainCover raw trace."""
+
+    _KEYS = {
+        TRACE_KEY_SOL_ELEV_DEG,
+        TRACE_KEY_GAMMA_DEG,
+        TRACE_KEY_POSITION_PCT,
+        "calculation_mode",
+        "direct_sun_valid",
+        "slide_direction",
+        "window_width_m",
+        "shade_point1_x_m",
+        "shade_point1_y_m",
+        "shade_point2_x_m",
+        "shade_point2_y_m",
+        "projected_point1_x_m",
+        "projected_point2_x_m",
+        "raw_interval_start_m",
+        "raw_interval_end_m",
+        "covered_interval_start_m",
+        "covered_interval_end_m",
+        "covered_width_m",
+        "interval_status",
+        "position_basis_m",
+        "unclamped_position_pct",
+    }
+
+    def _curtain(
+        self, sc_config: SlidingCurtainConfig | None
+    ) -> AdaptiveSlidingCurtainCover:
+        return AdaptiveSlidingCurtainCover(
+            logger=MagicMock(),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sun_data=make_daytime_sun_data(),
+            config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
+            sc_config=sc_config,
+        )
+
+    def test_binary_trace_has_numeric_position(self):
+        curtain = self._curtain(None)
+        result = curtain.calculate_percentage()
+        details = curtain._last_calc_details
+
+        assert result == 0
+        assert set(details) == self._KEYS
+        assert details[TRACE_KEY_POSITION_PCT] == 0.0
+        assert details["calculation_mode"] == "binary"
+        assert details["direct_sun_valid"] is True
+        assert details["interval_status"] == "not_applicable"
+        assert not _check_native_types(details)
+
+    def test_shade_area_trace_exposes_interval_and_percentage_basis(self):
+        curtain = self._curtain(
+            SlidingCurtainConfig(
+                enabled=True,
+                slide_direction="bi_part",
+                window_width=2.0,
+                point1_x=0.4,
+                point1_y=3.0,
+                point2_x=0.8,
+                point2_y=3.0,
+            )
+        )
+        result = curtain.calculate_percentage()
+        details = curtain._last_calc_details
+
+        assert result == pytest.approx(40.0)
+        assert set(details) == self._KEYS
+        assert details["calculation_mode"] == "shade_area"
+        assert details["interval_status"] == "covered"
+        assert details["projected_point1_x_m"] == pytest.approx(0.4)
+        assert details["projected_point2_x_m"] == pytest.approx(0.8)
+        assert details["covered_interval_start_m"] == pytest.approx(0.4)
+        assert details["covered_interval_end_m"] == pytest.approx(0.8)
+        assert details["covered_width_m"] == pytest.approx(0.4)
+        assert details["position_basis_m"] == pytest.approx(0.8)
+        assert details["unclamped_position_pct"] == pytest.approx(40.0)
+        assert details[TRACE_KEY_POSITION_PCT] == pytest.approx(40.0)
+        assert not _check_native_types(details)
+
+    def test_off_window_trace_explains_open_result(self):
+        curtain = self._curtain(
+            SlidingCurtainConfig(
+                enabled=True,
+                slide_direction="left",
+                window_width=2.0,
+                point1_x=3.0,
+                point1_y=3.0,
+                point2_x=4.0,
+                point2_y=3.0,
+            )
+        )
+        result = curtain.calculate_position()
+        details = curtain._last_calc_details
+
+        assert result == 100
+        assert set(details) == self._KEYS
+        assert details["interval_status"] == "outside_window"
+        assert details["raw_interval_start_m"] == pytest.approx(3.0)
+        assert details["covered_interval_start_m"] is None
+        assert details[TRACE_KEY_POSITION_PCT] == 100.0
+        assert not _check_native_types(details)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Record `_last_calc_details` for sliding-curtain calculations in both binary and shade-area modes.
- Expose projected points, raw and clamped covered intervals, the percentage basis, and branch status through the existing `solar_calculation` sensor and diagnostics rail.
- Keep a stable, JSON-native trace shape across binary, continuous, guard, and off-window branches.
- Add regression coverage for binary output, continuous centre-parting geometry, and an interval outside the window.

## Why

`solar_calculation` was introduced before `cover_sliding_curtain`. The later sliding-curtain engine returned its result without populating `_last_calc_details`, so `DiagnosticsBuilder` fell back to `position_pct: null` and the sensor stayed `unknown` even while the controller was actively responding to direct sun.

The sliding-curtain wiki also promises covered-interval and percentage intermediates, but the engine did not provide them.

## Impact

This does not change the calculated cover target. The existing interval and percentage formulas are reused; the patch records their inputs, intermediates, result, and branch reason. Sliding-curtain `solar_calculation` entities now expose a numeric state whenever the solar calculation runs.

## Checks

- `pytest -n auto -m 'not perf' -q` on `develop`: 13,488 passed, 33 skipped, 1 xfailed
- Ruff: passed
- Black: passed
- Live Home Assistant validation: config check passed with no errors or warnings
- Live binary sliding curtains under direct sun: changed from `unknown` to `0%` with the expected trace attributes
