### PR TITLE
fix: key the sunset edge on the configured boundary (#1287)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -62,6 +62,7 @@ from .helpers import (
     custom_position_slot_name,
     custom_position_slot_sensors,
     has_configured_window_end,
+    read_sunset_window_open,
     resolve_override_deadline,
     resolve_sun_boundaries,
     state_attr,
@@ -858,7 +859,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             hass=self.hass,
             logger=self.logger,
             event_buffer=self._event_buffer,
-            effective_default_fn=self._compute_current_effective_default,
+            sunset_window_open_fn=self._sunset_window_is_open,
         )
 
         # Time of the last successful _async_update_data() completion.
@@ -5925,10 +5926,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         ad-hoc ``async_apply_user_position`` path can never disagree about the
         same instant (issue #1055).
 
-        All this adds is the cover-data resolution: the transition call sites
-        (``_on_window_closed``, ``_check_sunset_window_transition``) have none in
-        hand, and ``get_blind_data`` is coordinator business the helper must not
-        reach into.
+        All this adds is the cover-data resolution: the ``_on_window_closed``
+        transition call site has none in hand, and ``get_blind_data`` is
+        coordinator business the helper must not reach into.
 
         Args:
             options: The config-entry options dict.
@@ -5940,6 +5940,35 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if cover_data is None:
             cover_data = self.get_blind_data(options=options)
         return _read_current_effective_default(
+            self.hass, options, cover_data.sun_data, self._time_mgr
+        )
+
+    def _sunset_window_is_open(self, options: dict, cover_data=None) -> bool:
+        """Return whether the configured SUNSET boundary owns this moment (#1287).
+
+        A thin wrapper over :func:`helpers.read_sunset_window_open` — the
+        predicate ``WindowTransitionTracker.check_sunset_window`` needs for
+        its False→True edge detector. Deliberately blind to the end-of-window
+        override (issue #625), unlike :meth:`_compute_current_effective_default`'s
+        ``is_sunset_active``, which is True for BOTH the end-of-window
+        position and the sunset position — feeding the tracker that
+        overloaded flag made its edge fire at clock ``end_time`` instead of
+        the configured sunset boundary.
+
+        Mirrors :meth:`_compute_current_effective_default`'s cover-data
+        resolution: the transition call site (``_check_sunset_window_transition``)
+        has none in hand.
+
+        Args:
+            options: The config-entry options dict.
+            cover_data: An already-computed cover-data object whose ``sun_data``
+                is reused. When ``None`` the cover data is computed fresh via
+                ``get_blind_data``.
+
+        """
+        if cover_data is None:
+            cover_data = self.get_blind_data(options=options)
+        return read_sunset_window_open(
             self.hass, options, cover_data.sun_data, self._time_mgr
         )
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -5943,7 +5943,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.hass, options, cover_data.sun_data, self._time_mgr
         )
 
-    def _sunset_window_is_open(self, options: dict, cover_data=None) -> bool:
+    def _sunset_window_is_open(self, options: dict) -> bool:
         """Return whether the configured SUNSET boundary owns this moment (#1287).
 
         A thin wrapper over :func:`helpers.read_sunset_window_open` — the
@@ -5955,19 +5955,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         overloaded flag made its edge fire at clock ``end_time`` instead of
         the configured sunset boundary.
 
-        Mirrors :meth:`_compute_current_effective_default`'s cover-data
-        resolution: the transition call site (``_check_sunset_window_transition``)
-        has none in hand.
+        Unlike :meth:`_compute_current_effective_default`, this seam has no
+        cover-data-reuse call site: the tracker injection (``__init__``) is
+        its only caller and always invokes it with ``options`` alone, so the
+        cover data is resolved fresh via ``get_blind_data`` every time.
 
         Args:
             options: The config-entry options dict.
-            cover_data: An already-computed cover-data object whose ``sun_data``
-                is reused. When ``None`` the cover data is computed fresh via
-                ``get_blind_data``.
 
         """
