### PR TITLE
fix: make the vertical sill offset perpendicular (#1290)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
@@ -274,6 +274,25 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
         the inherited ``calculate_position`` trace stays populated. At β=90° this
         returns the vertical drop unchanged (bit-for-bit regression anchor).
 
+        ``sill_height`` semantics on a pitched plane (discussion #1283): this
+        class does not override sill handling — the inherited
+        ``AdaptiveVerticalCover.calculate_position`` computes ``sill_offset =
+        _elevation_offset(sill_height, sol_elev, gamma)`` and subtracts it from
+        ``effective_distance`` *before* that value reaches this method. So
+        ``sill_height`` is currently interpreted as a vertical height above the
+        floor in the same horizontal frame the vertical engine uses (not a
+        distance measured along the pitched glass), and it is applied through
+        the same perpendicular ``_elevation_offset`` fix as the vertical case;
+        only the already sill-adjusted ``effective_distance`` gets re-projected
+        onto the slope here. #1283's fix to ``_elevation_offset`` (path length
+        → perpendicular offset) therefore moved this pitched-plane path in the
+        same opening direction it moved the vertical case — strictly closer to
+        correct, at every β < 90°, not just at the β=90° anchor. β=90° is
+        pinned bit-for-bit against the vertical engine (including with
+        ``sill_height`` > 0) by
+        ``test_pitch_90_matches_vertical_position`` in
+        ``tests/test_cover_types/test_roof_window.py``.
+
         For β<90° the down-slope shadow is ``effective_distance · (s·t)/(s·n)``.
         Factoring numerator and denominator by ``cos(elev)·cos Δazi`` expresses
         the ratio through the vertical foreshortening ``f = tan(elev)/cos(gamma)``

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -75,24 +75,30 @@ def glare_zone_effective_distance(
     ray path length — see its docstring, #1283) used by sill_offset in
     calculate_position, signed in the opposite direction.
 
-    Known conservatism gap: `_elevation_offset` runs its cos(gamma) term through
-    the one-sided `clamped_cos_gamma` floor (min 0.01, i.e. |gamma| > ~89.4°).
-    At the sill call site that floor is harmless — it shrinks the subtracted
-    offset, and `_project_drop` divides by the same clamped cosine, so the two
-    cancel to exactly `-sill_height` regardless. Here the floor only multiplies
-    (there is no matching division downstream), so at |gamma| > ~89.4° it
-    inflates this z-offset instead, which pushes the returned effective
-    distance — and therefore D_eff — higher, i.e. LESS zone protection than the
-    true geometry gives. This is genuinely reachable, not a theoretical corner:
-    `direct_sun_valid` (the only upstream gate GlareZoneHandler checks) requires
-    just `cos(gamma) > 0`, i.e. |gamma| < 90° with no margin, and the default
-    FOV cone (fov_left = fov_right = 90°) admits the same range — so a sun
-    grazing near-parallel to the glass at moderate elevation can land in this
-    band in normal operation. `vertical.py`'s own edge-case gate
-    (`EdgeCaseHandler`/`geometry._edge_case`) does not help either — it only
-    ever floors very-low elevation, not extreme gamma (the extreme-gamma branch
-    was deliberately removed, see its docstring). Narrow band, small effect,
-    but real.
+    The `clamped_cos_gamma` floor is not a conservatism gap here. This distance
+    is only ever consumed by re-entering `calculate_position` (`GlareZoneHandler`
+    calls `cover.calculate_raw_percentage(effective_distance_override=min_distance)`,
+    `glare_zone.py:114-115`), which projects it through `_project_drop`'s division
+    by `clamped_cos_gamma(self.gamma)` — the same gamma, same floor. Multiply then
+    divide by the same clamped cosine cancels exactly, so the z-term's contribution
+    to the final position is exactly `z`, independent of gamma — the same
+    cancellation as the sill case above (verified: elev=45°, gamma=89.6°, z=0.5 →
+    position delta = 0.5 exactly, floor engaged or not).
+
+    The one place this doesn't cancel: the raw `min_distance` feeds the
+    zone-selection `min()` and the sun-tracking early-return gate at
+    `glare_zone.py:109`, both evaluated *before* the re-entry above. There the
+    floor can inflate the z-term by up to `z·MIN_COS_GAMMA_CLAMP/tan(sol_elev)` —
+    ≤ `0.01·z` at elevations ≥45°, rising to `0.2·z` at the lowest elevations
+    `MIN_TAN_ELEVATION_CLAMP` (0.05) allows — enough to shift which zone is
+    selected or nudge the early-return gate by centimetres, never enough to
+    reach the returned position.
+
+    Pre-#1290 there was no cancellation at all: the z-term carried no
+    `cos(gamma)` factor, so it passed into `_project_drop`'s division
+    uncancelled and scaled as `z/clamped_cos_gamma(gamma)` — up to `100·z` at
+    the floor. This fix removed that blowup; the residual above is what's left
+    of it.
 
     Args:
         zone: The glare zone definition (x, y, radius, z — all in metres).

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -75,6 +75,25 @@ def glare_zone_effective_distance(
     ray path length — see its docstring, #1283) used by sill_offset in
     calculate_position, signed in the opposite direction.
 
+    Known conservatism gap: `_elevation_offset` runs its cos(gamma) term through
+    the one-sided `clamped_cos_gamma` floor (min 0.01, i.e. |gamma| > ~89.4°).
+    At the sill call site that floor is harmless — it shrinks the subtracted
+    offset, and `_project_drop` divides by the same clamped cosine, so the two
+    cancel to exactly `-sill_height` regardless. Here the floor only multiplies
+    (there is no matching division downstream), so at |gamma| > ~89.4° it
+    inflates this z-offset instead, which pushes the returned effective
+    distance — and therefore D_eff — higher, i.e. LESS zone protection than the
+    true geometry gives. This is genuinely reachable, not a theoretical corner:
+    `direct_sun_valid` (the only upstream gate GlareZoneHandler checks) requires
+    just `cos(gamma) > 0`, i.e. |gamma| < 90° with no margin, and the default
+    FOV cone (fov_left = fov_right = 90°) admits the same range — so a sun
+    grazing near-parallel to the glass at moderate elevation can land in this
+    band in normal operation. `vertical.py`'s own edge-case gate
+    (`EdgeCaseHandler`/`geometry._edge_case`) does not help either — it only
+    ever floors very-low elevation, not extreme gamma (the extreme-gamma branch
+    was deliberately removed, see its docstring). Narrow band, small effect,
+    but real.
+
     Args:
         zone: The glare zone definition (x, y, radius, z — all in metres).
         gamma: Surface solar azimuth in degrees (positive = sun to the right).
@@ -303,7 +322,12 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         # (sill_height·cos(γ)/tan(θ)) — the same units as `distance` — so
         #   effective_distance = distance − sill_offset          (perpendicular − perpendicular)
         #   position           = effective_distance·tan(θ) / cos(γ)   (via _project_drop)
-        # is algebraically identical to the formula above for EVERY γ, not only γ = 0.
+        # is algebraically identical to the formula above for EVERY γ, not only γ = 0 —
+        # PROVIDED θ is above the sill division's own clamp. `_elevation_offset` divides
+        # by tan(θ) floored at MIN_TAN_ELEVATION_CLAMP (0.05, θ ≈ 2.9°), while
+        # `_project_drop` multiplies by the raw, unclamped tan(θ); below ≈2.9° elevation
+        # the two no longer use the same tan(θ), so the cancellation is inexact there.
+        # This asymmetry predates #1283's fix and is unrelated to it.
         # (Before #1283's fix, `_elevation_offset` returned a ray PATH LENGTH instead of
         # a perpendicular offset, so this same-looking pair of lines silently
         # over-subtracted the sill by a factor of 1/cos(γ) at every γ != 0.)

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -26,18 +26,31 @@ from .base import AdaptiveGeneralCover
 MIN_TAN_ELEVATION_CLAMP = 0.05
 
 
-def _elevation_offset(height_m: float, sol_elev: float) -> float:
-    """Horizontal distance a sun ray covers while descending `height_m` metres.
+def _elevation_offset(height_m: float, sol_elev: float, gamma: float) -> float:
+    """Perpendicular in-room depth a sun ray covers while descending `height_m`.
 
-    For a sun ray at elevation `sol_elev` (degrees), descending a vertical
-    distance `height_m` corresponds to a horizontal distance of
-    `height_m / tan(sol_elev)`. The denominator is clamped at
-    MIN_TAN_ELEVATION_CLAMP so the offset stays finite at low sun.
+    Units contract: this returns a PERPENDICULAR depth (metres measured
+    straight out from the glass plane), the same units as `distance`
+    (`distance_shaded_area`) — never a ray path length. A sun ray at
+    elevation `sol_elev` (degrees) descending a vertical distance `height_m`
+    travels a horizontal PATH of `height_m / tan(sol_elev)`; only the
+    component of that path normal to the window, `path * cos(gamma)`, counts
+    as perpendicular depth. The denominator is clamped at
+    MIN_TAN_ELEVATION_CLAMP so the offset stays finite at low sun, and the
+    `cos(gamma)` factor goes through the shared one-sided `clamped_cos_gamma`
+    guard (#1030) rather than a raw `cos(rad(gamma))`.
+
+    Before this fix the helper returned the bare path length, which callers
+    then subtracted from a perpendicular `distance` and divided by `cos(gamma)`
+    a second time in `_project_drop` — over-subtracting the offset by a factor
+    of `1/cos(gamma)` at every gamma != 0 (discussion #1283).
 
     Shared by sill_height geometry in calculate_position and the optional
-    glare-zone Z (height above floor) offset.
+    glare-zone Z (height above floor) offset — one change here fixes both
+    call sites (CODING_GUIDELINES.md "No Code Duplication").
     """
-    return height_m / max(float(tan(rad(sol_elev))), MIN_TAN_ELEVATION_CLAMP)
+    path_length = height_m / max(float(tan(rad(sol_elev))), MIN_TAN_ELEVATION_CLAMP)
+    return path_length * clamped_cos_gamma(gamma)
 
 
 def glare_zone_effective_distance(
@@ -57,9 +70,10 @@ def glare_zone_effective_distance(
     uses min() across zones to select the most restrictive (closest) zone.
 
     When `zone.z > 0` the target sits above the floor (eye level, tabletop, TV).
-    The effective distance is then `nearest_y + z / tan(sol_elev)` — the same
-    trigonometric construction as sill_offset in calculate_position, signed in
-    the opposite direction.
+    The effective distance is then `nearest_y + z·cos(gamma)/tan(sol_elev)` —
+    the same shared `_elevation_offset` helper (a PERPENDICULAR offset, not a
+    ray path length — see its docstring, #1283) used by sill_offset in
+    calculate_position, signed in the opposite direction.
 
     Args:
         zone: The glare zone definition (x, y, radius, z — all in metres).
@@ -87,7 +101,7 @@ def glare_zone_effective_distance(
         return None  # Ray enters outside the window opening — zone is naturally blocked
 
     if zone.z > 0:
-        nearest_y += _elevation_offset(zone.z, sol_elev)
+        nearest_y += _elevation_offset(zone.z, sol_elev, gamma)
 
     return nearest_y
 
@@ -266,30 +280,37 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         # Account for window sill height (window not starting at floor)
         sill_offset = 0.0
         if self.sill_height > 0:
-            sill_offset = _elevation_offset(self.sill_height, self.sol_elev)
+            sill_offset = _elevation_offset(self.sill_height, self.sol_elev, self.gamma)
             effective_distance -= sill_offset
 
         # ── Sill geometry — why negative effective_distance means FULLY CLOSED ────────
         # "Position" = exposed glass from the bottom (0 = fully closed, h_win = open).
-        # A ray entering the glass at height h from the floor travels into the room at
-        # angle θ (sun elevation). At horizontal distance d from the window the ray is
-        # at height  h − d·tan(θ).
+        # Window plane at y=0 (the glass), room interior at y>0. A ray enters the
+        # glass at height H above the FLOOR (H = sill_height + position — the top of
+        # the exposed band) at surface-solar-azimuth γ and elevation θ. The ray's
+        # horizontal PATH before it reaches the floor is L = H / tan(θ); only the
+        # component of that path NORMAL to the window counts as perpendicular
+        # penetration into the room: y = L·cos(γ) = H·cos(γ) / tan(θ).
         #
-        # At d = shaded_distance (the protected-zone boundary):
-        #   • h > shaded_distance·tan(θ):  ray is ABOVE the floor at the boundary —
-        #     it has not hit anything and keeps travelling deeper into the room.
-        #     This counts as sun penetration past the protected zone.
-        #   • h ≤ shaded_distance·tan(θ):  ray hits the floor at or before the boundary.
+        # Contract: the ray must not penetrate past shaded_distance (D), i.e. y ≤ D:
+        #   H·cos(γ) / tan(θ) ≤ D  ⟺  H ≤ D·tan(θ) / cos(γ)
         #
-        # To stop ALL rays at the boundary, the top of exposed glass must satisfy
-        #   h_top ≤ shaded_distance·tan(θ)
-        # giving  position = clip(shaded_distance·tan(θ) − sill_height, 0, h_win),
-        # equivalently  effective_distance = max(distance − sill_offset, 0)
-        #               position           = effective_distance·tan(θ) / cos(γ)
+        # With H = sill_height + position, solving for position and clipping to the
+        # physical window range gives
+        #   position = clip(D·tan(θ)/cos(γ) − sill_height, 0, h_win)
         #
-        # When effective_distance ≤ 0, even the LOWEST glass entry (at sill_height)
-        # produces a ray that is still above the floor at the boundary. Every higher
-        # entry is worse. The blind must be FULLY CLOSED (position=0).
+        # `_elevation_offset` returns the PERPENDICULAR sill offset
+        # (sill_height·cos(γ)/tan(θ)) — the same units as `distance` — so
+        #   effective_distance = distance − sill_offset          (perpendicular − perpendicular)
+        #   position           = effective_distance·tan(θ) / cos(γ)   (via _project_drop)
+        # is algebraically identical to the formula above for EVERY γ, not only γ = 0.
+        # (Before #1283's fix, `_elevation_offset` returned a ray PATH LENGTH instead of
+        # a perpendicular offset, so this same-looking pair of lines silently
+        # over-subtracted the sill by a factor of 1/cos(γ) at every γ != 0.)
+        #
+        # When effective_distance ≤ 0, even the LOWEST glass entry (H = sill_height,
+        # i.e. position = 0) already violates the contract above. Every higher entry
+        # is worse. The blind must be FULLY CLOSED (position=0).
         #
         # Issue #304 short-circuited here with `return h_win` (fully open), which is
         # the geometric inverse of the correct answer. Issue #358 restores the clamp so

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -14,6 +14,7 @@ import pytest
 import numpy as np
 
 from custom_components.adaptive_cover_pro.calculation import AdaptiveVerticalCover
+from custom_components.adaptive_cover_pro.engine.sun_geometry import clamped_cos_gamma
 from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
 from tests.cover_helpers import build_vertical_cover
 
@@ -717,7 +718,12 @@ class TestLintelGate:
 
 
 def _lintel_gate_max_penetration(
-    position: float, h_win: float, depth: float, gamma: float, elev: float
+    position: float,
+    h_win: float,
+    depth: float,
+    gamma: float,
+    elev: float,
+    sill: float = 0.0,
 ) -> float:
     """Upper bound on in-room sun penetration a returned ``position`` can produce.
 
@@ -726,15 +732,26 @@ def _lintel_gate_max_penetration(
     both by the blind's own coverage (``position``) and by the physical limit
     of the lintel shadow (``h_win − depth·f``, the highest point the reveal can
     ever leave lit, regardless of blind position) — whichever is lower wins.
+
+    ``sill`` (discussion #1283) raises the whole window off the floor, so the
+    lit point's height above the floor is ``sill + exposed`` rather than just
+    ``exposed``. That shift only applies when something is actually exposed:
+    at ``exposed == 0`` the window is fully covered end to end (the blind
+    reaches all the way down to the sill), so literally no glass transmits
+    and the real penetration is 0 — not ``sill`` foreshortened. Without this
+    guard the helper would accuse a correctly fully-closed blind (or a
+    lintel-gated fully-open one whose gate has already zeroed the lit
+    ceiling) of leaking ``sill``'s own height into the room.
     """
     f = math.tan(math.radians(elev)) / math.cos(math.radians(gamma))
     lit_ceiling = max(h_win - depth * f, 0.0)
-    z = min(position, lit_ceiling)
+    exposed = min(position, lit_ceiling)
+    z = sill + exposed if exposed > 1e-9 else 0.0
     return z * math.cos(math.radians(gamma)) / math.tan(math.radians(elev))
 
 
 @pytest.mark.parametrize(
-    "distance,h_win,depth,gamma,elev",
+    "distance,h_win,depth,gamma,elev,sill",
     list(
         itertools.product(
             [0.0, 0.5, 1.5],
@@ -742,11 +759,12 @@ def _lintel_gate_max_penetration(
             [0.05, 0.18, 0.5],
             [0, 30, 60, 75],
             [20, 45, 75],
+            [0.0, 1.04],
         )
     ),
 )
 def test_no_direct_sun_lands_past_the_configured_distance(
-    base_cover_params, distance, h_win, depth, gamma, elev
+    base_cover_params, distance, h_win, depth, gamma, elev, sill
 ):
     """Contract (#1169): no position the engine returns may leak direct sun past
     the user's configured ``distance``.
@@ -757,20 +775,78 @@ def test_no_direct_sun_lands_past_the_configured_distance(
     continuous ``depth_contribution`` term, which opens the blind from the
     BOTTOM — where the lintel shadow (which falls on the TOP of the glass)
     protects nothing.
+
+    ``sill`` sweeps in a nonzero window-sill height (discussion #1283) so the
+    upper-bound contract is exercised on the dimension the units-mismatch bug
+    lives on, not just on the one configuration (``sill_height=0``) where the
+    bug is invisible.
     """
     params = base_cover_params.copy()
     params["distance"] = distance
     params["h_win"] = h_win
     params["window_depth"] = depth
+    params["sill_height"] = sill
     cover = make_cover_with_angles(params, gamma=gamma, sol_elev=elev)
     position = cover.calculate_position()
 
-    penetration = _lintel_gate_max_penetration(position, h_win, depth, gamma, elev)
+    penetration = _lintel_gate_max_penetration(
+        position, h_win, depth, gamma, elev, sill
+    )
 
     assert penetration <= distance + 1e-9, (
         f"distance={distance} h_win={h_win} depth={depth} gamma={gamma} "
-        f"elev={elev}: position={position:.4f} -> penetration={penetration:.4f} "
-        "exceeds the configured distance"
+        f"elev={elev} sill={sill}: position={position:.4f} -> "
+        f"penetration={penetration:.4f} exceeds the configured distance"
+    )
+
+
+@pytest.mark.parametrize(
+    "distance,h_win,gamma,elev,sill",
+    list(
+        itertools.product(
+            [0.0, 0.5, 1.5],
+            [0.62, 2.2],
+            [0, 30, 60, 75],
+            [20, 45, 75],
+            [0.0, 0.3, 1.04],
+        )
+    ),
+)
+def test_position_is_not_more_closed_than_the_contract_requires(
+    base_cover_params, distance, h_win, gamma, elev, sill
+):
+    """Contract (discussion #1283): the engine must never return LESS position
+    than the geometry requires.
+
+    ``test_no_direct_sun_lands_past_the_configured_distance`` is the upper
+    bound ("never leak past distance") — an engine that returns 0 everywhere
+    passes it trivially. This is the missing lower bound: the returned
+    position must be at least the analytically correct
+    ``clip(distance·tan(elev)/cos(gamma) − sill_height, 0, h_win)``
+    (``_elevation_offset`` returns a *perpendicular* offset — see
+    ``engine/covers/vertical.py`` — so the sill term is subtracted once, not
+    foreshortened a second time by ``/cos(gamma)``). ``window_depth`` is held
+    at 0 so the lintel gate (#1169, a one-way "may open further" relaxation)
+    never enters the comparison.
+    """
+    params = base_cover_params.copy()
+    params["distance"] = distance
+    params["h_win"] = h_win
+    params["window_depth"] = 0.0
+    params["sill_height"] = sill
+    cover = make_cover_with_angles(params, gamma=gamma, sol_elev=elev)
+    position = cover.calculate_position()
+
+    cos_gamma = clamped_cos_gamma(gamma)
+    correct = min(
+        max(distance * math.tan(math.radians(elev)) / cos_gamma - sill, 0.0),
+        h_win,
+    )
+
+    assert position >= correct - 1e-9, (
+        f"distance={distance} h_win={h_win} gamma={gamma} elev={elev} "
+        f"sill={sill}: position={position:.6f} is more closed than the "
+        f"contract requires (correct={correct:.6f})"
     )
 
 

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -746,6 +746,17 @@ def _lintel_gate_max_penetration(
     f = math.tan(math.radians(elev)) / math.cos(math.radians(gamma))
     lit_ceiling = max(h_win - depth * f, 0.0)
     exposed = min(position, lit_ceiling)
+    # This gate is a hard cutoff, not a limit: exposed == 0 forces z to 0, but
+    # exposed in (0, 1e-9] still takes the `sill + exposed` branch, so z jumps
+    # rather than approaching 0 continuously. That leaves a measure-zero blind
+    # band where a buggy engine returning a position in (0, 1e-9] when the
+    # correct answer is exactly 0 would leak `sill*cos(g)/tan(e)` past the
+    # upper-bound assertion below undetected (the lower-bound test doesn't
+    # catch that direction either). Unreachable on the current parametrize
+    # grid, and the epsilon matches distance_shaded_area's own "zero keeps
+    # direct sun from passing the glass plane" contract, so the gate itself is
+    # still the right call — this is a known, deliberately-accepted gap, not a
+    # bug in this helper.
     z = sill + exposed if exposed > 1e-9 else 0.0
     return z * math.cos(math.radians(gamma)) / math.tan(math.radians(elev))
 

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -746,17 +746,22 @@ def _lintel_gate_max_penetration(
     f = math.tan(math.radians(elev)) / math.cos(math.radians(gamma))
     lit_ceiling = max(h_win - depth * f, 0.0)
     exposed = min(position, lit_ceiling)
-    # This gate is a hard cutoff, not a limit: exposed == 0 forces z to 0, but
-    # exposed in (0, 1e-9] still takes the `sill + exposed` branch, so z jumps
-    # rather than approaching 0 continuously. That leaves a measure-zero blind
-    # band where a buggy engine returning a position in (0, 1e-9] when the
-    # correct answer is exactly 0 would leak `sill*cos(g)/tan(e)` past the
-    # upper-bound assertion below undetected (the lower-bound test doesn't
-    # catch that direction either). Unreachable on the current parametrize
-    # grid, and the epsilon matches distance_shaded_area's own "zero keeps
-    # direct sun from passing the glass plane" contract, so the gate itself is
-    # still the right call — this is a known, deliberately-accepted gap, not a
-    # bug in this helper.
+    # This gate is a hard cutoff, not a limit: exposed == 0 forces z to 0.0,
+    # and so does every exposed in (0, 1e-9] — `exposed > 1e-9` is False for
+    # both, so only exposed strictly above 1e-9 reaches the `sill + exposed`
+    # branch. z does not approach 0 continuously as exposed shrinks: it jumps
+    # from 0.0 straight to ~sill the instant exposed crosses 1e-9 (sill + 1e-9
+    # ~= sill). That leaves a measure-zero blind band: a buggy engine
+    # returning a position in (0, 1e-9] when the correct answer is exactly 0
+    # lands on the z = 0.0 side of the jump, so the helper reports
+    # penetration = 0 and the leak — which a continuous model would put at
+    # roughly `sill*cos(g)/tan(e)`, since even a sliver of exposed glass sits
+    # right at the sill line — slips past the upper-bound assertion below
+    # undetected (the lower-bound test doesn't catch that direction either).
+    # Unreachable on the current parametrize grid, and the epsilon matches
+    # distance_shaded_area's own "zero keeps direct sun from passing the
+    # glass plane" contract, so the gate itself is still the right call —
+    # this is a known, deliberately-accepted gap, not a bug in this helper.
     z = sill + exposed if exposed > 1e-9 else 0.0
     return z * math.cos(math.radians(gamma)) / math.tan(math.radians(elev))
 

--- a/tests/test_glare_zones.py
+++ b/tests/test_glare_zones.py
@@ -3,7 +3,7 @@
 Units: all glare zone coordinates (x, y, radius) and window_width are metres.
 """
 
-from math import radians, tan
+from math import cos, radians, tan
 
 import pytest
 from unittest.mock import MagicMock
@@ -53,24 +53,57 @@ class TestGlareZoneDataModel:
 
 
 class TestElevationOffset:
-    """The shared elevation-offset trig helper used by sill geometry and zone Z."""
+    """The shared elevation-offset trig helper used by sill geometry and zone Z.
+
+    Returns a PERPENDICULAR offset (discussion #1283): the ray's horizontal
+    path (``height / tan(elev)``) foreshortened by ``cos(gamma)`` down to the
+    component normal to the window. At ``gamma=0`` (``cos(gamma)=1``) this is
+    an exact no-op vs. the pre-#1283 path-length-only formula, so the
+    existing gamma=0 cases below are unchanged; ``test_gamma_scales_by_cosine``
+    pins the new factor directly.
+    """
 
     def test_zero_height_returns_zero(self):
-        assert _elevation_offset(0.0, 45.0) == pytest.approx(0.0)
+        assert _elevation_offset(0.0, 45.0, gamma=0.0) == pytest.approx(0.0)
 
     def test_height_one_at_45_degrees(self):
         # tan(45°) = 1 → height / tan = height
-        assert _elevation_offset(1.0, 45.0) == pytest.approx(1.0, rel=1e-9)
+        assert _elevation_offset(1.0, 45.0, gamma=0.0) == pytest.approx(1.0, rel=1e-9)
 
     def test_height_two_at_30_degrees(self):
         expected = 2.0 / tan(radians(30.0))
-        assert _elevation_offset(2.0, 30.0) == pytest.approx(expected, rel=1e-9)
+        assert _elevation_offset(2.0, 30.0, gamma=0.0) == pytest.approx(
+            expected, rel=1e-9
+        )
 
     def test_low_elevation_clamped(self):
         # Below the MIN_TAN_ELEVATION_CLAMP threshold, denominator caps so result stays finite.
-        result_low = _elevation_offset(1.0, 0.01)
+        result_low = _elevation_offset(1.0, 0.01, gamma=0.0)
         expected_cap = 1.0 / MIN_TAN_ELEVATION_CLAMP
         assert result_low == pytest.approx(expected_cap, rel=1e-9)
+
+    def test_gamma_scales_by_cosine(self):
+        """Non-zero gamma foreshortens the offset by cos(gamma) (discussion #1283).
+
+        Before the fix, this helper returned the bare ray path length
+        (``height / tan(elev)``) regardless of gamma; callers then subtracted
+        that path length from a perpendicular ``distance`` and divided the
+        difference by ``cos(gamma)`` a second time, over-subtracting by
+        ``1/cos(gamma)``. The helper itself must now fold in ``cos(gamma)``.
+        """
+        path_length = 2.0 / tan(radians(30.0))
+        expected = path_length * cos(radians(60.0))
+        assert _elevation_offset(2.0, 30.0, gamma=60.0) == pytest.approx(
+            expected, rel=1e-9
+        )
+        # Symmetric in sign — cos(gamma) is even.
+        assert _elevation_offset(2.0, 30.0, gamma=60.0) == pytest.approx(
+            _elevation_offset(2.0, 30.0, gamma=-60.0), rel=1e-9
+        )
+        # gamma=0 must reproduce the pre-#1283 no-cos path length exactly.
+        assert _elevation_offset(2.0, 30.0, gamma=0.0) == pytest.approx(
+            path_length, rel=1e-9
+        )
 
 
 class TestGlareZoneZHeight:
@@ -106,6 +139,33 @@ class TestGlareZoneZHeight:
         )
         expected = (2.0 - 0.3) + (1.0 / MIN_TAN_ELEVATION_CLAMP)
         assert dist == pytest.approx(expected, rel=1e-9)
+
+    def test_z_positive_with_nonzero_gamma_uses_perpendicular_offset(self):
+        """Z-offset at gamma != 0 is perpendicular (discussion #1283): the
+        elevation offset for the z (height-above-floor) term must be
+        ``z·cos(gamma)/tan(elev)``, not the bare path length ``z/tan(elev)``.
+
+        ``glare_zone_effective_distance`` shares ``_elevation_offset`` with
+        sill geometry in ``calculate_position`` — this pins the second of
+        the two call sites the fix touches (the first is sill_offset,
+        covered by tests/test_sill_height.py::TestSillOffsetIsPerpendicular).
+        """
+        zone_floor = GlareZone(name="Floor", x=0.0, y=2.0, radius=0.3, z=0.0)
+        zone_eye = GlareZone(name="Eye", x=0.0, y=2.0, radius=0.3, z=1.1)
+        gamma = 20.0
+        floor = _glare_zone_effective_distance(
+            zone_floor, gamma=gamma, sol_elev=45.0, window_half_width=1.0
+        )
+        eye = _glare_zone_effective_distance(
+            zone_eye, gamma=gamma, sol_elev=45.0, window_half_width=1.0
+        )
+        assert floor is not None and eye is not None
+        expected_delta = 1.1 * cos(radians(gamma)) / tan(radians(45.0))
+        assert eye == pytest.approx(floor + expected_delta, rel=1e-9)
+        # The pre-#1283 formula (bare path length, no cos(gamma)) would give a
+        # delta of 1.1/tan(45°) = 1.1 exactly — strictly larger. Confirms the
+        # cos(gamma) foreshortening is actually applied, not a no-op.
+        assert expected_delta < 1.1
 
     def test_z_does_not_bypass_window_aperture_gate(self):
         """Z>0 cannot rescue a zone whose sun ray enters outside the window."""

--- a/tests/test_sill_height.py
+++ b/tests/test_sill_height.py
@@ -2,11 +2,13 @@
 
 The sill_height parameter accounts for windows that do not start at floor level.
 When a window sill is at height S above the floor, the blind bottom is also at
-height S. The sill already blocks S/tan(elevation) meters of horizontal sun
-penetration for free, so the effective distance the blind needs to cover is
-reduced. This means the blind can be raised higher (smaller blind height needed).
+height S. The sill already blocks S·cos(gamma)/tan(elevation) meters of
+PERPENDICULAR sun penetration for free (discussion #1283 — the offset is
+perpendicular to the glass, the same units as ``distance``, never a ray path
+length), so the effective distance the blind needs to cover is reduced. This
+means the blind can be raised higher (smaller blind height needed).
 
-Implementation: effective_distance -= sill_height / max(tan(elevation), 0.05)
+Implementation: effective_distance -= sill_height * cos(gamma) / max(tan(elevation), 0.05)
 
 When effective_distance goes negative (sill shadow deeper than shaded distance),
 the blind must be FULLY CLOSED (position=0), not fully open. See the geometry
@@ -21,6 +23,7 @@ import pytest
 from custom_components.adaptive_cover_pro.calculation import (
     AdaptiveVerticalCover,
 )
+from custom_components.adaptive_cover_pro.engine.sun_geometry import clamped_cos_gamma
 from tests.cover_helpers import build_horizontal_cover, build_vertical_cover
 
 
@@ -130,16 +133,91 @@ class TestBackwardCompatibility:
             )
 
 
+class TestSillOffsetIsPerpendicular:
+    """Discussion #1283: the sill offset must be a PERPENDICULAR depth, not a
+    ray path length.
+
+    ``_elevation_offset(sill_height, sol_elev)`` returns ``sill/tan(elev)`` — a
+    horizontal PATH LENGTH. ``calculate_position`` subtracts that path length
+    from ``distance``, a PERPENDICULAR depth, and ``_project_drop`` then
+    divides the whole difference by ``cos(gamma)`` a SECOND time. Net effect:
+    ``position = D·tan(theta)/cos(gamma) - sill/cos(gamma)``, over-subtracting
+    the sill by a factor of ``1/cos(gamma)`` at every gamma != 0. The correct
+    form (derived from ``H = sill_height + position``, ray perpendicular
+    penetration ``y = H·cos(gamma)/tan(theta)``, contract ``y <= D``) is
+    ``position = clip(D·tan(theta)/cos(gamma) - sill_height, 0, h_win)`` — no
+    ``1/cos(gamma)`` on the sill term.
+    """
+
+    def test_sill_offset_is_perpendicular_not_path_length(self, base_cover_params):
+        """Reporter's exact geometry (discussion #1283): distance=1.25m,
+        h_win=0.98m, window_depth=0.25m, sill_height=1.04m, set_azimuth=300,
+        FOV +/-73.
+
+        Today both points return 0.0 (the sill's path-length over-subtraction
+        drives ``effective_distance`` negative, tripping the #358 clamp).
+        Correct: (elev=38.70, gamma=-45.65) -> 0.3926 m,
+        (elev=38.67, gamma=-68.76) -> 0.98 m (fully open, exactly h_win).
+        """
+        params = base_cover_params.copy()
+        params["win_azi"] = 300
+        params["fov_left"] = 73
+        params["fov_right"] = 73
+        params["distance"] = 1.25
+        params["h_win"] = 0.98
+        params["window_depth"] = 0.25
+        params["sill_height"] = 1.04
+
+        cover_a = make_vertical_cover(params, gamma=-45.65, sol_elev=38.70)
+        cover_b = make_vertical_cover(params, gamma=-68.76, sol_elev=38.67)
+
+        assert cover_a.calculate_position() == pytest.approx(
+            0.3926, abs=1e-4
+        ), f"expected ~0.3926m, got {cover_a.calculate_position():.4f}m"
+        assert cover_b.calculate_position() == pytest.approx(
+            0.98, abs=1e-4
+        ), f"expected ~0.98m (fully open), got {cover_b.calculate_position():.4f}m"
+
+    def test_sill_height_zero_is_bit_identical_across_gamma(self, base_cover_params):
+        """``sill_height=0`` must be an exact no-op at every gamma, not just
+        gamma=0 — the ``cos(gamma)`` factor this fix adds to
+        ``_elevation_offset`` is multiplied against a zero sill, so it must
+        stay bit-identical to omitting ``sill_height`` entirely.
+        """
+        for gamma in range(-85, 86, 5):
+            cover_no_sill = make_vertical_cover(
+                base_cover_params, gamma=float(gamma), sol_elev=45.0
+            )
+            cover_zero_sill = make_vertical_cover(
+                base_cover_params,
+                gamma=float(gamma),
+                sol_elev=45.0,
+                sill_height=0.0,
+            )
+            pos_no_sill = cover_no_sill.calculate_position()
+            pos_zero_sill = cover_zero_sill.calculate_position()
+            assert pos_no_sill == pos_zero_sill, (
+                f"gamma={gamma}: no_sill={pos_no_sill!r}, "
+                f"zero_sill={pos_zero_sill!r}"
+            )
+
+
 class TestGeometrySillHeightEffect:
     """Tests that verify the correct geometric effect of sill_height.
 
     Correct geometry: When a window sill is at height S above the floor, the blind
-    bottom starts at S meters height. The sill already provides S/tan(elevation) meters
-    of "free" horizontal sun protection. So the effective distance the blind needs to
-    cover is reduced by S/tan(elevation), meaning:
-      - effective_distance = distance - sill_height / tan(elevation)
+    bottom starts at S meters height. The sill already provides a PERPENDICULAR
+    S·cos(gamma)/tan(elevation) meters of "free" sun protection (discussion #1283
+    — the offset is perpendicular to the glass, the same units as ``distance``,
+    never a ray path length). So the effective distance the blind needs to
+    cover is reduced by S·cos(gamma)/tan(elevation), meaning:
+      - effective_distance = distance - sill_height * cos(gamma) / tan(elevation)
       - base_height = effective_distance * tan(elevation) / cos(gamma)
       - base_height DECREASES with sill_height (blind can be raised higher)
+
+    All tests in this class use gamma=0.0 (cos(gamma)=1), where this is an
+    exact no-op vs. the pre-#1283 path-length formula — see
+    ``TestSillOffsetIsPerpendicular`` for the gamma != 0 behaviour.
 
     When effective_distance goes negative (sill shadow deeper than shaded distance),
     it is clamped to 0 → blind fully closed. See TestRaysAbovefloorAtShadedBoundary.
@@ -502,6 +580,13 @@ class TestInteractionWithWindowDepth:
         drives effective_distance (#1169 — window_depth no longer adds a
         continuous ``depth·sin(gamma)`` term; see ``TestLintelGate`` in
         test_geometric_accuracy.py for the full-open gate itself).
+
+        The sill offset is PERPENDICULAR (discussion #1283): it is
+        ``sill_height * cos(gamma) / tan(elevation)``, not
+        ``sill_height / tan(elevation)`` — the latter is a ray path length,
+        and subtracting it from ``distance`` (a perpendicular depth) then
+        dividing by ``cos(gamma)`` a second time over-subtracts the sill by
+        ``1/cos(gamma)``.
         """
         gamma = 30.0
         sol_elev = 45.0
@@ -510,10 +595,11 @@ class TestInteractionWithWindowDepth:
 
         # window_depth contributes nothing below the gate — only sill_height
         # moves effective_distance.
-        sill_offset = sill_height / math.tan(math.radians(sol_elev))
+        cos_gamma = clamped_cos_gamma(gamma)
+        sill_offset = sill_height * cos_gamma / math.tan(math.radians(sol_elev))
         expected_effective_dist = 0.5 - sill_offset  # base distance=0.5
 
-        expected_path_length = expected_effective_dist / math.cos(math.radians(gamma))
+        expected_path_length = expected_effective_dist / cos_gamma
         expected_base_height = expected_path_length * math.tan(math.radians(sol_elev))
 
         cover_both = make_vertical_cover(

--- a/tests/test_sill_height.py
+++ b/tests/test_sill_height.py
@@ -762,8 +762,8 @@ class TestIssue358ReporterRegression:
     Reporter config: sill_height=1.6m, h_win=0.55m, distance=1.0m,
     sol_elev=47.4°, gamma≈35.8°.
 
-    Geometry: sill_offset = 1.6 · cos(35.8°) / tan(47.4°) ≈ 1.190m
-    effective_distance = 1.0 - 1.190 = -0.190 (< 0 → clamp to 0 → position=0)
+    Geometry: sill_offset = 1.6 · cos(35.8°) / tan(47.4°) ≈ 1.193m
+    effective_distance = 1.0 - 1.193 = -0.193 (< 0 → clamp to 0 → position=0)
 
     The offset is perpendicular, not a ray path length (#1290). The pre-#1290
     formula (1.6 / tan(47.4°) ≈ 1.467m) gave a different effective_distance but

--- a/tests/test_sill_height.py
+++ b/tests/test_sill_height.py
@@ -762,8 +762,12 @@ class TestIssue358ReporterRegression:
     Reporter config: sill_height=1.6m, h_win=0.55m, distance=1.0m,
     sol_elev=47.4°, gamma≈35.8°.
 
-    Geometry: sill_offset = 1.6 / tan(47.4°) ≈ 1.467m
-    effective_distance = 1.0 - 1.467 = -0.467 (< 0 → clamp to 0 → position=0)
+    Geometry: sill_offset = 1.6 · cos(35.8°) / tan(47.4°) ≈ 1.190m
+    effective_distance = 1.0 - 1.190 = -0.190 (< 0 → clamp to 0 → position=0)
+
+    The offset is perpendicular, not a ray path length (#1290). The pre-#1290
+    formula (1.6 / tan(47.4°) ≈ 1.467m) gave a different effective_distance but
+    the same clamped outcome, which is why this case reads identically either way.
 
     The sun enters through 0.55m of glass above the sill and every ray through
     that glass is still above the floor at the 1.0m shaded boundary. The blind
@@ -859,9 +863,11 @@ class TestSillGeometryInvariant:
     """Parametrized invariant: whenever analytical effective_distance < 0, position==0.
 
     Sweeps a grid of (sill, distance, sol_elev, gamma) values. Any combination where
-    sill_offset = sill/tan(elev) exceeds shaded_distance analytically must produce
-    position=0 from calculate_position(). This guard makes any future "return h_win
-    when effective_distance <= 0" regression break dozens of cases at once.
+    sill_offset = sill * clamped_cos_gamma(gamma) / tan(elev) — the PERPENDICULAR
+    offset (discussion #1283), same units as `distance`, never a bare path length —
+    exceeds shaded_distance analytically must produce position=0 from
+    calculate_position(). This guard makes any future "return h_win when
+    effective_distance <= 0" regression break dozens of cases at once.
     """
 
     @pytest.mark.parametrize(
@@ -902,14 +908,16 @@ class TestSillGeometryInvariant:
     ):
         """Any (sill, dist, elev, gamma) where effective_distance <= 0 must yield position=0.
 
-        effective_distance = distance - sill_height / max(tan(sol_elev), 0.05)
-        When <= 0, every ray through the glass is above the floor at the shaded
-        boundary. Blind must be fully closed.
+        effective_distance = distance - sill_height * clamped_cos_gamma(gamma) / max(tan(sol_elev), 0.05)
+        (the PERPENDICULAR sill offset, same units as `distance` — discussion #1283;
+        never the bare path-length `sill_height / tan(sol_elev)`). When <= 0, every
+        ray through the glass is above the floor at the shaded boundary. Blind must
+        be fully closed.
         """
         import math
 
         tan_elev = max(math.tan(math.radians(sol_elev)), 0.05)
-        sill_offset = sill_height / tan_elev
+        sill_offset = sill_height * clamped_cos_gamma(gamma) / tan_elev
         analytical_effective_distance = distance - sill_offset
 
         # Only run the assertion for cases that analytically trigger the clamp
@@ -932,6 +940,34 @@ class TestSillGeometryInvariant:
             f"effective_distance={analytical_effective_distance:.4f} ≤ 0 → "
             f"expected position=0.0, got {position}"
         )
+
+    def test_high_gamma_is_not_in_the_clamp_regime(self, base_cover_params):
+        """(sill=0.5, dist=0.5, elev=20°, gamma=75°) is the exact case where the
+        old (pre-#1290) path-length threshold and the corrected perpendicular
+        one disagree (issue #1290).
+
+        Old (buggy) path-length threshold: sill_offset = 0.5/tan(20°) = 1.3737,
+        effective_distance = 0.5 - 1.3737 = -0.8737 <= 0 -> would assert
+        position == 0 (wrongly, since the engine no longer computes this).
+
+        Corrected perpendicular threshold: sill_offset =
+        0.5*clamped_cos_gamma(75°)/tan(20°) = 0.35555, effective_distance =
+        0.5 - 0.35555 = +0.14445 > 0 -> NOT in the clamp regime, so this row
+        must never be added to TestSillGeometryInvariant's parametrize list
+        (it would silently land in that test's `pytest.skip` branch instead
+        of asserting anything). Pinning it here as its own asserting test
+        instead gives this exact divergence explicit, non-skippable coverage.
+        """
+        cover = make_vertical_cover(
+            base_cover_params,
+            gamma=75.0,
+            sol_elev=20.0,
+            sill_height=0.5,
+            distance=0.5,
+        )
+        position = cover.calculate_position()
+        assert position > 0.0
+        assert position == pytest.approx(0.2032, abs=1e-3)
 
 
 class TestNumericalStability:


### PR DESCRIPTION
## Summary

`_elevation_offset` returned a ray path length (`sill/tan(elev)`). `calculate_position` subtracted that from `distance`, a perpendicular depth, and `_project_drop` then divided by `cos(gamma)` a second time, over-subtracting the sill by `1/cos(gamma)` at every gamma != 0.

```
code:     position = D*tan(theta)/cos(gamma) - sill/cos(gamma)
correct:  position = D*tan(theta)/cos(gamma) - sill
```

The file's own comment stated the correct form and then claimed an "equivalently" that holds only at gamma = 0. In the reporter's geometry the error was 1.83 m of phantom shaded distance against a 0.98 m window, so `effective_distance` went negative, the clamp pinned position at 0, and the blind sat at `min_position_sun_tracking` all afternoon. Worst measured over-closure was 55 percentage points.

I gave the helper a `gamma` parameter and multiplied by `clamped_cos_gamma`, so it now returns a perpendicular offset in the same units as `distance`. One helper change fixes both call sites, the sill offset and the glare-zone z offset. Exact no-op at `sill_height = 0`.

Reported in discussion 1283. Prior art: 304 and 358 both patched this symptom at the wrong end without spotting the units mismatch.

### Tests

Adds the missing lower-bound half of the geometric contract (nothing previously asserted the engine is not MORE closed than required; it failed 28/216 pre-fix), a sill dimension on the existing upper-bound guard, a pin on the reporter's geometry, and a glare-zone z regression test.

### Also recorded

Comment-only notes on three clamp asymmetries the fix exposed: the sill cancellation holds only above the 2.9 degree tan clamp, the lintel gate's zero-exposure cutoff is a hard step, and `sill_height` on a pitched roof-window plane runs through the vertical path before projection.

## Testing
- ✅ 14877 tests passing

## Related Issues
Refs #1290