### PR TITLE
fix: refuse to estimate solar gain from a non-W/m2 irradiance sensor

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -650,6 +650,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Track position explanation for change detection logging
         self._last_position_explanation: str = ""
 
+        # (entity_id, unit) last WARNED about for the estimated-solar-gain
+        # irradiance-unit refusal (issue #1280 Fix 4), so the once-a-cycle
+        # ``build_diagnostic_data`` call logs a refusal ONCE rather than every
+        # cycle forever. ``None`` means nothing is currently being warned
+        # about — reset there whenever the unit becomes acceptable again, so a
+        # user who fixes and later re-breaks their sensor sees the warning
+        # again instead of it staying silenced from the first occurrence.
+        self._irradiance_unit_warned: tuple[str | None, str | None] | None = None
+
         # Built once and reused for both the command-service construction
         # (position_tolerance) and the late policy.attach below.
         _rc_attach = RuntimeConfig.from_options(self.config_entry.options)
@@ -4947,6 +4956,38 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return GlassArea(derived, AREA_SOURCE_DERIVED)
         return GlassArea(None, AREA_SOURCE_UNKNOWN)
 
+    def _warn_on_unsupported_irradiance_unit(
+        self, *, entity_id: str | None, unit: str | None, unit_ok: bool
+    ) -> None:
+        """Log, at most once per (entity, unit) situation, a gain-sensor refusal.
+
+        ``build_diagnostic_data`` runs once per coordinator cycle, so warning
+        unconditionally would spam the log forever for the lifetime of a
+        misconfigured sensor (issue #1280 Fix 4). Tracks the last situation
+        warned about in ``self._irradiance_unit_warned`` — the same
+        remember-and-compare shape this method's caller already uses for
+        ``_last_position_explanation`` — so a refusal that persists logs once,
+        a refusal that changes unit logs again, and a refusal that clears and
+        later recurs (even with the SAME unit) logs again too, because
+        clearing resets the tracked state to ``None``.
+        """
+        if unit_ok:
+            self._irradiance_unit_warned = None
+            return
+        situation = (entity_id, unit)
+        if situation == self._irradiance_unit_warned:
+            return
+        self.logger.warning(
+            "Irradiance entity %s reports unit '%s' instead of W/m² — the "
+            "estimated solar gain sensor cannot use this reading and is "
+            "reporting unknown. Fix the entity's unit_of_measurement, or "
+            "point the irradiance sensor option at one that reports W/m², "
+            "to restore it.",
+            entity_id,
+            unit,
+        )
+        self._irradiance_unit_warned = situation
+
     def build_diagnostic_data(self) -> dict:
         """Build diagnostic data from current coordinator state."""
         result = self._pipeline_result
@@ -4989,8 +5030,29 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         _irradiance_value = (
             _temp_readings.irradiance_value if _temp_readings is not None else None
         )