-        if cover_data is None:
-            cover_data = self.get_blind_data(options=options)
+        cover_data = self.get_blind_data(options=options)
         return read_sunset_window_open(
             self.hass, options, cover_data.sun_data, self._time_mgr
         )

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -1115,6 +1115,100 @@ def resolve_override_deadline(
     return min(upcoming) if upcoming else None
 
 
+@dataclass(frozen=True, slots=True)
+class SunsetVerdict:
+    """The day/night boundary decision, blind to the end-of-window override.
+
+    ``compute_effective_default``'s returned ``is_sunset_active`` means "a
+    night-type default is in effect" — True for BOTH the end-of-window
+    position (issue #625) AND the sunset position. That overload is fine for
+    the pipeline consumers that only care "should tonight's rules apply", but
+    it is the WRONG predicate for detecting the moment the configured SUNSET
+    boundary itself is crossed (issue #1287):
+    ``WindowTransitionTracker.check_sunset_window`` fed the overloaded flag
+    and mistook the end-of-window hold's False→True flip (at clock end_time)
+    for the astronomical-sunset edge, dispatching the raw sunset position
+    hours early and swallowing the real boundary crossing later that night.
+
+    ``window_open`` is the narrower, named answer: does the configured
+    SUNSET boundary own this moment (a configured ``daytime_gate`` OWNS the
+    answer when set — issue #632 — otherwise it is the astral
+    after-sunset-or-before-sunrise check). ``after_sunset`` is the raw astral
+    fact ("today's sunset boundary has passed") that
+    ``compute_effective_default``'s end-of-window phase 1 gates on to decide
+    when to hand off from the end-of-window position to the astral sunset
+    position; it is not meaningful when a ``daytime_gate`` owns the boundary
+    (the gate short-circuits before the astral math ever runs, mirroring the
+    original inline behaviour).
+    """
+
+    window_open: bool
+    after_sunset: bool
+
+
+def resolve_sunset_verdict(
+    sun_data: "SunData",
+    *,
+    sunset_off: int,
+    sunrise_off: int,
+    sunset_time: dt.datetime | None = None,
+    sunrise_time: dt.datetime | None = None,
+    window_explicitly_started: bool = False,
+    eval_time: dt.datetime | None = None,
+    daytime_gate: bool | None = None,
+) -> SunsetVerdict:
+    """Resolve the day/night boundary decision, blind to end-of-window (#1287).
+
+    Single source of truth for the "is the sunset position active" math that
+    used to live inline in :func:`compute_effective_default` — extracted so
+    :func:`read_sunset_window_open` (the sunset-window edge detector's input)
+    and :func:`compute_effective_default` (the pipeline's effective-default
+    resolver) can never derive two different answers for the same instant.
+
+    A configured ``daytime_gate`` OWNS the boundary and short-circuits the
+    astral math entirely (issue #632) — mirrors the original inline
+    short-circuit, including skipping the astral walk when the gate answers
+    the question. See :class:`SunsetVerdict` for what each field means in
+    that case.
+
+    Args:
+        sun_data: ``SunData`` instance providing today's sunset/sunrise times.
+        sunset_off: Minutes *added* to astronomical sunset before the window opens.
+        sunrise_off: Minutes *added* to astronomical sunrise before the window closes.
+        sunset_time: Optional override for the sunset boundary (naive-local datetime).
+        sunrise_time: Optional override for the sunrise boundary (naive-local datetime).
+        window_explicitly_started: See :func:`compute_effective_default`.
+        eval_time: Optional time at which to evaluate the window; ``None`` uses wall-clock now.
+        daytime_gate: Optional tri-state daytime-gate verdict (issue #632).
+
+    """
+    if daytime_gate is not None:
+        # The gate OWNS the boundary — no astral walk, matching the original
+        # inline short-circuit. ``after_sunset`` is inert here: no caller
+        # reads it when a gate is configured (compute_effective_default's
+        # phase 1 never reaches the astral branch in that case either).
+        return SunsetVerdict(window_open=daytime_gate is False, after_sunset=False)
+
+    boundaries = resolve_sun_boundaries(
+        sun_data,
+        sunset_time=sunset_time,
+        sunrise_time=sunrise_time,
+        sunset_off=sunset_off,
+        sunrise_off=sunrise_off,
+    )
+    now_naive = (
+        _eval_time_to_utc_naive(eval_time)
+        if eval_time is not None
+        else dt.datetime.now(UTC).replace(tzinfo=None)
+    )
+    after_sunset = now_naive > boundaries.sunset
+    before_sunrise = now_naive < boundaries.sunrise
+    # Suppress before_sunrise only when the operational window has *explicitly*
+    # started: see compute_effective_default's docstring (issue #438/#492).
+    window_open = after_sunset or (before_sunrise and not window_explicitly_started)
+    return SunsetVerdict(window_open=window_open, after_sunset=after_sunset)
+
+
 def compute_effective_default(
     h_def: int,
     sunset_pos: int | None,
@@ -1210,49 +1304,113 @@ def compute_effective_default(
     if sunset_pos is None:
         return h_def, False
 
+    # Single derivation of the day/night decision (issue #1287) — see
+    # resolve_sunset_verdict for what each field means and why a configured
+    # daytime_gate short-circuits it without an astral walk.
+    verdict = resolve_sunset_verdict(
+        sun_data,
+        sunset_off=sunset_off,
+        sunrise_off=sunrise_off,
+        sunset_time=sunset_time,
+        sunrise_time=sunrise_time,
+        window_explicitly_started=window_explicitly_started,
+        eval_time=eval_time,
+        daytime_gate=daytime_gate,
+    )
+
     # A configured daytime gate OWNS the day/night boundary: it fully replaces the
     # astronomical sunset/sunrise calc below (issue #632). Astral is the fallback
     # only when the gate is unconfigured (``daytime_gate is None``).
     if daytime_gate is not None:
-        is_sunset_active = daytime_gate is False
+        is_sunset_active = verdict.window_open
         effective = int(sunset_pos) if is_sunset_active else int(h_def)
         return effective, is_sunset_active
-
-    boundaries = resolve_sun_boundaries(
-        sun_data,
-        sunset_time=sunset_time,
-        sunrise_time=sunrise_time,
-        sunset_off=sunset_off,
-        sunrise_off=sunrise_off,
-    )
-    now_naive = (
-        _eval_time_to_utc_naive(eval_time)
-        if eval_time is not None
-        else dt.datetime.now(UTC).replace(tzinfo=None)
-    )
-
-    after_sunset = now_naive > boundaries.sunset
-    before_sunrise = now_naive < boundaries.sunrise
 
     # End-of-window phase 1 (issue #625): once the operating window is
     # clock-closed, the end-of-window position holds from window-end UNTIL astral
     # sunset; then phase 2 (the astral sunset_pos branch below) takes over. Gated
     # on ``not after_sunset`` so it yields to astral at the handoff. The
     # daytime_gate branch above intentionally still owns the boundary here.
-    if end_of_window_active and end_of_window_pos is not None and not after_sunset:
+    if (
+        end_of_window_active
+        and end_of_window_pos is not None
+        and not verdict.after_sunset
+    ):
         return int(end_of_window_pos), True
 
-    # Suppress before_sunrise only when the operational window has *explicitly*
-    # started: a real start_time < astronomical_sunrise is a valid user config
-    # (e.g. start at 08:00, sunrise at 08:15 in winter, issue #438) and once that
-    # window opens nighttime rules end. A blank start_time (issue #492) does NOT
-    # count as explicitly started, so the night position holds after midnight.
-    is_sunset_active = after_sunset or (
-        before_sunrise and not window_explicitly_started
-    )
-
+    is_sunset_active = verdict.window_open
     effective = int(sunset_pos) if is_sunset_active else int(h_def)
     return effective, is_sunset_active
+
+
+@dataclass(frozen=True, slots=True)
+class _EffectiveDefaultInputs:
+    """The live inputs shared by :func:`_read_current_effective_default` and :func:`read_sunset_window_open`.
+
+    Extracted so the option/manager reads (:func:`_read_sun_boundary_options`,
+    ``effective_daytime_gate``, ``window_explicitly_started``) exist exactly
+    once — the two callers derive different predicates (one still overloaded
+    with the end-of-window position, one blind to it — issue #1287) from the
+    same source values, so they cannot silently disagree about what those
+    values were for the same instant (CODING_GUIDELINES.md § no-duplication).
+    """
+
+    h_def: int
+    sunset_pos_cfg: int | None
+    bounds: SunBoundaryOptions
+    daytime_gate: bool | None
+    window_started: bool
+    eow_pos: int | None
+    window_is_closed: bool
+
+
+def _effective_default_inputs(
+    hass: HomeAssistant,
+    options: Mapping,
+    time_mgr: "TimeWindowManager | None",
+) -> _EffectiveDefaultInputs:
+    """Read the live inputs the day/night decision needs, exactly once.
+
+    Args:
+        hass: Used only for the boundary-entity reads in
+            :func:`_read_sun_boundary_options`. An instance with neither time
+            entity configured reads no state at all.
+        options: The config-entry options mapping.
+        time_mgr: The live ``TimeWindowManager``, or ``None``. ``None`` is the
+            contract for a builder constructed without one (tests, legacy call
+            sites): the manager-derived fields degrade to exactly the defaults
+            :func:`compute_effective_default` would have applied anyway.
+
+    """
+    h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
+    sunset_pos_cfg = options.get(CONF_SUNSET_POS)
+    bounds = _read_sun_boundary_options(hass, options)
+    # A configured daytime gate (issue #632) OWNS the day/night boundary:
+    # ``effective_daytime_gate`` is the single tri-state verdict to forward —
+    # True=daytime→no sunset, False=dark→apply sunset position, None=defer to
+    # the astronomical decision. None covers both an unconfigured gate and the
+    # graceful fallback after every gate source has been indeterminate past the
+    # grace window (issue #742).
+    daytime_gate = time_mgr.effective_daytime_gate if time_mgr is not None else None
+    window_started = (
+        time_mgr.window_explicitly_started if time_mgr is not None else False
+    )
+    # End-of-window position (issue #625): an optional, clearable position
+    # applied once the operating window is clock-closed. ``before_end_time``
+    # is True all morning (end is later today), so the override only fires in
+    # the evening — never before the start time. compute_effective_default
+    # owns the two-phase astral handoff; here we only read the inputs.
+    eow_pos = options.get(CONF_END_OF_WINDOW_POS)
+    window_is_closed = (not time_mgr.before_end_time) if time_mgr is not None else False
+    return _EffectiveDefaultInputs(
+        h_def=h_def,
+        sunset_pos_cfg=sunset_pos_cfg,
+        bounds=bounds,
+        daytime_gate=daytime_gate,
+        window_started=window_started,
+        eow_pos=eow_pos,
+        window_is_closed=window_is_closed,
+    )
 
 
 def _read_current_effective_default(
@@ -1299,39 +1457,64 @@ def _read_current_effective_default(
             the live manager.
 
     """
-    h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
-    sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-    bounds = _read_sun_boundary_options(hass, options)
-    # A configured daytime gate (issue #632) OWNS the day/night boundary:
-    # ``effective_daytime_gate`` is the single tri-state verdict to forward —
-    # True=daytime→no sunset, False=dark→apply sunset position, None=defer to
-    # the astronomical decision. None covers both an unconfigured gate and the
-    # graceful fallback after every gate source has been indeterminate past the
-    # grace window (issue #742).
-    daytime_gate = time_mgr.effective_daytime_gate if time_mgr is not None else None
-    window_started = (
-        time_mgr.window_explicitly_started if time_mgr is not None else False
-    )
-    # End-of-window position (issue #625): an optional, clearable position
-    # applied once the operating window is clock-closed. ``before_end_time``
-    # is True all morning (end is later today), so the override only fires in
-    # the evening — never before the start time. compute_effective_default
-    # owns the two-phase astral handoff; here we only read the inputs.
-    eow_pos = options.get(CONF_END_OF_WINDOW_POS)
-    window_is_closed = (not time_mgr.before_end_time) if time_mgr is not None else False
+    inputs = _effective_default_inputs(hass, options, time_mgr)
     return compute_effective_default(
-        h_def=h_def,
-        sunset_pos=sunset_pos_cfg,
+        h_def=inputs.h_def,
+        sunset_pos=inputs.sunset_pos_cfg,
         sun_data=sun_data,
-        sunset_off=bounds.sunset_off,
-        sunrise_off=bounds.sunrise_off,
-        sunset_time=bounds.sunset_time,
-        sunrise_time=bounds.sunrise_time,
-        window_explicitly_started=window_started,
-        daytime_gate=daytime_gate,
-        end_of_window_pos=eow_pos,
-        end_of_window_active=window_is_closed,
+        sunset_off=inputs.bounds.sunset_off,
+        sunrise_off=inputs.bounds.sunrise_off,
+        sunset_time=inputs.bounds.sunset_time,
+        sunrise_time=inputs.bounds.sunrise_time,
+        window_explicitly_started=inputs.window_started,
+        daytime_gate=inputs.daytime_gate,
+        end_of_window_pos=inputs.eow_pos,
+        end_of_window_active=inputs.window_is_closed,
     )
+
+
+def read_sunset_window_open(
+    hass: HomeAssistant,
+    options: Mapping,
+    sun_data: "SunData",
+    time_mgr: "TimeWindowManager | None" = None,
+) -> bool:
+    """Return whether the configured SUNSET boundary owns this moment (#1287).
+
+    This is the predicate :class:`~.state.window_transition_tracker.WindowTransitionTracker`'s
+    ``check_sunset_window`` needs for its False→True edge detector — deliberately
+    BLIND to the end-of-window override (issue #625), unlike
+    :func:`_read_current_effective_default`'s ``is_sunset_active``, which is
+    True for both the end-of-window position and the sunset position. Feeding
+    the tracker that overloaded flag made its edge fire at clock ``end_time``
+    instead of at the configured sunset boundary — the #1287 defect.
+
+    Shares its input reads with :func:`_read_current_effective_default`
+    through :func:`_effective_default_inputs` so the two predicates can never
+    disagree about what "the sunset boundary" means for the same instant.
+
+    Args:
+        hass: Used only for the boundary-entity reads in
+            :func:`_read_sun_boundary_options`.
+        options: The config-entry options mapping.
+        sun_data: Already-resolved ``SunData`` providing today's sunset/sunrise.
+        time_mgr: The live ``TimeWindowManager``, or ``None`` (degrades to the
+            same defaults :func:`compute_effective_default` would apply).
+
+    """
+    inputs = _effective_default_inputs(hass, options, time_mgr)
+    if inputs.sunset_pos_cfg is None:
+        return False
+    verdict = resolve_sunset_verdict(
+        sun_data,
+        sunset_off=inputs.bounds.sunset_off,
+        sunrise_off=inputs.bounds.sunrise_off,
+        sunset_time=inputs.bounds.sunset_time,
+        sunrise_time=inputs.bounds.sunrise_time,
+        window_explicitly_started=inputs.window_started,
+        daytime_gate=inputs.daytime_gate,
+    )
+    return verdict.window_open
 
 
 def should_use_tilt(is_tilt_cover: bool, caps) -> bool:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -1137,13 +1137,16 @@ class SunsetVerdict:
     fact ("today's sunset boundary has passed") that
     ``compute_effective_default``'s end-of-window phase 1 gates on to decide
     when to hand off from the end-of-window position to the astral sunset
-    position; it is not meaningful when a ``daytime_gate`` owns the boundary
-    (the gate short-circuits before the astral math ever runs, mirroring the
-    original inline behaviour).
+    position. It is ``None`` — not a fabricated ``False`` — when a configured
+    ``daytime_gate`` owns the boundary: the gate short-circuits before the
+    astral math ever runs (mirroring the original inline behaviour), so there
+    is no astral fact to report. The one caller that reads this field
+    (``compute_effective_default``'s phase 1) only does so on the path where
+    ``daytime_gate is None``, so it never observes the ``None``.
     """
 
     window_open: bool
-    after_sunset: bool
+    after_sunset: bool | None
 
 
 def resolve_sunset_verdict(
@@ -1184,10 +1187,11 @@ def resolve_sunset_verdict(
     """
     if daytime_gate is not None:
         # The gate OWNS the boundary — no astral walk, matching the original
-        # inline short-circuit. ``after_sunset`` is inert here: no caller
-        # reads it when a gate is configured (compute_effective_default's
-        # phase 1 never reaches the astral branch in that case either).
-        return SunsetVerdict(window_open=daytime_gate is False, after_sunset=False)
+        # inline short-circuit. ``after_sunset=None`` is honest about there
+        # being no astral fact to report here (no caller reads it in this
+        # branch — compute_effective_default's phase 1 never reaches the
+        # astral branch when a gate is configured either).
+        return SunsetVerdict(window_open=daytime_gate is False, after_sunset=None)
 
     boundaries = resolve_sun_boundaries(
         sun_data,
@@ -1330,7 +1334,10 @@ def compute_effective_default(
     # clock-closed, the end-of-window position holds from window-end UNTIL astral
     # sunset; then phase 2 (the astral sunset_pos branch below) takes over. Gated
     # on ``not after_sunset`` so it yields to astral at the handoff. The
-    # daytime_gate branch above intentionally still owns the boundary here.
+    # daytime_gate branch above intentionally still owns the boundary here —
+    # this line only runs when ``daytime_gate is None``, so ``verdict`` was
+    # resolved on the astral path and ``after_sunset`` is always a real bool
+    # here, never the gated branch's ``None``.
     if (
         end_of_window_active
         and end_of_window_pos is not None
@@ -1504,6 +1511,14 @@ def read_sunset_window_open(
     """
     inputs = _effective_default_inputs(hass, options, time_mgr)
     if inputs.sunset_pos_cfg is None:
+        # No sunset position configured: there is nothing for the tracker to
+        # dispatch, so "the boundary owns this moment" is meaningless here.
+        # ``False`` ("boundary not passed") rather than ``True`` is the safe
+        # reading — it can never itself trigger a False→True dispatch edge.
+        # Inert today: ``check_sunset_window`` already returns before calling
+        # this function when ``sunset_pos_cfg is None``
+        # (window_transition_tracker.py). Kept as a defensive default for any
+        # future caller of this predicate that isn't gated the same way.
         return False
     verdict = resolve_sunset_verdict(
         sun_data,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -2201,8 +2201,9 @@ class CoverCommandService:
         #   eventually break it — after a spurious ``policy_deferred`` skip on
         #   every raise.
         # - BEFORE ``_prepare_service_call`` below, because that call BOOKS the
-        #   command: ``sent_at`` (which ``_check_time_delta`` reads — issue
-        #   #853), ``waiting``, and the 5 s command grace window (issue #1139,
+        #   command: the cover entity's ``last_updated`` (which
+        #   ``_check_time_delta`` reads via ``get_last_updated`` — issue #853),
+        #   ``waiting``, and the 5 s command grace window (issue #1139,
         #   whose reporter measured backend queue waits of 10.6 / 20.9 / 33.7 s
         #   — 2× to 7× that window). A wait placed after the booking would start
         #   both clocks at DECISION time, silently shortening the min-interval

--- a/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
+++ b/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
@@ -25,7 +25,8 @@ The tracker is framework-light: it never imports the coordinator.
 Per-cycle collaborators (entities list, manager, command service,
 position-context builder, refresh callback) flow in by parameter at each
 call.  Long-lived collaborators (hass, logger, event buffer, and a
-closure that returns the current effective default + sunset flag) are
+closure that returns whether the configured SUNSET boundary owns this
+moment — blind to the end-of-window override, issue #1287) are
 constructor-injected.
 """
 
@@ -46,7 +47,12 @@ if TYPE_CHECKING:
 
 
 # Type aliases for readability of the public surface.
-EffectiveDefaultFn = Callable[[dict], tuple[int, bool]]
+# Returns whether the configured SUNSET boundary owns this moment — blind to
+# the end-of-window override (issue #1287). See helpers.read_sunset_window_open
+# for why this must NOT be compute_effective_default's overloaded
+# is_sunset_active ("a night-type default is in effect", true for both the
+# end-of-window position and the sunset position).
+SunsetWindowOpenFn = Callable[[dict], bool]
 BuildContextFn = Callable[[str, dict], "PositionContext"]
 ApplyPositionFn = Callable[..., Awaitable[Any]]
 RefreshFn = Callable[[], Awaitable[Any]]
@@ -66,13 +72,13 @@ class WindowTransitionTracker:
         logger: ConfigContextAdapter,
         *,
         event_buffer: EventBuffer,
-        effective_default_fn: EffectiveDefaultFn,
+        sunset_window_open_fn: SunsetWindowOpenFn,
     ) -> None:
         """Bind collaborators and reset transition state to ``None``."""
         self._hass = hass
         self._logger = logger
         self._event_buffer = event_buffer
-        self._effective_default_fn = effective_default_fn
+        self._sunset_window_open_fn = sunset_window_open_fn
         # ``None`` on first call prevents spurious dispatch when the
         # integration starts mid-transition (issue #266 / sun FoV).
         self._last_sun_validity_state: bool | None = None
@@ -185,7 +191,7 @@ class WindowTransitionTracker:
             )
             return
 
-        _effective_pos, is_sunset = self._effective_default_fn(options)
+        is_sunset = self._sunset_window_open_fn(options)
 
         if self._prev_sunset_active is None:
             self._prev_sunset_active = is_sunset

--- a/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
+++ b/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
@@ -82,7 +82,7 @@ class WindowTransitionTracker:
         # ``None`` on first call prevents spurious dispatch when the
         # integration starts mid-transition (issue #266 / sun FoV).
         self._last_sun_validity_state: bool | None = None
-        self._prev_sunset_active: bool | None = None
+        self._prev_sunset_window_open: bool | None = None
 
     # ---- Sun visibility --------------------------------------------------
 
@@ -191,14 +191,14 @@ class WindowTransitionTracker:
             )
             return
 
-        is_sunset = self._sunset_window_open_fn(options)
+        sunset_window_open = self._sunset_window_open_fn(options)
 
-        if self._prev_sunset_active is None:
-            self._prev_sunset_active = is_sunset
+        if self._prev_sunset_window_open is None:
+            self._prev_sunset_window_open = sunset_window_open
             return
 
-        just_opened = (not self._prev_sunset_active) and is_sunset
-        self._prev_sunset_active = is_sunset
+        just_opened = (not self._prev_sunset_window_open) and sunset_window_open
+        self._prev_sunset_window_open = sunset_window_open
 
         if not just_opened:
             return

--- a/tests/_helpers/time_freeze.py
+++ b/tests/_helpers/time_freeze.py
@@ -1,0 +1,25 @@
+"""Freeze ``helpers.dt.datetime.now()`` for deterministic sunset/window tests.
+
+``compute_effective_default`` (and everything built on it — the sunset-window
+edge detector, the end-of-window handoff) reads wall-clock time via
+``helpers.dt.datetime.now()``. Tests that need a fixed instant patch that one
+call site. Per CODING_GUIDELINES § No Duplication ("cross-file test helpers
+live in ``tests/_helpers/``"), this lives here rather than being copied
+verbatim per test module — it previously existed identically in both
+``tests/test_end_of_window_position.py`` and
+``tests/test_issue_266_sunset_transition.py`` (issue #1287 audit).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import patch
+
+
+def freeze_helpers_now(naive_utc: dt.datetime):
+    """Patch ``helpers.dt.datetime.now()`` so it returns a UTC-aware ``naive_utc``."""
+    aware = naive_utc.replace(tzinfo=dt.UTC)
+    return patch(
+        "custom_components.adaptive_cover_pro.helpers.dt.datetime",
+        **{"now.return_value": aware},
+    )

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -353,7 +353,7 @@ async def _trigger_window_close_return_sunset(coord):
         event_buffer=event_buffer,
         sunset_window_open_fn=lambda _opts: False,
     )
-    tracker._prev_sunset_active = True
+    tracker._prev_sunset_window_open = True
     coord._window_tracker = tracker
 
     async def _invoke(track_end_time, refresh_callback, on_window_open=None):
@@ -391,7 +391,7 @@ async def _trigger_sunset_window_opened(coord):
         event_buffer=event_buffer,
         sunset_window_open_fn=lambda _opts: True,
     )
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     coord._window_tracker = tracker
     await coord._check_sunset_window_transition()
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -351,7 +351,7 @@ async def _trigger_window_close_return_sunset(coord):
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._prev_sunset_active = True
     coord._window_tracker = tracker
@@ -382,7 +382,6 @@ async def _trigger_sunset_window_opened(coord):
     coord.config_entry = MagicMock()
     coord.config_entry.options = {"sunset_position": 0}
     coord._inverse_state = False
-    coord._compute_current_effective_default = MagicMock(return_value=(0, True))
     coord.async_refresh = AsyncMock()
     event_buffer = getattr(coord, "_event_buffer", None) or EventBuffer(maxlen=10)
     coord._event_buffer = event_buffer
@@ -390,7 +389,7 @@ async def _trigger_sunset_window_opened(coord):
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=event_buffer,
-        effective_default_fn=coord._compute_current_effective_default,
+        sunset_window_open_fn=lambda _opts: True,
     )
     tracker._prev_sunset_active = False
     coord._window_tracker = tracker

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -540,7 +540,7 @@ async def test_window_close_sends_reposition_when_auto_control_on():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: False,
     )
-    tracker._prev_sunset_active = True
+    tracker._prev_sunset_window_open = True
     coord._window_tracker = tracker
 
     with patch(
@@ -635,7 +635,7 @@ async def test_window_close_skips_reposition_when_custom_position_active():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: False,
     )
-    tracker._prev_sunset_active = True
+    tracker._prev_sunset_window_open = True
     coord._window_tracker = tracker
 
     with patch(
@@ -736,7 +736,7 @@ async def test_window_close_sends_when_stale_winner_is_window_gated():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: False,
     )
-    tracker._prev_sunset_active = True
+    tracker._prev_sunset_window_open = True
     coord._window_tracker = tracker
 
     with patch(
@@ -836,7 +836,7 @@ async def test_window_close_still_defers_to_custom_position_after_refresh():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: False,
     )
-    tracker._prev_sunset_active = True
+    tracker._prev_sunset_window_open = True
     coord._window_tracker = tracker
 
     with patch(
@@ -1449,7 +1449,7 @@ async def test_end_time_default_clamped_by_outside_window_bound():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: False,
     )
-    tracker._prev_sunset_active = True
+    tracker._prev_sunset_window_open = True
     coord._window_tracker = tracker
 
     time_mgr = MagicMock()
@@ -1539,7 +1539,7 @@ async def test_sunset_window_dispatch_clamped_by_outside_window_bound():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: True,
     )
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     coord._window_tracker = tracker
 
     await coord._check_sunset_window_transition()
@@ -1618,7 +1618,7 @@ async def test_sunset_window_dispatch_clamped_with_the_clock_still_open():
         event_buffer=coord._event_buffer,
         sunset_window_open_fn=lambda _opts: True,
     )
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     coord._window_tracker = tracker
 
     await coord._check_sunset_window_transition()

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -125,7 +125,7 @@ def _attach_window_tracker(coord, *, prev_state: bool | None) -> None:
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._last_sun_validity_state = prev_state
     coord._window_tracker = tracker
@@ -452,7 +452,7 @@ async def test_window_close_skips_reposition_when_auto_control_off():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
 
     cmd_svc = MagicMock()
@@ -538,7 +538,7 @@ async def test_window_close_sends_reposition_when_auto_control_on():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._prev_sunset_active = True
     coord._window_tracker = tracker
@@ -633,7 +633,7 @@ async def test_window_close_skips_reposition_when_custom_position_active():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._prev_sunset_active = True
     coord._window_tracker = tracker
@@ -734,7 +734,7 @@ async def test_window_close_sends_when_stale_winner_is_window_gated():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._prev_sunset_active = True
     coord._window_tracker = tracker
@@ -834,7 +834,7 @@ async def test_window_close_still_defers_to_custom_position_after_refresh():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (0, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._prev_sunset_active = True
     coord._window_tracker = tracker
@@ -1447,7 +1447,7 @@ async def test_end_time_default_clamped_by_outside_window_bound():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (100, False),
+        sunset_window_open_fn=lambda _opts: False,
     )
     tracker._prev_sunset_active = True
     coord._window_tracker = tracker
@@ -1537,7 +1537,7 @@ async def test_sunset_window_dispatch_clamped_by_outside_window_bound():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (100, True),
+        sunset_window_open_fn=lambda _opts: True,
     )
     tracker._prev_sunset_active = False
     coord._window_tracker = tracker
@@ -1616,7 +1616,7 @@ async def test_sunset_window_dispatch_clamped_with_the_clock_still_open():
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=lambda _opts: (100, True),
+        sunset_window_open_fn=lambda _opts: True,
     )
     tracker._prev_sunset_active = False
     coord._window_tracker = tracker

--- a/tests/test_day_night_dual_entity.py
+++ b/tests/test_day_night_dual_entity.py
@@ -266,7 +266,7 @@ async def test_sunset_window_transition_remaps_middle_rail() -> None:
         MagicMock(),
         MagicMock(),
         event_buffer=MagicMock(),
-        effective_default_fn=lambda _opts: (60, is_sunset["value"]),
+        sunset_window_open_fn=lambda _opts: is_sunset["value"],
     )
 
     common = {
@@ -399,7 +399,7 @@ async def test_sunset_seam_inverse_uses_seam_space_not_cached_flag() -> None:
         MagicMock(),
         MagicMock(),
         event_buffer=MagicMock(),
-        effective_default_fn=lambda _o: (0, is_sunset["v"]),
+        sunset_window_open_fn=lambda _o: is_sunset["v"],
     )
 
     targets: dict[str, int] = {}

--- a/tests/test_dual_panel_dispatch.py
+++ b/tests/test_dual_panel_dispatch.py
@@ -403,7 +403,7 @@ async def test_sunset_seam_calibrates_the_back_under_interpolation() -> None:
         MagicMock(),
         MagicMock(),
         event_buffer=MagicMock(),
-        effective_default_fn=lambda _o: (0, is_sunset["v"]),
+        sunset_window_open_fn=lambda _o: is_sunset["v"],
     )
 
     targets: dict[str, int] = {}

--- a/tests/test_end_of_window_position.py
+++ b/tests/test_end_of_window_position.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 from custom_components.adaptive_cover_pro.const import (
     CONF_DEFAULT_HEIGHT,
     CONF_END_OF_WINDOW_POS,
+    CONF_SUNSET_OFFSET,
     CONF_SUNSET_POS,
 )
 from custom_components.adaptive_cover_pro.coordinator import (
@@ -170,3 +171,121 @@ class TestLivePipelineStickiness:
         result = DefaultHandler().evaluate(snap)
         assert result.position == 0
         assert "sunset position" in result.reason
+
+
+class TestSunsetBoundaryPredicateIsNotIsSunsetActive:
+    """Issue #1287: pin ``read_sunset_window_open`` apart from ``is_sunset_active``.
+
+    ``compute_effective_default``'s returned ``is_sunset_active`` means "a
+    night-type default is in effect" — True for BOTH the end-of-window
+    position (#625) AND the sunset position. The sunset-window edge detector
+    (``WindowTransitionTracker.check_sunset_window``) needs a narrower
+    predicate: "has the configured SUNSET boundary actually passed?" These
+    tests prove the two answers diverge during an end-of-window hold —
+    exactly the #1287 defect — and that ``compute_effective_default`` keeps
+    returning its existing (unchanged) values throughout.
+
+    Config mirrors the reporter's: end-of-window position 60, sunset
+    position 16, astral sunset 21:04 local + a 60-minute offset → the real
+    sunset BOUNDARY is 22:04.
+    """
+
+    def _hass_time_mgr_sun_data(self):
+        hass = MagicMock()
+        hass.states.get.return_value = None  # no sunset/sunrise time entities
+
+        time_mgr = MagicMock()
+        time_mgr.effective_daytime_gate = None  # no gate — astral path (#742)
+        time_mgr.window_explicitly_started = False
+        time_mgr.before_end_time = False  # window already clock-closed
+
+        today = _dt.date.today()
+        sun_data = MagicMock()
+        sun_data.sunset.return_value = _dt.datetime(
+            today.year, today.month, today.day, 21, 4, 0
+        )
+        sun_data.sunrise.return_value = _dt.datetime(
+            today.year, today.month, today.day, 6, 0, 0
+        )
+        return hass, time_mgr, sun_data
+
+    def test_window_open_false_during_end_of_window_hold(self):
+        """19:30 — eow position holds (is_sunset_active True), boundary NOT passed."""
+        from custom_components.adaptive_cover_pro.helpers import (
+            read_sunset_window_open,
+        )
+
+        hass, time_mgr, sun_data = self._hass_time_mgr_sun_data()
+        options = {
+            CONF_DEFAULT_HEIGHT: 100,
+            CONF_SUNSET_POS: 16,
+            CONF_END_OF_WINDOW_POS: 60,
+            CONF_SUNSET_OFFSET: 60,
+        }
+        today = _dt.date.today()
+        now = _dt.datetime(today.year, today.month, today.day, 19, 30, 0)
+
+        coord = _coord_with_window(before_end_time=False)
+        coord.hass = hass
+        coord._time_mgr = time_mgr
+        coord.get_blind_data = MagicMock(return_value=MagicMock(sun_data=sun_data))
+        with _freeze_helpers_now(now):
+            eff, is_sunset = coord._compute_current_effective_default(options)
+            window_open = read_sunset_window_open(hass, options, sun_data, time_mgr)
+
+        # compute_effective_default is unchanged: the eow position holds and
+        # is still reported with the existing "night-type default" flag.
+        assert (eff, is_sunset) == (60, True)
+        # The narrower predicate says the SUNSET boundary itself has not
+        # passed — this is the fix: the tracker must key off THIS, not
+        # is_sunset_active.
+        assert window_open is False
+
+    def test_window_open_true_after_configured_sunset_boundary(self):
+        """22:05 — past the configured boundary (astral sunset + offset)."""
+        from custom_components.adaptive_cover_pro.helpers import (
+            read_sunset_window_open,
+        )
+
+        hass, time_mgr, sun_data = self._hass_time_mgr_sun_data()
+        options = {
+            CONF_DEFAULT_HEIGHT: 100,
+            CONF_SUNSET_POS: 16,
+            CONF_END_OF_WINDOW_POS: 60,
+            CONF_SUNSET_OFFSET: 60,
+        }
+        today = _dt.date.today()
+        now = _dt.datetime(today.year, today.month, today.day, 22, 5, 0)
+
+        coord = _coord_with_window(before_end_time=False)
+        coord.hass = hass
+        coord._time_mgr = time_mgr
+        coord.get_blind_data = MagicMock(return_value=MagicMock(sun_data=sun_data))
+        with _freeze_helpers_now(now):
+            eff, is_sunset = coord._compute_current_effective_default(options)
+            window_open = read_sunset_window_open(hass, options, sun_data, time_mgr)
+
+        # compute_effective_default has handed off to phase 2 (astral
+        # sunset_pos) — still the SAME "night-type default" flag as before.
+        assert (eff, is_sunset) == (16, True)
+        # The boundary predicate now agrees — this is the edge the tracker
+        # must fire on.
+        assert window_open is True
+
+    def test_window_open_false_when_sunset_position_not_configured(self):
+        """No sunset position configured → the boundary predicate is inert."""
+        from custom_components.adaptive_cover_pro.helpers import (
+            read_sunset_window_open,
+        )
+
+        hass, time_mgr, sun_data = self._hass_time_mgr_sun_data()
+        options = {
+            CONF_DEFAULT_HEIGHT: 100,
+            CONF_SUNSET_POS: None,
+            CONF_END_OF_WINDOW_POS: 60,
+            CONF_SUNSET_OFFSET: 60,
+        }
+
+        window_open = read_sunset_window_open(hass, options, sun_data, time_mgr)
+
+        assert window_open is False

--- a/tests/test_end_of_window_position.py
+++ b/tests/test_end_of_window_position.py
@@ -25,6 +25,7 @@ from custom_components.adaptive_cover_pro.coordinator import (
 from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
     DefaultHandler,
 )
+from tests._helpers.time_freeze import freeze_helpers_now
 from tests.test_pipeline.conftest import make_snapshot
 
 
@@ -68,16 +69,6 @@ def _coord_with_window(
     return coord
 
 
-def _freeze_helpers_now(naive_utc: _dt.datetime):
-    from unittest.mock import patch
-
-    aware = naive_utc.replace(tzinfo=_dt.UTC)
-    return patch(
-        "custom_components.adaptive_cover_pro.helpers.dt.datetime",
-        **{"now.return_value": aware},
-    )
-
-
 class TestCoordinatorSeamReadsEndOfWindow:
     """_compute_current_effective_default threads the eow option + window state."""
 
@@ -92,7 +83,7 @@ class TestCoordinatorSeamReadsEndOfWindow:
         today = _dt.date.today()
         # 19:30 — after the window end but before astral sunset (20:00).
         now = _dt.datetime(today.year, today.month, today.day, 19, 30, 0)
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
         assert eff == 0
         assert is_sunset is True
@@ -107,7 +98,7 @@ class TestCoordinatorSeamReadsEndOfWindow:
         }
         today = _dt.date.today()
         now = _dt.datetime(today.year, today.month, today.day, 12, 0, 0)
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
         assert eff == 80
         assert is_sunset is False
@@ -122,7 +113,7 @@ class TestCoordinatorSeamReadsEndOfWindow:
         }
         today = _dt.date.today()
         now = _dt.datetime(today.year, today.month, today.day, 21, 0, 0)
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
         assert eff == 20
         assert is_sunset is True
@@ -137,7 +128,7 @@ class TestCoordinatorSeamReadsEndOfWindow:
         }
         today = _dt.date.today()
         now = _dt.datetime(today.year, today.month, today.day, 22, 0, 0)
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
         assert eff == 0
         assert is_sunset is True
@@ -151,7 +142,7 @@ class TestCoordinatorSeamReadsEndOfWindow:
         }
         today = _dt.date.today()
         now = _dt.datetime(today.year, today.month, today.day, 19, 30, 0)
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
         assert eff == 80
         assert is_sunset is False
