### PR TITLE
fix: clear the no-motion timer stamp when it expires (#1266)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -194,6 +194,14 @@ class MotionManager:
         timer starts (issue #1266). Single owner of this formula — callers
         must not recompute it from ``last_motion_time`` and
         ``_timeout_seconds``.
+
+        The backing stamp (``_timeout_started_at``) is live only while a
+        timer is actually counting down. All four exits from that state —
+        ``record_motion_detected``, ``cancel_motion_timeout``,
+        ``set_no_motion``, and the timer firing naturally
+        (``_on_motion_timeout_expired``) — clear it, so this property
+        returns ``None`` rather than a stale past timestamp once the timer
+        is gone, whichever way it left.
         """
         if self._timeout_started_at is None:
             return None
@@ -288,6 +296,11 @@ class MotionManager:
             return
 
         self._motion_timeout_active = True
+        # Timer has fired; nothing is counting down. Clear the stamp like the
+        # other three exits from "timer counting" (record_motion_detected,
+        # cancel_motion_timeout, set_no_motion) so timeout_end_time honors its
+        # own contract instead of returning a past timestamp forever (#1266).
+        self._timeout_started_at = None
         self._logger.info(
             "Motion timeout expired (%s seconds) - using default position",
             timeout_seconds,

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1000,6 +1000,52 @@ def test_motion_timeout_end_time_absent_when_no_timer_started():
     assert "motion_timeout_end_time" not in attrs
 
 
+@pytest.mark.asyncio
+async def test_motion_timeout_end_time_absent_after_timer_expires():
+    """No motion_timeout_end_time once the real expiry handler has fired.
+
+    Regression for issue #1266 Part B. Unlike ``_make_motion_mgr``'s
+    ``timeout_active=True`` path (which reaches the active state via
+    ``set_no_motion()``, a *different* code path that already clears the
+    stamp), this test drives the real ``_on_motion_timeout_expired`` body —
+    the seam no existing test crosses. ``start_motion_timeout`` stamps
+    ``_timeout_started_at``; the expiry handler must clear it the same way
+    ``record_motion_detected``, ``cancel_motion_timeout``, and
+    ``set_no_motion`` already do, or ``timeout_end_time`` keeps returning a
+    timestamp in the past forever — the sensor attribute publishes an
+    already-expired end time indefinitely ("expires in expired").
+
+    Also guards #122/#75: the ``motion_status`` value string must not move
+    as a side effect of this fix.
+    """
+    hass = MagicMock()
+    state = MagicMock()
+    state.state = "off"
+    hass.states.get.return_value = state
+    logger = MagicMock()
+
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=30)
+
+    mgr.start_motion_timeout(AsyncMock())
+    assert mgr.timeout_end_time is not None  # timer really is pending
+
+    await mgr._on_motion_timeout_expired(30, AsyncMock())
+
+    assert mgr.is_motion_timeout_active is True
+    assert mgr.timeout_end_time is None
+
+    coordinator = MagicMock()
+    coordinator._motion_mgr = mgr
+    type(coordinator).is_motion_detected = property(lambda self: False)
+    sensor = _make_motion_status_sensor(coordinator)
+
+    assert sensor.native_value == "no_motion"
+    assert "motion_timeout_end_time" not in sensor.extra_state_attributes
+
+    mgr.cancel_motion_timeout()  # tear down the still-sleeping background task
+
+
 def test_motion_status_sensor_no_timestamp_device_class():
     """Sensor does not use TIMESTAMP device class (regression for issue #75)."""
     from homeassistant.components.sensor import SensorDeviceClass


### PR DESCRIPTION
## Summary
PR #1268 fixed the no-motion countdown window but not the state after it ends. `_on_motion_timeout_expired` set `_motion_timeout_active` without clearing `_timeout_started_at`, so `timeout_end_time` kept returning a past timestamp for the whole no-occupancy state and the card rendered a permanent "expires in expired".

The other three exits from "timer counting" (`record_motion_detected`, `cancel_motion_timeout`, `set_no_motion`) already clear the stamp. The expiry path now agrees with them, so the property honors its own documented contract: a time while the timer runs, `None` otherwise.

No card change needed: the sensor already omits a `None` attribute and the card already renders nothing when it is absent.

## Testing
- ✅ 13269 tests passing

## Related Issues
Refs #1266