+        _irradiance_entity = self.config_entry.options.get(CONF_IRRADIANCE_ENTITY)
         _irradiance_unit = self._climate_provider.read_irradiance_unit(
-            self.config_entry.options.get(CONF_IRRADIANCE_ENTITY)
+            _irradiance_entity
+        )
+        # Irradiance unit gate (#1237 admits the raw value unit-blind; #1280
+        # refuses to hand it to the estimator unless it is W/m²). HA's
+        # ``irradiance`` device class also permits BTU/(h·ft²) (what HA shows
+        # on the imperial unit system); admitting that unconverted would
+        # silently under-report gain by roughly a factor of 3, so a value that
+        # ISN'T W/m² never reaches ``estimate_solar_gain`` at all — no numeric
+        # reading means the gate can never fire, which is why the ``no entity
+        # configured`` and ``entity unavailable`` cases both stay
+        # ``irradiance_unit_ok=True`` (nothing to refuse).
+        _irradiance_unit_ok = (
+            _irradiance_value is None
+            or _irradiance_unit == UnitOfIrradiance.WATTS_PER_SQUARE_METER
+        )
+        # Fix 4 (#1280): surface the refusal in the log, not just silently as
+        # ``unknown`` — at most once per (entity, unit) situation.
+        self._warn_on_unsupported_irradiance_unit(
+            entity_id=_irradiance_entity,
+            unit=_irradiance_unit,
+            unit_ok=_irradiance_unit_ok,
         )
         ctx = DiagnosticContext(
             pos_sun=self.pos_sun,
@@ -5048,22 +5110,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             day_of_year=dt_util.now().timetuple().tm_yday,
             glass_area_m2=_glass_area.area_m2,
             glass_area_source=_glass_area.source,
-            # Irradiance unit gate (#1237 admits the raw value unit-blind;
-            # #1280 refuses to hand it to the estimator unless it is W/m²).
             # A DELIBERATELY SEPARATE HA read from the climate cycle above —
             # see ``ClimateProvider.read_irradiance_unit``'s docstring for why
-            # it cannot live inside that single-read admission path. HA's
-            # ``irradiance`` device class also permits BTU/(h·ft²) (what HA
-            # shows on the imperial unit system); admitting that unconverted
-            # would silently under-report gain by roughly a factor of 3, so a
-            # value that ISN'T W/m² never reaches ``estimate_solar_gain`` at
-            # all — no numeric reading means the gate can never fire, which is
-            # why the ``no entity configured`` and ``entity unavailable``
-            # cases both stay ``irradiance_unit_ok=True`` (nothing to refuse).
-            irradiance_unit_ok=(
-                _irradiance_value is None
-                or _irradiance_unit == UnitOfIrradiance.WATTS_PER_SQUARE_METER
-            ),
+            # it cannot live inside that single-read admission path.
+            # ``_irradiance_unit_ok`` itself is computed above, alongside the
+            # #1280 Fix 4 one-shot warning that shares its verdict.
+            irradiance_unit_ok=_irradiance_unit_ok,
             irradiance_unit=_irradiance_unit,
             config_options=dict(self.config_entry.options),
             resolved_options=dict(self._resolved_options),

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_STOP_COVER,
     STATE_ON,
+    UnitOfIrradiance,
 )
 from homeassistant.core import (
     Event,
@@ -98,6 +99,7 @@ from .const import (
     CONF_INTERP,
     CONF_INVERSE_STATE,
     CONF_INVERSE_TILT,
+    CONF_IRRADIANCE_ENTITY,
     CONF_MANUAL_IGNORE_EXTERNAL,
     CONF_MANUAL_IGNORE_INTERMEDIATE,
     CONF_MANUAL_OVERRIDE_DURATION,
@@ -4984,6 +4986,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         _temp_readings = self._weather_readings
         _glass_area = self.glass_area()
+        _irradiance_value = (
+            _temp_readings.irradiance_value if _temp_readings is not None else None
+        )
+        _irradiance_unit = self._climate_provider.read_irradiance_unit(
+            self.config_entry.options.get(CONF_IRRADIANCE_ENTITY)
+        )
         ctx = DiagnosticContext(
             pos_sun=self.pos_sun,
             cover=self._cover_data,
@@ -5036,12 +5044,27 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # read — and the day of year comes from HA's clock frame, never the
             # host's, so a host in another timezone cannot shift the orbital
             # eccentricity term by a day.
-            irradiance_w_m2=(
-                _temp_readings.irradiance_value if _temp_readings is not None else None
-            ),
+            irradiance_w_m2=_irradiance_value,
             day_of_year=dt_util.now().timetuple().tm_yday,
             glass_area_m2=_glass_area.area_m2,
             glass_area_source=_glass_area.source,
+            # Irradiance unit gate (#1237 admits the raw value unit-blind;
+            # #1280 refuses to hand it to the estimator unless it is W/m²).
+            # A DELIBERATELY SEPARATE HA read from the climate cycle above —
+            # see ``ClimateProvider.read_irradiance_unit``'s docstring for why
+            # it cannot live inside that single-read admission path. HA's
+            # ``irradiance`` device class also permits BTU/(h·ft²) (what HA
+            # shows on the imperial unit system); admitting that unconverted
+            # would silently under-report gain by roughly a factor of 3, so a
+            # value that ISN'T W/m² never reaches ``estimate_solar_gain`` at
+            # all — no numeric reading means the gate can never fire, which is
+            # why the ``no entity configured`` and ``entity unavailable``
+            # cases both stay ``irradiance_unit_ok=True`` (nothing to refuse).
+            irradiance_unit_ok=(
+                _irradiance_value is None
+                or _irradiance_unit == UnitOfIrradiance.WATTS_PER_SQUARE_METER
+            ),
+            irradiance_unit=_irradiance_unit,
             config_options=dict(self.config_entry.options),
             resolved_options=dict(self._resolved_options),
             hass=self.hass,

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -147,6 +147,17 @@ class DiagnosticContext:
     glass_area_m2: float | None = None
     glass_area_source: str = "unknown"
 
+    # Whether the irradiance entity's unit supports the gain estimate (issue
+    # #1280), and the raw unit observed. HA's ``irradiance`` device class also
+    # permits BTU/(h·ft²) — the unit HA presents on the imperial unit system —
+    # and admitting that number as W/m² would silently under-report gain by
+    # roughly a factor of 3. Defaults to ``True`` / ``None`` so every context
+    # built without these (tests, older callers) computes gain exactly as
+    # before; the coordinator is the only production caller that ever sets
+    # ``irradiance_unit_ok=False``.
+    irradiance_unit_ok: bool = True
+    irradiance_unit: str | None = None
+
     # Configuration snapshot
     config_options: dict = field(default_factory=dict)
 
@@ -430,6 +441,7 @@ class DiagnosticsBuilder:
 
         estimate = estimate_solar_gain(
             ghi_w_m2=ctx.irradiance_w_m2,
+            irradiance_unit_ok=ctx.irradiance_unit_ok,
             irradiance_plane=options.get(
                 CONF_IRRADIANCE_PLANE, DEFAULT_IRRADIANCE_PLANE
             ),
@@ -459,6 +471,10 @@ class DiagnosticsBuilder:
             if transmittance is not None and transmittance.shaded_fraction is not None
             else None
         )
+        # The raw unit the irradiance entity reports (issue #1280) — surfaced
+        # even when it IS W/m² so a user auditing the block sees the full
+        # picture, not just the rejection case.
+        block["irradiance_unit"] = ctx.irradiance_unit
         return {"solar_gain": block}
 
     @staticmethod

--- a/custom_components/adaptive_cover_pro/engine/solar_gain.py
+++ b/custom_components/adaptive_cover_pro/engine/solar_gain.py
@@ -91,6 +91,10 @@ NOTE_SUN_TOO_LOW = "sun_too_low"
 UNKNOWN_NO_IRRADIANCE = "no_irradiance"
 UNKNOWN_GLASS_AREA = "glass_area_unknown"
 UNKNOWN_EFFECTIVE_G = "effective_g_unknown"
+# The entity IS configured and reporting a number, but not in a unit this
+# module may consume (issue #1280). Distinct from ``UNKNOWN_NO_IRRADIANCE`` —
+# that one means "nothing to read"; this one means "read it, and refused it".
+UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT = "unsupported_irradiance_unit"
 
 #: ``area_source`` values — where the glazed area came from.
 AREA_SOURCE_CONFIGURED = "configured"  # the user's explicit override
@@ -269,6 +273,7 @@ def estimate_solar_gain(
     effective_g: float | None,
     effective_g_source: str,
     albedo: float = DEFAULT_GROUND_ALBEDO,
+    irradiance_unit_ok: bool = True,
 ) -> SolarGainEstimate:
     """Estimate the instantaneous solar gain through one window, in watts.
 
@@ -277,6 +282,19 @@ def estimate_solar_gain(
     ``window_plane`` mode the reading is already plane-of-array and passes
     straight through — zero transposition error. Otherwise it is treated as
     global horizontal and run through the decomposition + transposition above.
+
+    ``irradiance_unit_ok`` (issue #1280) is the HA-side unit check's verdict:
+    HA's ``irradiance`` device class permits BOTH W/m² and BTU/(h·ft²) — the
+    latter is what HA presents on the imperial unit system — and 1 BTU/(h·ft²)
+    = 3.15 W/m², so admitting that number unconverted would silently
+    under-report gain by roughly a factor of 3. The CHOSEN fix is refusal, not
+    conversion: ``False`` treats ``ghi_w_m2`` as absent for every purpose
+    below — the transposition does not run, the echoed ``ghi_w_m2`` audit
+    field reports ``None`` rather than the mis-labelled number, and
+    ``unknown_reason`` becomes ``unsupported_irradiance_unit`` rather than
+    ``no_irradiance`` — a user who configured a real entity should not be told
+    there is nothing to read. Defaults to ``True`` so every caller that
+    predates this parameter is unaffected.
 
     Below ``MIN_GAIN_SUN_ELEVATION_DEG`` the TRANSPOSED gain is reported as a
     hard ``0.0`` with ``model_note='sun_too_low'``: the true figure is negligible
@@ -293,6 +311,12 @@ def estimate_solar_gain(
 
     Never raises.
     """
+    # A reading in an unsupported unit is treated exactly like no reading at
+    # all for every calculation below (issue #1280) — resolved ONCE, here, so
+    # the transposition, the echoed audit field, and the missing-term branch
+    # all agree instead of three separate call sites re-deriving it.
+    effective_ghi = ghi_w_m2 if irradiance_unit_ok else None
+
     passthrough = irradiance_plane == IRRADIANCE_PLANE_WINDOW
     model = MODEL_PASSTHROUGH if passthrough else MODEL_ISOTROPIC_ERBS
     # The guard protects the ``1/sin h`` decomposition, which only the
@@ -303,17 +327,17 @@ def estimate_solar_gain(
     model_note = NOTE_SUN_TOO_LOW if sun_too_low else None
 
     plane: PlaneIrradiance | None = None
-    if ghi_w_m2 is not None and not sun_too_low:
+    if effective_ghi is not None and not sun_too_low:
         if passthrough:
             plane = PlaneIrradiance(
-                poa_w_m2=max(float(ghi_w_m2), 0.0),
+                poa_w_m2=max(float(effective_ghi), 0.0),
                 dni_w_m2=None,  # type: ignore[arg-type]
                 dhi_w_m2=None,  # type: ignore[arg-type]
                 clearness_index=None,  # type: ignore[arg-type]
             )
         else:
             plane = plane_of_array_irradiance(
-                ghi=float(ghi_w_m2),
+                ghi=float(effective_ghi),
                 sin_elev=math.sin(math.radians(float(sol_elev_deg))),
                 cos_aoi=cos_aoi,
                 plane_tilt_deg=plane_tilt_deg,
@@ -323,7 +347,9 @@ def estimate_solar_gain(
 
     unknown_reason: str | None = None
     gain_w: float | None = None
-    if ghi_w_m2 is None:
+    if not irradiance_unit_ok:
+        unknown_reason = UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+    elif effective_ghi is None:
         unknown_reason = UNKNOWN_NO_IRRADIANCE
     elif area_m2 is None:
         unknown_reason = UNKNOWN_GLASS_AREA
@@ -340,7 +366,7 @@ def estimate_solar_gain(
         dni_w_m2=plane.dni_w_m2 if plane is not None else None,
         dhi_w_m2=plane.dhi_w_m2 if plane is not None else None,
         clearness_index=plane.clearness_index if plane is not None else None,
-        ghi_w_m2=float(ghi_w_m2) if ghi_w_m2 is not None else None,
+        ghi_w_m2=float(effective_ghi) if effective_ghi is not None else None,
         area_m2=float(area_m2) if area_m2 is not None else None,
         area_source=area_source,
         effective_g=float(effective_g) if effective_g is not None else None,

--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -230,6 +230,33 @@ class ClimateProvider:
             ),
         )
 
+    def read_irradiance_unit(self, irradiance_entity: str | None) -> str | None:
+        """Read the irradiance entity's raw ``unit_of_measurement`` (issue #1280).
+
+        HA's ``irradiance`` device class permits BOTH W/m² and BTU/(h·ft²) —
+        the latter is what HA presents on the imperial unit system — and
+        nothing else in this provider ever inspects which one an irradiance
+        entity reports. The estimated-solar-gain sensor is the only consumer
+        that needs to know: it must refuse to compute rather than silently
+        treat a BTU reading as W/m².
+
+        A DELIBERATELY SEPARATE read from :meth:`read` / ``_read_irradiance``.
+        Folding this into the admission path there would either touch the
+        shared threshold read that cloud suppression depends on (forbidden —
+        a BTU-unit user has already calibrated their threshold against the
+        numbers they observe) or read the same entity's state TWICE per
+        cycle, breaking the "exactly one HA read" contract
+        ``_read_irradiance`` documents and its regression test locks. This
+        method makes no interpretation of the unit it returns — that
+        decision belongs to its caller.
+
+        Returns ``None`` when no entity is configured, the entity has no
+        state, or the state carries no ``unit_of_measurement`` attribute.
+        """
+        if irradiance_entity is None:
+            return None
+        return state_attr(self._hass, irradiance_entity, "unit_of_measurement")
+
     def _read_temperature_crossings(
         self,
         *,

--- a/tests/_helpers/diagnostic_coordinator.py
+++ b/tests/_helpers/diagnostic_coordinator.py
@@ -1,0 +1,163 @@
+"""Shared coordinator stub for behavioural ``build_diagnostic_data`` tests.
+
+A ``MagicMock(spec=AdaptiveDataUpdateCoordinator)`` carrying every seam
+``build_diagnostic_data`` reads, with the REAL method bound on top — so the
+code under test is the shipped code, not a re-derivation of it. Mirrors the
+full-method-bind pattern in
+``tests/test_position_explanation.py``'s ``_make_coordinator_mock`` and the
+single-method-bind pattern in ``tests/test_coordinator_solar_transmittance.py``'s
+``_coordinator``.
+
+Used by both the irradiance-unit-gate behavioural tests
+(``tests/test_coordinator_solar_gain.py``, issue #1280) and the real-chain
+estimate tests (``tests/test_sensor_solar_gain.py``) so neither file has to
+hand-roll its own copy of this stub, or re-derive the coordinator's own
+``irradiance_unit_ok`` gate formula to exercise it.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, PropertyMock
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_IRRADIANCE_ENTITY,
+    ControlMethod,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.diagnostics.builder import DiagnosticsBuilder
+from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
+from custom_components.adaptive_cover_pro.engine.solar_gain import GlassArea
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+_DEFAULT_GLASS_AREA = GlassArea(3.0, "derived")
+
+
+def _default_cover() -> SimpleNamespace:
+    """Build a minimal cover stub carrying every attribute the builder reads directly.
+
+    Mirrors ``tests/test_position_explanation.py``'s ``_make_cover()`` — the
+    builder accesses several of these (``valid``, ``valid_elevation``,
+    ``control_state_reason``) without a ``getattr`` default, so a bare
+    ``SimpleNamespace()`` raises ``AttributeError`` partway through ``build()``.
+    """
+    return SimpleNamespace(
+        gamma=10.0,
+        valid=True,
+        valid_elevation=True,
+        is_sun_in_blind_spot=False,
+        direct_sun_valid=True,
+        sunset_valid=False,
+        sunset_pos=None,
+        default=50.0,
+        control_state_reason="Sun in FOV",
+    )
+
+
+def make_diagnostic_coordinator(
+    *,
+    climate_provider: Any,
+    weather_readings: Any,
+    irradiance_entity: str | None,
+    cover_type: str = "cover_blind",
+    glass_area: GlassArea | None = None,
+) -> MagicMock:
+    """Build a coordinator stub that can run the REAL ``build_diagnostic_data``.
+
+    ``climate_provider`` and ``weather_readings`` are the two seams a caller
+    typically varies: a stubbed ``MagicMock`` climate provider (and a bare
+    ``ClimateReadings``) for gate-boolean tests, or a real ``ClimateProvider``
+    bound to a mock ``hass`` (and its own ``.read()`` output) for end-to-end
+    tests that also exercise the HA state read.
+
+    ``glass_area`` and ``solar_transmittance`` are pinned to a fixed derived
+    area and "feature off" respectively — this stub is for exercising the
+    irradiance-unit gate, not the area/transmittance resolution paths, which
+    have their own dedicated coordinator tests.
+    """
+    coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+    coord._diagnostics_builder = DiagnosticsBuilder()
+    coord._last_position_explanation = ""
+    # Issue #1280 Fix 4's one-shot warning state, plus the real (bound) method
+    # that reads/writes it — left auto-mocked, the spec'd MagicMock would
+    # silently no-op the warning instead of running the shipped logic.
+    coord._irradiance_unit_warned = None
+    coord._warn_on_unsupported_irradiance_unit = (
+        AdaptiveDataUpdateCoordinator._warn_on_unsupported_irradiance_unit.__get__(
+            coord
+        )
+    )
+    coord._reason_labels = None
+    coord.logger = MagicMock()
+    coord.pos_sun = [180.0, 45.0]
+    coord._cover_data = _default_cover()
+    coord._position_forecast = None
+    coord._climate_mode = False
+    coord._weather_readings = weather_readings
+    coord._pipeline_result = PipelineResult(
+        position=50,
+        control_method=ControlMethod.SOLAR,
+        reason="sun in FOV — position 50%",
+        raw_calculated_position=50,
+    )
+    type(coord).check_adaptive_time = PropertyMock(return_value=True)
+    type(coord).after_start_time = PropertyMock(return_value=True)
+    type(coord).before_end_time = PropertyMock(return_value=True)
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.start_time_value = None
+    type(coord).automatic_control = PropertyMock(return_value=True)
+    type(coord).last_cover_action = PropertyMock(return_value={})
+    type(coord).last_skipped_action = PropertyMock(return_value={})
+    coord.min_change = 5
+    coord.time_threshold = 2
+    coord._toggles = MagicMock()
+    coord._toggles.switch_mode = False
+    coord._inverse_state = False
+    coord._use_interpolation = False
+    type(coord).state = PropertyMock(return_value=50)
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = (
+        {CONF_IRRADIANCE_ENTITY: irradiance_entity}
+        if irradiance_entity is not None
+        else {}
+    )
+    coord._resolved_options = {}
+    coord._climate_provider = climate_provider
+    coord.hass = MagicMock()
+    coord.hass.config_entries.async_entries.return_value = []
+    coord.hass.states.get.return_value = None
+    type(coord).is_motion_detected = PropertyMock(return_value=True)
+    coord._motion_mgr = MagicMock()
+    coord._motion_mgr._motion_timeout_active = False
+    coord._event_buffer = EventBuffer(maxlen=50)
+    coord.manager = MagicMock()
+    coord.manager.covers = set()
+    coord.manager.manual_control = {}
+    coord.manager.manual_control_time = {}
+    coord.manager.reset_duration = timedelta(hours=2)
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.get_all_entity_state_snapshots.return_value = {}
+    coord.entities = []
+    coord._cover_provider = MagicMock()
+    coord._cover_provider.read_positions.return_value = {}
+    coord._cover_provider.read_all_capabilities.return_value = {}
+    coord._cover_type = cover_type
+    coord._policy = get_policy(cover_type)
+    coord.last_update_success = True
+    coord.last_exception = None
+    coord._last_update_success_time = None
+    coord.update_interval = None
+    coord.glass_area = MagicMock(
+        return_value=glass_area if glass_area is not None else _DEFAULT_GLASS_AREA
+    )
+    coord.solar_transmittance = MagicMock(return_value=None)
+
+    coord.build_diagnostic_data = (
+        AdaptiveDataUpdateCoordinator.build_diagnostic_data.__get__(coord)
+    )
+    return coord

--- a/tests/test_coordinator_solar_gain.py
+++ b/tests/test_coordinator_solar_gain.py
@@ -151,3 +151,38 @@ def test_irradiance_reaches_the_context_from_the_climate_readings() -> None:
 
     source = inspect.getsource(AdaptiveDataUpdateCoordinator.build_diagnostic_data)
     assert "irradiance_value" in source
+
+
+# ---------------------------------------------------------------------------
+# Unsupported irradiance unit (issue #1280) — refuse to compute, don't convert
+# ---------------------------------------------------------------------------
+
+
+def test_the_irradiance_unit_is_read_and_handed_to_the_context() -> None:
+    """The coordinator wires ``read_irradiance_unit`` into the gate fields.
+
+    A SEPARATE call from the per-cycle ``ClimateProvider.read()`` — folding it
+    into ``_read_irradiance`` would either touch the shared threshold read
+    cloud suppression depends on, or read the same entity's state twice per
+    cycle (see ``ClimateProvider.read_irradiance_unit``'s docstring). This
+    only proves the coordinator calls it and forwards both fields; the
+    read/compare behaviour itself is covered where it is unit-testable:
+    ``tests/test_state/test_climate_provider_irradiance_unit.py`` and the
+    real-chain tests in ``tests/test_sensor_solar_gain.py``.
+    """
+    import inspect
+
+    source = inspect.getsource(AdaptiveDataUpdateCoordinator.build_diagnostic_data)
+    assert "read_irradiance_unit(" in source
+    assert "irradiance_unit_ok=" in source
+    assert "irradiance_unit=" in source
+
+
+def test_the_accepted_unit_is_home_assistants_own_constant() -> None:
+    """No hardcoded ``"W/m²"`` literal — HA's own enum is the source of truth."""
+    import inspect
+
+    source = inspect.getsource(AdaptiveDataUpdateCoordinator.build_diagnostic_data)
+    assert "UnitOfIrradiance.WATTS_PER_SQUARE_METER" in source
+    assert '"W/m' not in source
+    assert "'W/m" not in source

--- a/tests/test_coordinator_solar_gain.py
+++ b/tests/test_coordinator_solar_gain.py
@@ -13,15 +13,24 @@ import types
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.const import UnitOfIrradiance
 
 from custom_components.adaptive_cover_pro.const import CONF_GLASS_AREA
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
 from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.engine.solar_gain import (
+    UNKNOWN_NO_IRRADIANCE,
+    UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT,
+)
 from custom_components.adaptive_cover_pro.services.configuration_service import (
     ConfigurationService,
 )
+from custom_components.adaptive_cover_pro.state.climate_provider import (
+    ClimateReadings,
+)
+from tests._helpers.diagnostic_coordinator import make_diagnostic_coordinator
 
 pytestmark = pytest.mark.unit
 
@@ -158,24 +167,88 @@ def test_irradiance_reaches_the_context_from_the_climate_readings() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_the_irradiance_unit_is_read_and_handed_to_the_context() -> None:
-    """The coordinator wires ``read_irradiance_unit`` into the gate fields.
+def _coordinator_with_irradiance(
+    *, irradiance_value: float | None, irradiance_unit: str | None
+) -> MagicMock:
+    """Build a coordinator stub for the gate itself — a STUBBED climate provider.
 
-    A SEPARATE call from the per-cycle ``ClimateProvider.read()`` — folding it
-    into ``_read_irradiance`` would either touch the shared threshold read
-    cloud suppression depends on, or read the same entity's state twice per
-    cycle (see ``ClimateProvider.read_irradiance_unit``'s docstring). This
-    only proves the coordinator calls it and forwards both fields; the
-    read/compare behaviour itself is covered where it is unit-testable:
-    ``tests/test_state/test_climate_provider_irradiance_unit.py`` and the
-    real-chain tests in ``tests/test_sensor_solar_gain.py``.
+    ``read_irradiance_unit`` is stubbed directly rather than driven through a
+    real HA state read (that end-to-end path, including the state read, is
+    covered by ``tests/test_sensor_solar_gain.py``'s real-chain tests): this
+    helper isolates the ONE thing worth pinning here — that
+    ``build_diagnostic_data`` combines the value and the unit into
+    ``irradiance_unit_ok`` correctly, in particular that a missing VALUE
+    (entity unavailable) is never confused with an unsupported UNIT.
     """
-    import inspect
+    climate_provider = MagicMock()
+    climate_provider.read_irradiance_unit.return_value = irradiance_unit
+    weather_readings = ClimateReadings(
+        outside_temperature=None,
+        inside_temperature=None,
+        is_presence=False,
+        is_sunny=False,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+        irradiance_value=irradiance_value,
+    )
+    return make_diagnostic_coordinator(
+        climate_provider=climate_provider,
+        weather_readings=weather_readings,
+        irradiance_entity="sensor.solar",
+    )
 
-    source = inspect.getsource(AdaptiveDataUpdateCoordinator.build_diagnostic_data)
-    assert "read_irradiance_unit(" in source
-    assert "irradiance_unit_ok=" in source
-    assert "irradiance_unit=" in source
+
+def test_a_missing_value_reports_no_irradiance_even_with_an_unsupported_unit() -> None:
+    """The short-circuit this whole fix hinges on.
+
+    An irradiance sensor that has gone momentarily ``unavailable`` reports NO
+    value — but ``read_irradiance_unit`` still answers with whatever unit it
+    last carried (HA does not clear ``unit_of_measurement`` just because the
+    state went unavailable). Without the ``_irradiance_value is None``
+    short-circuit in ``build_diagnostic_data``, a BTU-configured sensor going
+    briefly unavailable would flip from "nothing to read" to "refused" on
+    every such blip. THIS is the case the audit proved the old test suite
+    never actually exercised.
+    """
+    coord = _coordinator_with_irradiance(
+        irradiance_value=None, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    diag = coord.build_diagnostic_data()
+    assert diag["solar_gain"]["unknown_reason"] == UNKNOWN_NO_IRRADIANCE
+
+
+def test_a_missing_value_reports_no_irradiance_with_a_supported_unit_too() -> None:
+    """Regression guard: the ordinary 'nothing configured/available' path."""
+    coord = _coordinator_with_irradiance(
+        irradiance_value=None,
+        irradiance_unit=UnitOfIrradiance.WATTS_PER_SQUARE_METER,
+    )
+    diag = coord.build_diagnostic_data()
+    assert diag["solar_gain"]["unknown_reason"] == UNKNOWN_NO_IRRADIANCE
+
+
+def test_a_present_value_in_an_unsupported_unit_is_refused() -> None:
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    diag = coord.build_diagnostic_data()
+    assert diag["solar_gain"]["unknown_reason"] == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+    assert diag["solar_gain"]["ghi_w_m2"] is None
+    assert diag["solar_gain"]["irradiance_unit"] == "BTU/(h⋅ft²)"
+
+
+def test_a_present_value_in_the_supported_unit_computes_a_real_gain() -> None:
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0,
+        irradiance_unit=UnitOfIrradiance.WATTS_PER_SQUARE_METER,
+    )
+    diag = coord.build_diagnostic_data()
+    assert diag["solar_gain"]["unknown_reason"] is None
+    assert diag["solar_gain"]["gain_w"] is not None
+    assert (
+        diag["solar_gain"]["irradiance_unit"] == UnitOfIrradiance.WATTS_PER_SQUARE_METER
+    )
 
 
 def test_the_accepted_unit_is_home_assistants_own_constant() -> None:
@@ -186,3 +259,106 @@ def test_the_accepted_unit_is_home_assistants_own_constant() -> None:
     assert "UnitOfIrradiance.WATTS_PER_SQUARE_METER" in source
     assert '"W/m' not in source
     assert "'W/m" not in source
+
+
+# ---------------------------------------------------------------------------
+# ⚠️ The refusal is logged, exactly once per (entity, unit) situation
+# (issue #1280 Fix 4) — a user must not have to open the entity's attributes
+# to discover why the gain sensor reports ``unknown``, but
+# ``build_diagnostic_data`` runs every cycle, so an unconditional warning
+# would spam the log forever.
+# ---------------------------------------------------------------------------
+
+
+def test_no_warning_on_the_healthy_metric_path() -> None:
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0,
+        irradiance_unit=UnitOfIrradiance.WATTS_PER_SQUARE_METER,
+    )
+    coord.build_diagnostic_data()
+    coord.logger.warning.assert_not_called()
+
+
+def test_no_warning_when_no_value_is_available() -> None:
+    """A momentarily-unavailable sensor is not itself refused — no warning."""
+    coord = _coordinator_with_irradiance(
+        irradiance_value=None, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    coord.build_diagnostic_data()
+    coord.logger.warning.assert_not_called()
+
+
+def test_warns_once_naming_the_entity_and_the_unit() -> None:
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    coord.build_diagnostic_data()
+    coord.logger.warning.assert_called_once()
+    message = (
+        coord.logger.warning.call_args[0][0] % coord.logger.warning.call_args[0][1:]
+    )
+    assert "sensor.solar" in message
+    assert "BTU/(h⋅ft²)" in message
+    assert "unknown" in message
+
+
+def test_does_not_repeat_for_an_identical_refusal_every_cycle() -> None:
+    """The whole point: a persistent misconfiguration logs ONCE, not forever."""
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    coord.build_diagnostic_data()
+    coord.build_diagnostic_data()
+    coord.build_diagnostic_data()
+    coord.logger.warning.assert_called_once()
+
+
+def test_warns_again_when_the_unsupported_unit_changes() -> None:
+    """A different unsupported unit is a NEW situation — it must be reported."""
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    coord.build_diagnostic_data()
+    coord._climate_provider.read_irradiance_unit.return_value = "cd"
+    coord.build_diagnostic_data()
+    assert coord.logger.warning.call_count == 2
+
+
+def test_warns_again_after_the_refusal_clears_and_recurs() -> None:
+    """Fix, then re-break: the user must see the warning again, not silence."""
+    coord = _coordinator_with_irradiance(
+        irradiance_value=600.0, irradiance_unit="BTU/(h⋅ft²)"
+    )
+    coord.build_diagnostic_data()
+    assert coord.logger.warning.call_count == 1
+
+    # The unit becomes acceptable — refusal clears.
+    coord._climate_provider.read_irradiance_unit.return_value = (
+        UnitOfIrradiance.WATTS_PER_SQUARE_METER
+    )
+    coord.build_diagnostic_data()
+    assert coord.logger.warning.call_count == 1
+
+    # Same unsupported unit as before, but the refusal recurred — must warn again.
+    coord._climate_provider.read_irradiance_unit.return_value = "BTU/(h⋅ft²)"
+    coord.build_diagnostic_data()
+    assert coord.logger.warning.call_count == 2
+
+
+def test_no_warning_when_no_entity_is_configured() -> None:
+    coord = make_diagnostic_coordinator(
+        climate_provider=MagicMock(read_irradiance_unit=MagicMock(return_value=None)),
+        weather_readings=ClimateReadings(
+            outside_temperature=None,
+            inside_temperature=None,
+            is_presence=False,
+            is_sunny=False,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            cloud_coverage_above_threshold=False,
+            irradiance_value=None,
+        ),
+        irradiance_entity=None,
+    )
+    coord.build_diagnostic_data()
+    coord.logger.warning.assert_not_called()

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -2198,6 +2198,7 @@ class TestSolarGainDiagnostics:
         "position_pct",
         "position_source",
         "shaded_fraction",
+        "irradiance_unit",
     }
 
     # -- presence -----------------------------------------------------------
@@ -2392,3 +2393,75 @@ class TestSolarGainDiagnostics:
         block = builder.build(_gain_ctx(cover=None))[0]["solar_gain"]
         assert block["gain_w"] is not None
         assert block["cos_aoi"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Unsupported irradiance unit (issue #1280) — refuse to compute, don't convert
+# ---------------------------------------------------------------------------
+
+
+class TestSolarGainIrradianceUnitGate:
+    """``ctx.irradiance_unit_ok`` decides whether ``ctx.irradiance_w_m2`` reaches
+    the estimator at all.
+
+    ``irradiance_unit_ok`` defaults to ``True`` so every context built before
+    this fix existed — including every other test in ``TestSolarGainDiagnostics``
+    above, none of which set it — keeps computing gain exactly as before.
+    """
+
+    def test_defaults_to_admitting_the_reading(self, builder: DiagnosticsBuilder):
+        block = builder.build(_gain_ctx())[0]["solar_gain"]
+        assert block["unknown_reason"] is None
+        assert block["ghi_w_m2"] == pytest.approx(700.0)
+
+    def test_an_unsupported_unit_is_refused(self, builder: DiagnosticsBuilder):
+        from custom_components.adaptive_cover_pro.engine.solar_gain import (
+            UNKNOWN_NO_IRRADIANCE,
+            UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT,
+        )
+
+        block = builder.build(
+            _gain_ctx(irradiance_unit_ok=False, irradiance_unit="BTU/(h⋅ft²)")
+        )[0]["solar_gain"]
+        assert block["gain_w"] is None
+        assert block["unknown_reason"] == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+        assert block["unknown_reason"] != UNKNOWN_NO_IRRADIANCE
+
+    def test_an_absent_unit_takes_the_same_refusal_path(
+        self, builder: DiagnosticsBuilder
+    ):
+        from custom_components.adaptive_cover_pro.engine.solar_gain import (
+            UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT,
+        )
+
+        block = builder.build(
+            _gain_ctx(irradiance_unit_ok=False, irradiance_unit=None)
+        )[0]["solar_gain"]
+        assert block["unknown_reason"] == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+
+    def test_the_raw_reading_does_not_leak_into_the_audit_trail(
+        self, builder: DiagnosticsBuilder
+    ):
+        block = builder.build(_gain_ctx(irradiance_unit_ok=False))[0]["solar_gain"]
+        assert block["ghi_w_m2"] is None
+
+    def test_the_observed_unit_is_surfaced_for_audit(self, builder: DiagnosticsBuilder):
+        block = builder.build(
+            _gain_ctx(irradiance_unit_ok=False, irradiance_unit="BTU/(h⋅ft²)")
+        )[0]["solar_gain"]
+        assert block["irradiance_unit"] == "BTU/(h⋅ft²)"
+
+    def test_the_unit_is_surfaced_even_when_supported(
+        self, builder: DiagnosticsBuilder
+    ):
+        block = builder.build(
+            _gain_ctx(irradiance_unit_ok=True, irradiance_unit="W/m²")
+        )[0]["solar_gain"]
+        assert block["irradiance_unit"] == "W/m²"
+
+    def test_the_no_entity_configured_case_is_unaffected(
+        self, builder: DiagnosticsBuilder
+    ):
+        """The gate is orthogonal to the existing entity-not-configured guard."""
+        diag, _ = builder.build(_gain_ctx(config_options={}))
+        assert "solar_gain" not in diag

--- a/tests/test_engine/test_solar_gain.py
+++ b/tests/test_engine/test_solar_gain.py
@@ -41,6 +41,7 @@ from custom_components.adaptive_cover_pro.engine.solar_gain import (
     UNKNOWN_EFFECTIVE_G,
     UNKNOWN_GLASS_AREA,
     UNKNOWN_NO_IRRADIANCE,
+    UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT,
     SolarGainEstimate,
     erbs_diffuse_fraction,
     estimate_solar_gain,
@@ -572,3 +573,63 @@ class TestEstimateSolarGain:
         est = _estimate(ghi_w_m2=713.7, area_m2=2.37, effective_g=0.583)
         assert est.gain_w != round(est.gain_w)
         assert est.poa_w_m2 != round(est.poa_w_m2, 3)
+
+
+# ---------------------------------------------------------------------------
+# Unsupported irradiance unit (issue #1280) — refuse to compute, don't convert
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedIrradianceUnit:
+    """``irradiance_unit_ok=False`` refuses the reading rather than converting it.
+
+    HA's ``irradiance`` device class permits BTU/(h·ft²) as well as W/m² — the
+    unit HA presents on the imperial unit system. 1 BTU/(h·ft²) = 3.15 W/m², so
+    admitting that number as if it were W/m² would silently under-report gain
+    by roughly a factor of 3. Issue #1280's chosen fix is refusal, never
+    conversion, so this parameter only ever nulls the reading out.
+    """
+
+    def test_defaults_to_admitting_the_reading(self) -> None:
+        """Opt-in: every caller that predates this fix is unaffected."""
+        est = _estimate()
+        assert est.unknown_reason is None
+        assert est.gain_w == pytest.approx(3.0 * est.poa_w_m2 * 0.55)
+
+    def test_an_unsupported_unit_is_refused(self) -> None:
+        est = _estimate(irradiance_unit_ok=False)
+        assert est.gain_w is None
+        assert est.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+        assert est.unknown_reason != UNKNOWN_NO_IRRADIANCE
+
+    def test_the_raw_reading_is_not_leaked_into_the_audit_trail(self) -> None:
+        """A mis-unit number must not appear under a field labelled W/m²."""
+        est = _estimate(irradiance_unit_ok=False, ghi_w_m2=190.0)
+        assert est.ghi_w_m2 is None
+        assert est.poa_w_m2 is None
+        assert est.dni_w_m2 is None
+        assert est.dhi_w_m2 is None
+
+    def test_unsupported_unit_outranks_every_other_missing_term(self) -> None:
+        """One reason, and it names the unit problem first."""
+        est = _estimate(
+            irradiance_unit_ok=False,
+            area_m2=None,
+            area_source=AREA_SOURCE_UNKNOWN,
+            effective_g=None,
+            effective_g_source="unknown",
+        )
+        assert est.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+
+    def test_a_supported_unit_computes_gain_exactly_as_before(self) -> None:
+        """Explicit True is byte-identical to the default — the regression guard."""
+        est_default = _estimate()
+        est_explicit = _estimate(irradiance_unit_ok=True)
+        assert est_explicit.gain_w == pytest.approx(est_default.gain_w)
+        assert est_explicit.unknown_reason is None
+
+    def test_the_sun_too_low_zero_requires_an_admitted_reading(self) -> None:
+        """The 'sun too low' hard zero only applies once a reading is ADMITTED."""
+        est = _estimate(irradiance_unit_ok=False, sol_elev_deg=1.0)
+        assert est.gain_w is None
+        assert est.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -844,6 +844,8 @@ class TestPositionExplanationChangeDetection:
         coord.config_entry = MagicMock()
         coord.config_entry.options = {}
         coord._resolved_options = {}
+        coord._climate_provider = MagicMock()
+        coord._climate_provider.read_irradiance_unit.return_value = None
         coord.hass = MagicMock()
         coord.hass.config_entries.async_entries.return_value = []
         coord.hass.states.get.return_value = None

--- a/tests/test_sensor_solar_gain.py
+++ b/tests/test_sensor_solar_gain.py
@@ -21,11 +21,17 @@ import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfPower
 
+from homeassistant.const import UnitOfIrradiance
+
 from custom_components.adaptive_cover_pro.diagnostics.builder import (
     DiagnosticContext,
     DiagnosticsBuilder,
 )
-from custom_components.adaptive_cover_pro.engine.solar_gain import estimate_solar_gain
+from custom_components.adaptive_cover_pro.engine.solar_gain import (
+    UNKNOWN_NO_IRRADIANCE,
+    UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT,
+    estimate_solar_gain,
+)
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 from custom_components.adaptive_cover_pro.state.climate_provider import ClimateProvider
 from custom_components.adaptive_cover_pro.const import (
@@ -342,3 +348,140 @@ def test_a_non_finite_reading_reports_unknown_instead_of_crashing_the_sensor():
         effective_g_source="preset",
     )
     assert _spec().value_fn(_stub_sensor(asdict(estimate))) is None
+
+
+# ---------------------------------------------------------------------------
+# ⚠️ Irradiance unit (issue #1280) — the whole chain, end to end
+#
+# HA's ``irradiance`` device class permits BOTH W/m² and BTU/(h·ft²) — the
+# latter is what HA presents on the imperial unit system — and nothing
+# upstream of this fix ever checked which one an irradiance entity reports.
+# 1 BTU/(h·ft²) = 3.15 W/m², so admitting a BTU reading as W/m² silently
+# under-reports gain by roughly a factor of 3. The chosen fix is REFUSAL, not
+# conversion: an unsupported (or absent) unit must produce ``unknown`` with a
+# reason distinct from "no entity configured".
+#
+# These tests drive the REAL glue the coordinator uses: a ``ClimateProvider``
+# read for the magnitude (unit-blind, exactly as issue #1237 left it) plus its
+# SEPARATE ``read_irradiance_unit`` for the unit, combined via the same
+# ``value is None or unit == WATTS_PER_SQUARE_METER`` formula
+# ``AdaptiveDataUpdateCoordinator.build_diagnostic_data`` uses (locked by
+# ``tests/test_coordinator_solar_gain.py``'s source-inspection tests), then
+# handed to the pure estimator.
+# ---------------------------------------------------------------------------
+
+
+def _mock_irradiance_state(state: str, unit: str | None):
+    s = MagicMock()
+    s.entity_id = "sensor.solar"
+    s.state = state
+    s.attributes = {"unit_of_measurement": unit} if unit is not None else {}
+    return s
+
+
+def _real_chain_estimate(
+    *, entity: str | None, state: str | None = None, unit: str | None = None
+):
+    """Reproduce the coordinator's exact irradiance→gain glue, end to end."""
+    hass = MagicMock()
+    hass.states.get.return_value = (
+        _mock_irradiance_state(state, unit) if entity is not None else None
+    )
+
+    provider = ClimateProvider(hass=hass, logger=MagicMock())
+    readings = provider.read(
+        use_irradiance=True,
+        irradiance_entity=entity,
+        irradiance_threshold=300,
+    )
+    observed_unit = provider.read_irradiance_unit(entity)
+    unit_ok = (
+        readings.irradiance_value is None
+        or observed_unit == UnitOfIrradiance.WATTS_PER_SQUARE_METER
+    )
+    estimate = estimate_solar_gain(
+        ghi_w_m2=readings.irradiance_value,
+        irradiance_unit_ok=unit_ok,
+        irradiance_plane=IRRADIANCE_PLANE_HORIZONTAL,
+        sol_elev_deg=45.0,
+        cos_aoi=0.8,
+        plane_tilt_deg=VERTICAL_GLASS_PITCH_DEG,
+        day_of_year=172,
+        area_m2=3.0,
+        area_source="derived",
+        effective_g=0.55,
+        effective_g_source="preset",
+    )
+    return readings, estimate
+
+
+def test_a_metric_reading_computes_gain_exactly_as_before():
+    """Regression guard: W/m² is the shipped, unaffected happy path."""
+    readings, estimate = _real_chain_estimate(
+        entity="sensor.solar", state="600", unit="W/m²"
+    )
+    assert readings.irradiance_value == pytest.approx(600.0)
+    assert estimate.unknown_reason is None
+    assert estimate.gain_w is not None
+    assert _spec().value_fn(_stub_sensor(asdict(estimate))) is not None
+
+
+def test_an_imperial_reading_is_refused_not_converted():
+    """The BTU number is NOT silently divided by 3 — it is refused outright."""
+    readings, estimate = _real_chain_estimate(
+        entity="sensor.solar", state="190", unit="BTU/(h⋅ft²)"
+    )
+    # The state-layer read stays unit-blind (issue #1237's own contract) —
+    # only the GAIN estimator refuses the number.
+    assert readings.irradiance_value == pytest.approx(190.0)
+    assert estimate.gain_w is None
+    assert estimate.ghi_w_m2 is None
+    assert estimate.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+    assert estimate.unknown_reason != UNKNOWN_NO_IRRADIANCE
+    assert _spec().value_fn(_stub_sensor(asdict(estimate))) is None
+
+
+def test_an_absent_unit_takes_the_same_refusal_path():
+    """A sensor with no ``unit_of_measurement`` at all is treated the same way."""
+    readings, estimate = _real_chain_estimate(
+        entity="sensor.solar", state="612.5", unit=None
+    )
+    assert readings.irradiance_value == pytest.approx(612.5)
+    assert estimate.gain_w is None
+    assert estimate.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+
+
+def test_no_entity_configured_still_reports_no_irradiance():
+    """Regression guard: the pre-existing 'nothing configured' path is unchanged."""
+    readings, estimate = _real_chain_estimate(entity=None)
+    assert readings.irradiance_value is None
+    assert estimate.gain_w is None
+    assert estimate.unknown_reason == UNKNOWN_NO_IRRADIANCE
+
+
+def test_cloud_suppression_threshold_is_unaffected_by_an_imperial_unit():
+    """The guard that proves the shared threshold path was never touched.
+
+    Cloud suppression compares the raw number against a user-tuned threshold —
+    a BTU-unit user has already calibrated that threshold against the numbers
+    they observe, so this must produce IDENTICAL booleans regardless of unit.
+    """
+
+    def _threshold_reading(unit: str | None):
+        hass = MagicMock()
+        hass.states.get.return_value = _mock_irradiance_state("250", unit)
+        provider = ClimateProvider(hass=hass, logger=MagicMock())
+        return provider.read(
+            use_irradiance=True,
+            irradiance_entity="sensor.solar",
+            irradiance_threshold=300,
+        )
+
+    metric = _threshold_reading("W/m²")
+    imperial = _threshold_reading("BTU/(h⋅ft²)")
+    absent = _threshold_reading(None)
+
+    for readings in (metric, imperial, absent):
+        assert readings.irradiance_below_threshold is True
+        assert readings.irradiance_release_cleared is False
+        assert readings.irradiance_value == pytest.approx(250.0)

--- a/tests/test_sensor_solar_gain.py
+++ b/tests/test_sensor_solar_gain.py
@@ -39,6 +39,7 @@ from custom_components.adaptive_cover_pro.const import (
     IRRADIANCE_PLANE_HORIZONTAL,
     VERTICAL_GLASS_PITCH_DEG,
 )
+from tests._helpers.diagnostic_coordinator import make_diagnostic_coordinator
 
 pytestmark = pytest.mark.unit
 
@@ -363,11 +364,14 @@ def test_a_non_finite_reading_reports_unknown_instead_of_crashing_the_sensor():
 #
 # These tests drive the REAL glue the coordinator uses: a ``ClimateProvider``
 # read for the magnitude (unit-blind, exactly as issue #1237 left it) plus its
-# SEPARATE ``read_irradiance_unit`` for the unit, combined via the same
-# ``value is None or unit == WATTS_PER_SQUARE_METER`` formula
-# ``AdaptiveDataUpdateCoordinator.build_diagnostic_data`` uses (locked by
-# ``tests/test_coordinator_solar_gain.py``'s source-inspection tests), then
-# handed to the pure estimator.
+# SEPARATE ``read_irradiance_unit`` for the unit, combined by actually calling
+# ``AdaptiveDataUpdateCoordinator.build_diagnostic_data`` through a coordinator
+# stub — not by re-deriving its ``value is None or unit == WATTS_PER_SQUARE_METER``
+# gate formula here. A hand-rolled second copy of that formula is exactly what
+# let the #1280 audit delete the coordinator's short-circuit unnoticed: this
+# file's own test suite kept passing because it was checking its OWN copy of
+# the rule, not the coordinator's. See ``tests/test_coordinator_solar_gain.py``
+# for the dedicated gate-boolean tests that pin the short-circuit itself.
 # ---------------------------------------------------------------------------
 
 
@@ -382,7 +386,21 @@ def _mock_irradiance_state(state: str, unit: str | None):
 def _real_chain_estimate(
     *, entity: str | None, state: str | None = None, unit: str | None = None
 ):
-    """Reproduce the coordinator's exact irradiance→gain glue, end to end."""
+    """Reproduce the coordinator's exact irradiance→gain glue, end to end.
+
+    A real ``ClimateProvider`` reads the magnitude and (separately) the unit
+    from a mocked HA state, exactly as the coordinator does; the combination
+    of the two into ``irradiance_unit_ok`` is then exercised by calling the
+    REAL ``build_diagnostic_data`` through a coordinator stub, so this test
+    can never drift from what the coordinator actually computes.
+
+    ``entity=None`` is the one exception: with no entity configured, the
+    ``solar_gain`` block is gated off entirely at the diagnostics layer (see
+    ``test_gated_on_the_irradiance_entity``) — there would be no block to
+    inspect. That case exercises the pure estimator directly instead, with
+    ``irradiance_unit_ok`` hardcoded True — the coordinator's own docstring
+    on the gate documents this as the trivial, nothing-to-refuse case.
+    """
     hass = MagicMock()
     hass.states.get.return_value = (
         _mock_irradiance_state(state, unit) if entity is not None else None
@@ -394,69 +412,76 @@ def _real_chain_estimate(
         irradiance_entity=entity,
         irradiance_threshold=300,
     )
-    observed_unit = provider.read_irradiance_unit(entity)
-    unit_ok = (
-        readings.irradiance_value is None
-        or observed_unit == UnitOfIrradiance.WATTS_PER_SQUARE_METER
+
+    if entity is None:
+        estimate = estimate_solar_gain(
+            ghi_w_m2=readings.irradiance_value,
+            irradiance_unit_ok=True,
+            irradiance_plane=IRRADIANCE_PLANE_HORIZONTAL,
+            sol_elev_deg=45.0,
+            cos_aoi=0.8,
+            plane_tilt_deg=VERTICAL_GLASS_PITCH_DEG,
+            day_of_year=172,
+            area_m2=3.0,
+            area_source="derived",
+            effective_g=0.55,
+            effective_g_source="preset",
+        )
+        return readings, asdict(estimate)
+
+    coord = make_diagnostic_coordinator(
+        climate_provider=provider,
+        weather_readings=readings,
+        irradiance_entity=entity,
     )
-    estimate = estimate_solar_gain(
-        ghi_w_m2=readings.irradiance_value,
-        irradiance_unit_ok=unit_ok,
-        irradiance_plane=IRRADIANCE_PLANE_HORIZONTAL,
-        sol_elev_deg=45.0,
-        cos_aoi=0.8,
-        plane_tilt_deg=VERTICAL_GLASS_PITCH_DEG,
-        day_of_year=172,
-        area_m2=3.0,
-        area_source="derived",
-        effective_g=0.55,
-        effective_g_source="preset",
-    )
-    return readings, estimate
+    diagnostics = coord.build_diagnostic_data()
+    return readings, diagnostics.get("solar_gain", {})
 
 
 def test_a_metric_reading_computes_gain_exactly_as_before():
     """Regression guard: W/m² is the shipped, unaffected happy path."""
-    readings, estimate = _real_chain_estimate(
-        entity="sensor.solar", state="600", unit="W/m²"
+    readings, block = _real_chain_estimate(
+        entity="sensor.solar",
+        state="600",
+        unit=UnitOfIrradiance.WATTS_PER_SQUARE_METER,
     )
     assert readings.irradiance_value == pytest.approx(600.0)
-    assert estimate.unknown_reason is None
-    assert estimate.gain_w is not None
-    assert _spec().value_fn(_stub_sensor(asdict(estimate))) is not None
+    assert block["unknown_reason"] is None
+    assert block["gain_w"] is not None
+    assert _spec().value_fn(_stub_sensor(block)) is not None
 
 
 def test_an_imperial_reading_is_refused_not_converted():
     """The BTU number is NOT silently divided by 3 — it is refused outright."""
-    readings, estimate = _real_chain_estimate(
+    readings, block = _real_chain_estimate(
         entity="sensor.solar", state="190", unit="BTU/(h⋅ft²)"
     )
     # The state-layer read stays unit-blind (issue #1237's own contract) —
     # only the GAIN estimator refuses the number.
     assert readings.irradiance_value == pytest.approx(190.0)
-    assert estimate.gain_w is None
-    assert estimate.ghi_w_m2 is None
-    assert estimate.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
-    assert estimate.unknown_reason != UNKNOWN_NO_IRRADIANCE
-    assert _spec().value_fn(_stub_sensor(asdict(estimate))) is None
+    assert block["gain_w"] is None
+    assert block["ghi_w_m2"] is None
+    assert block["unknown_reason"] == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+    assert block["unknown_reason"] != UNKNOWN_NO_IRRADIANCE
+    assert _spec().value_fn(_stub_sensor(block)) is None
 
 
 def test_an_absent_unit_takes_the_same_refusal_path():
     """A sensor with no ``unit_of_measurement`` at all is treated the same way."""
-    readings, estimate = _real_chain_estimate(
+    readings, block = _real_chain_estimate(
         entity="sensor.solar", state="612.5", unit=None
     )
     assert readings.irradiance_value == pytest.approx(612.5)
-    assert estimate.gain_w is None
-    assert estimate.unknown_reason == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
+    assert block["gain_w"] is None
+    assert block["unknown_reason"] == UNKNOWN_UNSUPPORTED_IRRADIANCE_UNIT
 
 
 def test_no_entity_configured_still_reports_no_irradiance():
     """Regression guard: the pre-existing 'nothing configured' path is unchanged."""
-    readings, estimate = _real_chain_estimate(entity=None)
+    readings, block = _real_chain_estimate(entity=None)
     assert readings.irradiance_value is None
-    assert estimate.gain_w is None
-    assert estimate.unknown_reason == UNKNOWN_NO_IRRADIANCE
+    assert block["gain_w"] is None
+    assert block["unknown_reason"] == UNKNOWN_NO_IRRADIANCE
 
 
 def test_cloud_suppression_threshold_is_unaffected_by_an_imperial_unit():

--- a/tests/test_state/test_climate_provider_irradiance_unit.py
+++ b/tests/test_state/test_climate_provider_irradiance_unit.py
@@ -1,0 +1,109 @@
+"""``ClimateProvider.read_irradiance_unit`` — issue #1280.
+
+HA's ``irradiance`` device class permits TWO units: W/m² and BTU/(h·ft²) — the
+latter is what HA presents on the imperial unit system, and
+``hass.states.get(entity).state`` returns that converted number. Nothing
+upstream ever checked which one an irradiance entity reports, so a BTU-unit
+install's raw number silently arrived at the estimated-solar-gain sensor as if
+it were W/m², under-reporting gain by roughly a factor of 3
+(1 BTU/(h·ft²) = 3.15 W/m²).
+
+This read is DELIBERATELY separate from :meth:`ClimateProvider.read` and its
+``_read_irradiance`` admission path — folding it in there would either touch
+the shared threshold/admission read that cloud suppression depends on (a
+change issue #1280's fix explicitly forbids) or add a second
+``hass.states.get`` call for the SAME entity, breaking
+``test_climate_provider.py``'s "read exactly once per cycle" contract. The
+estimated-solar-gain sensor is the only consumer, so the coordinator calls
+this as a genuinely separate read.
+
+Lives in its own module for the same reason ``test_climate_provider_non_finite.py``
+does: ``test_climate_provider.py`` is a locked regression surface (issues
+#864 / #269 / #1237) and stays byte-identical.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.state.climate_provider import ClimateProvider
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def mock_hass():
+    h = MagicMock()
+    h.states.get.return_value = None
+    return h
+
+
+@pytest.fixture
+def provider(mock_hass, mock_logger):
+    return ClimateProvider(hass=mock_hass, logger=mock_logger)
+
+
+def _mock_state(entity_id: str, state: str, attributes: dict | None = None):
+    s = MagicMock()
+    s.entity_id = entity_id
+    s.state = state
+    s.attributes = attributes or {}
+    return s
+
+
+class TestReadIrradianceUnit:
+    """The raw ``unit_of_measurement`` read — no interpretation, no gating."""
+
+    def test_none_when_no_entity_is_configured(self, provider, mock_hass):
+        assert provider.read_irradiance_unit(None) is None
+        mock_hass.states.get.assert_not_called()
+
+    def test_returns_the_metric_unit(self, provider, mock_hass):
+        mock_hass.states.get.return_value = _mock_state(
+            "sensor.solar", "612.5", {"unit_of_measurement": "W/m²"}
+        )
+        assert provider.read_irradiance_unit("sensor.solar") == "W/m²"
+
+    def test_returns_the_imperial_unit_when_thats_what_the_entity_reports(
+        self, provider, mock_hass
+    ):
+        mock_hass.states.get.return_value = _mock_state(
+            "sensor.solar", "190.0", {"unit_of_measurement": "BTU/(h⋅ft²)"}
+        )
+        assert provider.read_irradiance_unit("sensor.solar") == "BTU/(h⋅ft²)"
+
+    def test_none_when_the_entity_carries_no_unit_attribute(self, provider, mock_hass):
+        mock_hass.states.get.return_value = _mock_state("sensor.solar", "612.5")
+        assert provider.read_irradiance_unit("sensor.solar") is None
+
+    def test_none_when_the_entity_does_not_exist(self, provider, mock_hass):
+        mock_hass.states.get.return_value = None
+        assert provider.read_irradiance_unit("sensor.missing") is None
+
+    def test_does_not_touch_the_per_cycle_read_call_count(self, provider, mock_hass):
+        """A SEPARATE call site — ``.read()``'s own single read is untouched."""
+        mock_hass.states.get.return_value = _mock_state(
+            "sensor.solar", "250", {"unit_of_measurement": "W/m²"}
+        )
+        provider.read(
+            use_irradiance=True,
+            irradiance_entity="sensor.solar",
+            irradiance_threshold=300,
+        )
+        reads_from_dot_read = [
+            c
+            for c in mock_hass.states.get.call_args_list
+            if c.args and c.args[0] == "sensor.solar"
+        ]
+        assert len(reads_from_dot_read) == 1
+        # A subsequent, independent call to the new method is a SECOND read —
+        # proving the two are genuinely decoupled call sites.
+        provider.read_irradiance_unit("sensor.solar")
+        all_reads = [
+            c
+            for c in mock_hass.states.get.call_args_list
+            if c.args and c.args[0] == "sensor.solar"
+        ]
+        assert len(all_reads) == 2


### PR DESCRIPTION
## Summary

The estimated solar gain sensor read its irradiance entity as W/m2 without checking the unit.

Home Assistant's `irradiance` device class permits both `W/m²` and `BTU/(h·ft²)`, and presents the second to users on the imperial unit system. Nothing in the integration read `unit_of_measurement`, so a genuine 600 W/m2 arrived as roughly 190 and the sensor reported about a third of the true gain. Silently: no error, no `unknown`, no log line.

That is worse than a crash for this entity in particular. Its whole purpose is to be an absolute figure an automation can threshold against, so a condition like "estimated gain above 150 W, do not open the window" would simply never fire, with nothing to indicate why.

## The fix: refuse, do not convert

When the entity's unit is anything other than `W/m²`, including absent, the reading is not admitted and the sensor reports `unknown` with `unknown_reason = "unsupported_irradiance_unit"`. The observed unit is echoed in the sensor's attributes, and a warning names the entity and its unit and says what to change.

Converting via HA's `IrradianceConverter` was the alternative and was deliberately rejected. A converted figure is one the user cannot check against the number their own sensor displays, whereas a named `unknown` says exactly what to fix. An estimate that silently disagrees with the dashboard is the failure mode this whole feature exists to avoid.

The refusal is total: with an unusable unit the reading is nulled for transposition, for the plane-of-array figure, and for the echoed audit field, so no BTU magnitude reaches any field labelled W/m2.

## Cloud suppression is untouched

The unit read is a separate method called from the coordinator, never from `ClimateProvider.read()`.

Folding it into the admission path would have done one of two harmful things: touched the shared threshold read that cloud suppression depends on, where a BTU-unit user has already calibrated their threshold against the numbers they observe, or read the same entity twice per cycle and broken the "exactly one read" contract that path's regression test locks.

`state/climate_provider.py` is +27/-0, a single appended method. These four suites pass **unmodified**: `test_climate_provider.py` (including its 43-case threshold truth table), `test_climate_provider_non_finite.py`, `test_cloud_suppression.py`, `test_climate_cover_state.py`.

## Scope note

The entity picker filters on `device_class="irradiance"`, which already excludes the things people confuse with irradiance: accumulated irradiation in Wh/m2 or MJ/m2 (device class `energy`) and PV forecast output in watts (device class `power`). This is narrowly about the two units the irradiance device class itself allows.

One consequence worth stating plainly: a template or MQTT sensor publishing ASCII `W/m2` with no device class was computing a correct gain before this change and now reports `unknown`. That is the chosen policy rather than an oversight, and the new warning is what makes it discoverable instead of silent.

## Testing

- 14434 tests passing, 4 skipped, 1 xfailed, 0 failures (baseline 14398, so +36)
- `./scripts/lint` clean
- Two audit passes; the second found no must-fix items
- Tests cover W/m2, BTU/(h·ft²), a missing unit, no entity configured, and cloud suppression with a BTU entity

The gate that keeps a momentarily unavailable sensor reporting `no_irradiance` rather than `unsupported_irradiance_unit` is now pinned by tests that call the real `build_diagnostic_data`. It was previously unprotected: deleting that short-circuit passed the whole suite.

## Related Issues

Refs #1280

Fixes a defect in the sensor added for #1237, which shipped in PR #1279.