@@ -229,7 +220,7 @@ class TestSunsetBoundaryPredicateIsNotIsSunsetActive:
         coord.hass = hass
         coord._time_mgr = time_mgr
         coord.get_blind_data = MagicMock(return_value=MagicMock(sun_data=sun_data))
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
             window_open = read_sunset_window_open(hass, options, sun_data, time_mgr)
 
@@ -261,7 +252,7 @@ class TestSunsetBoundaryPredicateIsNotIsSunsetActive:
         coord.hass = hass
         coord._time_mgr = time_mgr
         coord.get_blind_data = MagicMock(return_value=MagicMock(sun_data=sun_data))
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             eff, is_sunset = coord._compute_current_effective_default(options)
             window_open = read_sunset_window_open(hass, options, sun_data, time_mgr)
 

--- a/tests/test_event_buffer_recording.py
+++ b/tests/test_event_buffer_recording.py
@@ -439,7 +439,7 @@ class TestEndTimeDefaultSentEvent:
             event_buffer=buf,
             sunset_window_open_fn=lambda _opts: is_sunset,
         )
-        tracker._prev_sunset_active = True
+        tracker._prev_sunset_window_open = True
         coord._window_tracker = tracker
 
         return coord
@@ -543,7 +543,7 @@ class TestSunsetWindowOpenedEvent:
             event_buffer=buf,
             sunset_window_open_fn=lambda _opts: True,
         )
-        tracker._prev_sunset_active = False
+        tracker._prev_sunset_window_open = False
         coord._window_tracker = tracker
         return coord
 
@@ -581,7 +581,9 @@ class TestSunsetWindowOpenedEvent:
         )
 
         coord = self._make_coord()
-        coord._window_tracker._prev_sunset_active = True  # already open — no transition
+        coord._window_tracker._prev_sunset_window_open = (
+            True  # already open — no transition
+        )
         await AdaptiveDataUpdateCoordinator._check_sunset_window_transition(coord)
         assert "sunset_window_opened" not in _event_types(coord._event_buffer)
 

--- a/tests/test_event_buffer_recording.py
+++ b/tests/test_event_buffer_recording.py
@@ -334,7 +334,7 @@ class TestSunFOVEvents:
             hass=MagicMock(),
             logger=coord.logger,
             event_buffer=buf,
-            effective_default_fn=lambda _opts: (0, False),
+            sunset_window_open_fn=lambda _opts: False,
         )
         tracker._last_sun_validity_state = prev_state
         coord._window_tracker = tracker
@@ -437,7 +437,7 @@ class TestEndTimeDefaultSentEvent:
             hass=MagicMock(),
             logger=coord.logger,
             event_buffer=buf,
-            effective_default_fn=coord._compute_current_effective_default,
+            sunset_window_open_fn=lambda _opts: is_sunset,
         )
         tracker._prev_sunset_active = True
         coord._window_tracker = tracker
@@ -536,13 +536,12 @@ class TestSunsetWindowOpenedEvent:
                 is_safety=False,
             )
         )
-        coord._compute_current_effective_default = MagicMock(return_value=(0, True))
         # Phase E: sunset-window state lives on the WindowTransitionTracker.
         tracker = WindowTransitionTracker(
             hass=MagicMock(),
             logger=coord.logger,
             event_buffer=buf,
-            effective_default_fn=coord._compute_current_effective_default,
+            sunset_window_open_fn=lambda _opts: True,
         )
         tracker._prev_sunset_active = False
         coord._window_tracker = tracker

--- a/tests/test_issue_266_sunset_transition.py
+++ b/tests/test_issue_266_sunset_transition.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -27,6 +27,7 @@ from custom_components.adaptive_cover_pro.coordinator import (
 )
 from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 from custom_components.adaptive_cover_pro.managers.toggles import ToggleManager
+from tests._helpers.time_freeze import freeze_helpers_now
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -130,7 +131,7 @@ def _seed_sunset_state(
     from the configured ``sunset_position`` option, not from this predicate.
     """
     del pos  # inert — see docstring
-    coord._window_tracker._prev_sunset_active = prev
+    coord._window_tracker._prev_sunset_window_open = prev
     coord._sunset_window_is_open = MagicMock(return_value=current_is_sunset)
     coord._window_tracker._sunset_window_open_fn = coord._sunset_window_is_open
 
@@ -237,15 +238,6 @@ def _make_boundary_test_coord(
     return coord
 
 
-def _freeze_helpers_now(naive_utc: _dt.datetime):
-    """Patch ``helpers.dt.datetime.now()`` so ``compute_effective_default`` sees a fixed instant."""
-    aware = naive_utc.replace(tzinfo=_dt.UTC)
-    return patch(
-        "custom_components.adaptive_cover_pro.helpers.dt.datetime",
-        **{"now.return_value": aware},
-    )
-
-
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -311,7 +303,7 @@ async def test_no_dispatch_when_sunset_pos_not_configured():
     """No dispatch when sunset_pos is not configured (None)."""
     coord = _make_coord(sunset_pos=None)
     # _compute_current_effective_default won't be called because we return early
-    coord._window_tracker._prev_sunset_active = False
+    coord._window_tracker._prev_sunset_window_open = False
     # No sunset_pos in options → return early before checking transition
 
     await coord._check_sunset_window_transition()
@@ -348,7 +340,7 @@ async def test_transition_detected_only_once_per_day():
     _seed_sunset_state(coord, prev=False, current_is_sunset=True)
 
     await coord._check_sunset_window_transition()
-    # Second call: _prev_sunset_active is now True, is_sunset still True → no transition
+    # Second call: _prev_sunset_window_open is now True, is_sunset still True → no transition
     await coord._check_sunset_window_transition()
 
     assert coord._cmd_svc.apply_position.call_count == 1
@@ -356,15 +348,15 @@ async def test_transition_detected_only_once_per_day():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_prev_sunset_active_initial_none_does_not_dispatch():
-    """On HA restart mid-sunset (_prev_sunset_active=None), no spurious dispatch.
+async def test_prev_sunset_window_open_initial_none_does_not_dispatch():
+    """On HA restart mid-sunset (_prev_sunset_window_open=None), no spurious dispatch.
 
     Mirrors the _last_sun_validity_state=None pattern: first call initializes
     state without dispatching, so covers aren't blindly repositioned on startup.
     """
     coord = _make_coord(sunset_pos=0)
-    # _prev_sunset_active starts as None (fresh coordinator)
-    assert coord._window_tracker._prev_sunset_active is None
+    # _prev_sunset_window_open starts as None (fresh coordinator)
+    assert coord._window_tracker._prev_sunset_window_open is None
     coord._sunset_window_is_open = MagicMock(return_value=True)
     coord._window_tracker._sunset_window_open_fn = coord._sunset_window_is_open
 
@@ -372,7 +364,7 @@ async def test_prev_sunset_active_initial_none_does_not_dispatch():
 
     coord._cmd_svc.apply_position.assert_not_called()
     # State should be initialized
-    assert coord._window_tracker._prev_sunset_active is True
+    assert coord._window_tracker._prev_sunset_window_open is True
 
 
 @pytest.mark.asyncio
@@ -395,7 +387,7 @@ async def test_end_time_after_sunset_does_not_double_dispatch():
     """When end_time fires after sunset is already active, no follow-up dispatch.
 
     If end_time > sunset+offset, _on_window_closed already sent sunset_pos.
-    _prev_sunset_active should be True when _check_sunset_window_transition runs,
+    _prev_sunset_window_open should be True when _check_sunset_window_transition runs,
     so the transition guard prevents a second send.
     """
     coord = _make_coord(sunset_pos=0)
@@ -486,12 +478,12 @@ async def test_no_dispatch_at_end_time_when_end_of_window_position_holds():
 
     coord._time_mgr.before_end_time = True
     now = _dt.datetime(today.year, today.month, today.day, 18, 59, 0)
-    with _freeze_helpers_now(now):
+    with freeze_helpers_now(now):
         await coord._check_sunset_window_transition()
 
     coord._time_mgr.before_end_time = False
     now = _dt.datetime(today.year, today.month, today.day, 19, 0, 0)
-    with _freeze_helpers_now(now):
+    with freeze_helpers_now(now):
         await coord._check_sunset_window_transition()
 
     coord._cmd_svc.apply_position.assert_not_called()
@@ -508,7 +500,7 @@ async def test_dispatch_at_configured_sunset_boundary_after_end_of_window_hold()
     Same config as the sibling test above. Under the bug, the False→True
     edge is consumed the moment end-of-window position first reports
     ``is_sunset_active=True`` (at/after 19:00), so by 22:05 — the moment the
-    configured sunset boundary has genuinely passed — ``_prev_sunset_active``
+    configured sunset boundary has genuinely passed — ``_prev_sunset_window_open``
     is already True and no transition is left to detect: the sunset
     position never dispatches at all. Ticking 19:00 → 21:00 → 22:05 must
     produce exactly one dispatch, of the configured sunset position (16),
@@ -524,13 +516,20 @@ async def test_dispatch_at_configured_sunset_boundary_after_end_of_window_hold()
     today = _dt.date.today()
     coord._time_mgr.before_end_time = False  # window already clock-closed
 
-    for hour, minute in ((19, 0), (21, 0), (22, 5)):
+    for hour, minute in ((19, 0), (21, 0)):
         now = _dt.datetime(today.year, today.month, today.day, hour, minute, 0)
-        with _freeze_helpers_now(now):
+        with freeze_helpers_now(now):
             await coord._check_sunset_window_transition()
+
+    # Pin the boundary itself, not just the eventual count: a regression that
+    # dispatched early (e.g. at 19:00 or 21:00) must fail here, before the
+    # 22:05 tick below would otherwise mask it by bringing the total back to 1.
+    coord._cmd_svc.apply_position.assert_not_called()
+
+    now = _dt.datetime(today.year, today.month, today.day, 22, 5, 0)
+    with freeze_helpers_now(now):
+        await coord._check_sunset_window_transition()
 
     coord._cmd_svc.apply_position.assert_called_once()
     sent_pos = coord._cmd_svc.apply_position.call_args.args[1]
     assert sent_pos == 16
-
-    coord._cmd_svc.apply_position.assert_called_once()

--- a/tests/test_issue_266_sunset_transition.py
+++ b/tests/test_issue_266_sunset_transition.py
@@ -8,12 +8,19 @@ the transition and dispatch the sunset position.
 
 from __future__ import annotations
 
+import datetime as _dt
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.adaptive_cover_pro.const import CONF_SUNSET_POS, ControlMethod
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
+    CONF_END_OF_WINDOW_POS,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_POS,
+    ControlMethod,
+)
 from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
@@ -99,13 +106,15 @@ def _make_coord(
 
     coord._event_buffer = EventBuffer(maxlen=50)
     # Phase E: sunset-window state lives on the WindowTransitionTracker.  Each
-    # test reseeds via _seed_sunset_state below.
-    coord._compute_current_effective_default = MagicMock(return_value=(0, False))
+    # test reseeds via _seed_sunset_state below.  ``_sunset_window_is_open`` is
+    # the real coordinator seam (issue #1287) — blind to the end-of-window
+    # override, unlike the old ``_compute_current_effective_default`` tuple.
+    coord._sunset_window_is_open = MagicMock(return_value=False)
     coord._window_tracker = WindowTransitionTracker(
         hass=MagicMock(),
         logger=coord.logger,
         event_buffer=coord._event_buffer,
-        effective_default_fn=coord._compute_current_effective_default,
+        sunset_window_open_fn=coord._sunset_window_is_open,
     )
 
     return coord
@@ -114,13 +123,126 @@ def _make_coord(
 def _seed_sunset_state(
     coord, *, prev: bool | None, current_is_sunset: bool, pos: int = 0
 ):
-    """Seed the tracker's prior-sunset state and what the next effective-default lookup returns."""
+    """Seed the tracker's prior-sunset state and what the next boundary lookup returns.
+
+    ``pos`` is accepted for call-site compatibility with the pre-#1287 tuple
+    shape but no longer feeds anything: the dispatched position always comes
+    from the configured ``sunset_position`` option, not from this predicate.
+    """
+    del pos  # inert — see docstring
     coord._window_tracker._prev_sunset_active = prev
-    coord._compute_current_effective_default = MagicMock(
-        return_value=(pos, current_is_sunset)
+    coord._sunset_window_is_open = MagicMock(return_value=current_is_sunset)
+    coord._window_tracker._sunset_window_open_fn = coord._sunset_window_is_open
+
+
+def _make_boundary_test_coord(
+    *,
+    end_of_window_pos: int,
+    sunset_pos: int,
+    sunset_hour: int,
+    sunset_minute: int,
+    sunset_offset: int,
+    default_height: int = 100,
+) -> AdaptiveDataUpdateCoordinator:
+    """Coordinator fixture that drives the REAL sunset-boundary predicate (#1287).
+
+    Unlike ``_make_coord``/``_seed_sunset_state`` above (which stub the
+    tracker's edge-detector input directly with a canned value), this
+    fixture wires ``coord._window_tracker`` to the coordinator's real
+    ``_sunset_window_is_open`` — backed by a fake ``hass`` / ``_time_mgr`` /
+    ``get_blind_data`` — so the False→True edge is driven by the actual
+    ``read_sunset_window_open``/``resolve_sunset_verdict`` decision, exactly
+    like production. ``coord._time_mgr.before_end_time`` is left for the
+    caller to flip between ticks (real ``TimeWindowManager`` behavior,
+    simplified to a plain attribute here).
+    """
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._toggles = ToggleManager()
+    coord._policy = get_policy("cover_blind")
+    coord.automatic_control = True
+    coord._track_end_time = True
+    coord._inverse_state = False
+    coord.hass = MagicMock()
+    coord.hass.states.get.return_value = None  # no sunset/sunrise time entities
+
+    coord.entities = [MagicMock()]
+
+    options = {
+        CONF_DEFAULT_HEIGHT: default_height,
+        CONF_SUNSET_POS: sunset_pos,
+        CONF_END_OF_WINDOW_POS: end_of_window_pos,
+        CONF_SUNSET_OFFSET: sunset_offset,
+    }
+    config_entry = MagicMock()
+    config_entry.options = options
+    coord.config_entry = config_entry
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
+    coord._cmd_svc = cmd_svc
+    coord.async_refresh = AsyncMock()
+
+    manager = MagicMock()
+    manager.is_cover_manual.return_value = False
+    coord.manager = manager
+
+    def _fake_build_ctx(entity, options, *, force=False, is_safety=False, **_):
+        return PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=2,
+            time_threshold=0,
+            special_positions=[0, 100],
+            force=force,
+            is_safety=is_safety,
+        )
+
+    coord._build_position_context = _fake_build_ctx
+
+    today = _dt.date.today()
+    sun_data = MagicMock()
+    sun_data.sunset.return_value = _dt.datetime(
+        today.year, today.month, today.day, sunset_hour, sunset_minute, 0
     )
-    coord._window_tracker._effective_default_fn = (
-        coord._compute_current_effective_default
+    sun_data.sunrise.return_value = _dt.datetime(
+        today.year, today.month, today.day, 6, 0, 0
+    )
+    cover_data = MagicMock()
+    cover_data.sun_data = sun_data
+    coord.get_blind_data = MagicMock(return_value=cover_data)
+
+    time_mgr = MagicMock()
+    time_mgr.effective_daytime_gate = None  # no gate — astral path (#742)
+    time_mgr.window_explicitly_started = False
+    time_mgr.before_end_time = True
+    coord._time_mgr = time_mgr
+
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    coord._event_buffer = EventBuffer(maxlen=50)
+    coord._window_tracker = WindowTransitionTracker(
+        hass=coord.hass,
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        sunset_window_open_fn=coord._sunset_window_is_open,
+    )
+
+    return coord
+
+
+def _freeze_helpers_now(naive_utc: _dt.datetime):
+    """Patch ``helpers.dt.datetime.now()`` so ``compute_effective_default`` sees a fixed instant."""
+    aware = naive_utc.replace(tzinfo=_dt.UTC)
+    return patch(
+        "custom_components.adaptive_cover_pro.helpers.dt.datetime",
+        **{"now.return_value": aware},
     )
 
 
@@ -243,10 +365,8 @@ async def test_prev_sunset_active_initial_none_does_not_dispatch():
     coord = _make_coord(sunset_pos=0)
     # _prev_sunset_active starts as None (fresh coordinator)
     assert coord._window_tracker._prev_sunset_active is None
-    coord._compute_current_effective_default = MagicMock(return_value=(0, True))
-    coord._window_tracker._effective_default_fn = (
-        coord._compute_current_effective_default
-    )
+    coord._sunset_window_is_open = MagicMock(return_value=True)
+    coord._window_tracker._sunset_window_open_fn = coord._sunset_window_is_open
 
     await coord._check_sunset_window_transition()
 
@@ -328,5 +448,89 @@ async def test_dispatch_still_occurs_when_pipeline_control_method_is_default():
     _seed_sunset_state(coord, prev=False, current_is_sunset=True)
 
     await coord._check_sunset_window_transition()
+
+
+# ---------------------------------------------------------------------------
+# Issue #1287: end-of-window position (issue #625) must not open the
+# sunset-window latch — the configured sunset BOUNDARY must own the edge,
+# not the "a night-type default is in effect" flag ``compute_effective_default``
+# returns for both the end-of-window AND the sunset position.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_dispatch_at_end_time_when_end_of_window_position_holds():
+    """Regression for issue #1287.
+
+    Reporter's config: end_time clock-closes the window at 19:00, an
+    end-of-window position of 60 holds until astral sunset (21:04 local),
+    and ``sunset_offset=60`` pushes the real sunset BOUNDARY to 22:04. At
+    18:59 (window still open) and 19:00 (window just clock-closed) the
+    astral sunset boundary has NOT passed, so the tracker's False→True
+    latch must not open at end_time — dispatching the raw configured
+    sunset position (16) three hours early is exactly the bug:
+    ``compute_effective_default`` pairs the end-of-window position with
+    ``is_sunset_active=True`` (a "night-type default is in effect" flag),
+    and the tracker mis-reads that as "the configured sunset boundary has
+    passed."
+    """
+    coord = _make_boundary_test_coord(
+        end_of_window_pos=60,
+        sunset_pos=16,
+        sunset_hour=21,
+        sunset_minute=4,
+        sunset_offset=60,
+    )
+    today = _dt.date.today()
+
+    coord._time_mgr.before_end_time = True
+    now = _dt.datetime(today.year, today.month, today.day, 18, 59, 0)
+    with _freeze_helpers_now(now):
+        await coord._check_sunset_window_transition()
+
+    coord._time_mgr.before_end_time = False
+    now = _dt.datetime(today.year, today.month, today.day, 19, 0, 0)
+    with _freeze_helpers_now(now):
+        await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    assert "sunset_window_opened" not in [
+        e["event"] for e in coord._event_buffer.snapshot()
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_dispatch_at_configured_sunset_boundary_after_end_of_window_hold():
+    """Regression for issue #1287: the real 22:04 boundary must not be swallowed.
+
+    Same config as the sibling test above. Under the bug, the False→True
+    edge is consumed the moment end-of-window position first reports
+    ``is_sunset_active=True`` (at/after 19:00), so by 22:05 — the moment the
+    configured sunset boundary has genuinely passed — ``_prev_sunset_active``
+    is already True and no transition is left to detect: the sunset
+    position never dispatches at all. Ticking 19:00 → 21:00 → 22:05 must
+    produce exactly one dispatch, of the configured sunset position (16),
+    on the 22:05 tick.
+    """
+    coord = _make_boundary_test_coord(
+        end_of_window_pos=60,
+        sunset_pos=16,
+        sunset_hour=21,
+        sunset_minute=4,
+        sunset_offset=60,
+    )
+    today = _dt.date.today()
+    coord._time_mgr.before_end_time = False  # window already clock-closed
+
+    for hour, minute in ((19, 0), (21, 0), (22, 5)):
+        now = _dt.datetime(today.year, today.month, today.day, hour, minute, 0)
+        with _freeze_helpers_now(now):
+            await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_called_once()
+    sent_pos = coord._cmd_svc.apply_position.call_args.args[1]
+    assert sent_pos == 16
 
     coord._cmd_svc.apply_position.assert_called_once()

--- a/tests/test_state/test_window_transition_tracker.py
+++ b/tests/test_state/test_window_transition_tracker.py
@@ -18,12 +18,12 @@ from custom_components.adaptive_cover_pro.state.window_transition_tracker import
 )
 
 
-def _make_tracker(effective_default=(0, False)) -> WindowTransitionTracker:
+def _make_tracker(sunset_window_open=False) -> WindowTransitionTracker:
     return WindowTransitionTracker(
         hass=MagicMock(),
         logger=MagicMock(),
         event_buffer=EventBuffer(maxlen=10),
-        effective_default_fn=lambda _opts: effective_default,
+        sunset_window_open_fn=lambda _opts: sunset_window_open,
     )
 
 
@@ -115,7 +115,7 @@ def _common_kwargs(
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_skips_when_track_end_time_off():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     kwargs, apply_position, refresh = _common_kwargs()
     kwargs["track_end_time"] = False
     await tracker.check_sunset_window(**kwargs)
@@ -125,7 +125,7 @@ async def test_check_sunset_window_skips_when_track_end_time_off():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_skips_when_automatic_control_off():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     kwargs, apply_position, _ = _common_kwargs(automatic_control=False)
     await tracker.check_sunset_window(**kwargs)
     apply_position.assert_not_called()
@@ -133,7 +133,7 @@ async def test_check_sunset_window_skips_when_automatic_control_off():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_skips_when_sunset_pos_not_configured():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     kwargs, apply_position, _ = _common_kwargs(sunset_pos_cfg=None)
     await tracker.check_sunset_window(**kwargs)
     apply_position.assert_not_called()
@@ -142,7 +142,7 @@ async def test_check_sunset_window_skips_when_sunset_pos_not_configured():
 @pytest.mark.asyncio
 async def test_check_sunset_window_first_call_seeds_state_without_dispatch():
     """Mirrors the _last_sun_validity_state=None pattern (no spurious restart dispatch)."""
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     kwargs, apply_position, _ = _common_kwargs()
     await tracker.check_sunset_window(**kwargs)
     apply_position.assert_not_called()
@@ -151,7 +151,7 @@ async def test_check_sunset_window_first_call_seeds_state_without_dispatch():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_dispatches_on_false_to_true_transition():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     tracker._prev_sunset_active = False
     kwargs, apply_position, refresh = _common_kwargs(
         sunset_pos_cfg=25, entities=["cover.a", "cover.b"]
@@ -167,7 +167,7 @@ async def test_check_sunset_window_dispatches_on_false_to_true_transition():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_inverse_state_inverts_position():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     tracker._prev_sunset_active = False
     kwargs, apply_position, _ = _common_kwargs(sunset_pos_cfg=0, inverse=True)
     await tracker.check_sunset_window(**kwargs)
@@ -177,7 +177,7 @@ async def test_check_sunset_window_inverse_state_inverts_position():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_skips_manual_covers():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     tracker._prev_sunset_active = False
     kwargs, apply_position, _ = _common_kwargs(entities=["cover.manual", "cover.auto"])
     kwargs["is_cover_manual"] = lambda eid: eid == "cover.manual"
@@ -188,7 +188,7 @@ async def test_check_sunset_window_skips_manual_covers():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_no_double_dispatch_when_already_true():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     tracker._prev_sunset_active = True  # already in the sunset window
     kwargs, apply_position, _ = _common_kwargs()
     await tracker.check_sunset_window(**kwargs)
@@ -197,7 +197,7 @@ async def test_check_sunset_window_no_double_dispatch_when_already_true():
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_records_sunset_window_opened_event():
-    tracker = _make_tracker(effective_default=(0, True))
+    tracker = _make_tracker(sunset_window_open=True)
     tracker._prev_sunset_active = False
     kwargs, _, _ = _common_kwargs(sunset_pos_cfg=25, entities=["a", "b", "c"])
     await tracker.check_sunset_window(**kwargs)

--- a/tests/test_state/test_window_transition_tracker.py
+++ b/tests/test_state/test_window_transition_tracker.py
@@ -146,13 +146,13 @@ async def test_check_sunset_window_first_call_seeds_state_without_dispatch():
     kwargs, apply_position, _ = _common_kwargs()
     await tracker.check_sunset_window(**kwargs)
     apply_position.assert_not_called()
-    assert tracker._prev_sunset_active is True
+    assert tracker._prev_sunset_window_open is True
 
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_dispatches_on_false_to_true_transition():
     tracker = _make_tracker(sunset_window_open=True)
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     kwargs, apply_position, refresh = _common_kwargs(
         sunset_pos_cfg=25, entities=["cover.a", "cover.b"]
     )
@@ -162,13 +162,13 @@ async def test_check_sunset_window_dispatches_on_false_to_true_transition():
     for call in apply_position.call_args_list:
         assert call.args[1] == 25
     refresh.assert_awaited()
-    assert tracker._prev_sunset_active is True
+    assert tracker._prev_sunset_window_open is True
 
 
 @pytest.mark.asyncio
 async def test_check_sunset_window_inverse_state_inverts_position():
     tracker = _make_tracker(sunset_window_open=True)
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     kwargs, apply_position, _ = _common_kwargs(sunset_pos_cfg=0, inverse=True)
     await tracker.check_sunset_window(**kwargs)
     apply_position.assert_called_once()
@@ -178,7 +178,7 @@ async def test_check_sunset_window_inverse_state_inverts_position():
 @pytest.mark.asyncio
 async def test_check_sunset_window_skips_manual_covers():
     tracker = _make_tracker(sunset_window_open=True)
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     kwargs, apply_position, _ = _common_kwargs(entities=["cover.manual", "cover.auto"])
     kwargs["is_cover_manual"] = lambda eid: eid == "cover.manual"
     await tracker.check_sunset_window(**kwargs)
@@ -189,7 +189,7 @@ async def test_check_sunset_window_skips_manual_covers():
 @pytest.mark.asyncio
 async def test_check_sunset_window_no_double_dispatch_when_already_true():
     tracker = _make_tracker(sunset_window_open=True)
-    tracker._prev_sunset_active = True  # already in the sunset window
+    tracker._prev_sunset_window_open = True  # already in the sunset window
     kwargs, apply_position, _ = _common_kwargs()
     await tracker.check_sunset_window(**kwargs)
     apply_position.assert_not_called()
@@ -198,7 +198,7 @@ async def test_check_sunset_window_no_double_dispatch_when_already_true():
 @pytest.mark.asyncio
 async def test_check_sunset_window_records_sunset_window_opened_event():
     tracker = _make_tracker(sunset_window_open=True)
-    tracker._prev_sunset_active = False
+    tracker._prev_sunset_window_open = False
     kwargs, _, _ = _common_kwargs(sunset_pos_cfg=25, entities=["a", "b", "c"])
     await tracker.check_sunset_window(**kwargs)
     events = tracker._event_buffer.snapshot()


### PR DESCRIPTION
## Summary
`compute_effective_default` returns `is_sunset_active=True` for the end-of-window position, because that flag means "a night-type default is in effect", not "the configured sunset boundary has passed". `WindowTransitionTracker.check_sunset_window` was using that same flag as its sunset edge detector, so the False->True latch flipped at the clock end time instead of at the configured boundary. A reporter with end_time 19:00, an end-of-window position of 60% and a sunset position of 16% due at 22:04 got 60% and 16% dispatched 0.3s apart at 19:00, and the genuine 22:04 edge was swallowed because the latch had already consumed it.

I gave the edge detector its own named predicate rather than changing what `is_sunset_active` means to its eight consumers. `resolve_sunset_verdict` now owns the day/night decision and returns the two facts separately; `compute_effective_default` delegates to it and behaves identically, which is what keeps the #625 end-of-window position clear of the min/max clamp (#128) and keeps its sunset tilt (#1214). `read_sunset_window_open` reads the boundary fact directly, the coordinator injects it as `sunset_window_open_fn`, and the tracker now asks a boolean question instead of unpacking a tuple it only ever used half of. Fixing the latch also restores the real boundary edge, so the sunset position arrives at 22:04 where it was previously lost.

The 0.3s command pair is a consequence, not a second defect: both sends are unforced, `sunset_position` skips the position-delta gate by design, and the interval gate is anchored on the cover's `last_updated`. Gating semantics are untouched.

A second commit applies seven optional findings from the pre-merge audit, none of them behavioural: `SunsetVerdict.after_sunset` is now `bool | None` and returns `None` on the daytime-gate path instead of a fabricated `False`; the boundary test now asserts not-called between ticks so it pins the boundary rather than the count; `_prev_sunset_active` is renamed for the question it now asks; the duplicated time-freeze test helper moves to `tests/_helpers/time_freeze.py`.

## Testing
- 14439 tests passing (4 skipped, 1 xfailed)

## Related Issues
Refs #1287