### PR TITLE
feat: publish per-slot blind-spot elevation gating (#1292)

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -29,6 +29,7 @@ from .const import (
     BLIND_SPOT_SLOTS,
     CONF_CLIMATE_MODE,
     CONF_TRAVEL_TIME_CALIBRATION,
+    DEFAULT_BLIND_SPOT_ELEVATION_MODE,
     TRAVEL_CALIBRATION_STATE_CANCELLED,
     TRAVEL_CALIBRATION_STATE_COMPLETE,
     TRAVEL_CALIBRATION_STATE_FAILED,
@@ -674,8 +675,11 @@ def _sun_position_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
         # One [right_edge, left_edge] pair per active slot (issue #701). Slot 1
         # reuses the legacy unsuffixed keys. ``blind_spot_range`` keeps emitting
         # only slot 1 for Lovelace-card back-compat; ``blind_spot_ranges`` lists
-        # every active slot.
+        # every active slot. ``blind_spot_slots`` (issue #1292) pairs each range
+        # with the elevation gate that decides when the slot is active, built in
+        # this same loop so the two attributes never drift out of sync.
         ranges: list[list[float]] = []
+        slots: list[dict[str, Any]] = []
         for keys in BLIND_SPOT_SLOTS.values():
             # Signed-gamma keys are the primary source (issue #247): the wedge is
             # -right_gamma..left_gamma, so the emitted [right, left] pair is
@@ -683,16 +687,32 @@ def _sun_position_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
             lg = config.get(keys["left_gamma"])
             rg = config.get(keys["right_gamma"])
             if lg is not None and rg is not None:
-                ranges.append([-rg, lg])
-                continue
-            bs_left = config.get(keys["left"])
-            bs_right = config.get(keys["right"])
-            if bs_left is None or bs_right is None:
-                continue
-            ranges.append([fov_left - bs_right, fov_left - bs_left])
+                pair = [-rg, lg]
+            else:
+                bs_left = config.get(keys["left"])
+                bs_right = config.get(keys["right"])
+                if bs_left is None or bs_right is None:
+                    continue
+                pair = [fov_left - bs_right, fov_left - bs_left]
+            ranges.append(pair)
+            slots.append(
+                {
+                    "range": pair,
+                    "elevation": config.get(keys["elevation"]),
+                    # ``configuration`` always materializes this key (builder.py
+                    # copies it unconditionally via options.get(...)), so a
+                    # key-absent default would never fire for a legacy
+                    # pre-#702 blind spot whose raw option is genuinely unset —
+                    # coalesce the None instead, matching config_types.py's
+                    # ``elevation_mode or DEFAULT_BLIND_SPOT_ELEVATION_MODE``.
+                    "elevation_mode": config.get(keys["elevation_mode"])
+                    or DEFAULT_BLIND_SPOT_ELEVATION_MODE,
+                }
+            )
         if ranges:
             attrs["blind_spot_range"] = ranges[0]
             attrs["blind_spot_ranges"] = ranges
+            attrs["blind_spot_slots"] = slots
 
     return attrs or None
 

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -9,7 +9,12 @@ import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass
 
-from custom_components.adaptive_cover_pro.const import CONF_SENSOR_TYPE, CoverType
+from custom_components.adaptive_cover_pro.const import (
+    BLIND_SPOT_ELEV_MODE_ABOVE,
+    CONF_SENSOR_TYPE,
+    CoverType,
+    DEFAULT_BLIND_SPOT_ELEVATION_MODE,
+)
 from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverClimateStatusSensor,
     AdaptiveCoverControlStatusSensor,
@@ -314,6 +319,148 @@ def test_sun_position_attributes_blind_spot_ranges_multi_slot():
     # New multi-slot attr: slot 1 then slot 2.
     # slot 2: left_edge = 45 - 20 = 25, right_edge = 45 - 15 = 30
     assert attrs["blind_spot_ranges"] == [[40.0, 35.0], [30.0, 25.0]]
+
+
+def test_sun_position_attributes_blind_spot_slots_includes_elevation_gate():
+    """blind_spot_slots carries the per-slot elevation gate alongside the range."""
+    coord = _make_coordinator(
+        diagnostics={
+            "sun_azimuth": 180.0,
+            "sun_elevation": 45.0,
+            "gamma": None,
+            "configuration": {
+                "azimuth": 180,
+                "fov_left": 45,
+                "fov_right": 45,
+                "enable_blind_spot": True,
+                "blind_spot_left": 10.0,
+                "blind_spot_right": 5.0,
+                "blind_spot_elevation": 20.0,
+                "blind_spot_elevation_mode": BLIND_SPOT_ELEV_MODE_ABOVE,
+            },
+        }
+    )
+    entry = _make_config_entry()
+    sensor = AdaptiveCoverSunPositionSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    # left_edge = fov_left - blind_spot_left = 45 - 10 = 35
+    # right_edge = fov_left - blind_spot_right = 45 - 5 = 40
+    assert attrs["blind_spot_slots"] == [
+        {
+            "range": [40.0, 35.0],
+            "elevation": 20.0,
+            "elevation_mode": BLIND_SPOT_ELEV_MODE_ABOVE,
+        }
+    ]
+
+
+def test_sun_position_attributes_blind_spot_slots_multi_slot_and_gamma_source():
+    """blind_spot_slots enumerates every slot in the same order as blind_spot_ranges.
+
+    Slot 1 is sourced from the signed-gamma keys and carries an explicit
+    elevation gate; slot 2 is sourced from the legacy left/right keys and has
+    no elevation gate configured, so it falls back to
+    ``DEFAULT_BLIND_SPOT_ELEVATION_MODE``.
+    """
+    coord = _make_coordinator(
+        diagnostics={
+            "sun_azimuth": 180.0,
+            "sun_elevation": 45.0,
+            "gamma": None,
+            "configuration": {
+                "azimuth": 180,
+                "fov_left": 45,
+                "fov_right": 45,
+                "enable_blind_spot": True,
+                "blind_spot_left_gamma": 35.0,
+                "blind_spot_right_gamma": -40.0,
+                "blind_spot_elevation": 20.0,
+                "blind_spot_elevation_mode": BLIND_SPOT_ELEV_MODE_ABOVE,
+                "blind_spot_left_2": 20.0,
+                "blind_spot_right_2": 15.0,
+            },
+        }
+    )
+    entry = _make_config_entry()
+    sensor = AdaptiveCoverSunPositionSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    slots = attrs["blind_spot_slots"]
+    assert [slot["range"] for slot in slots] == attrs["blind_spot_ranges"]
+    assert slots == [
+        {
+            "range": [40.0, 35.0],
+            "elevation": 20.0,
+            "elevation_mode": BLIND_SPOT_ELEV_MODE_ABOVE,
+        },
+        {
+            "range": [30.0, 25.0],
+            "elevation": None,
+            "elevation_mode": DEFAULT_BLIND_SPOT_ELEVATION_MODE,
+        },
+    ]
+
+
+def test_sun_position_attributes_blind_spot_slots_none_elevation_mode_falls_back_to_default():
+    """A present-but-None elevation_mode (legacy pre-#702 config) still defaults.
+
+    ``diagnostics/builder.py`` materializes ``blind_spot_elevation_mode`` in the
+    ``configuration`` dict unconditionally via ``options.get(...)`` — for a blind
+    spot configured before #702 introduced the elevation-mode option and never
+    re-saved, the raw option is absent, so the copied value is ``None`` rather
+    than the key being absent entirely. ``config.get(key, DEFAULT)`` would not
+    catch this, since the key IS present (with value ``None``). The engine
+    (``config_types.py``) already treats an unset elevation_mode as
+    ``DEFAULT_BLIND_SPOT_ELEVATION_MODE``, so the sensor attribute must publish
+    the same gate the engine actually applies, not ``None``.
+    """
+    coord = _make_coordinator(
+        diagnostics={
+            "sun_azimuth": 180.0,
+            "sun_elevation": 45.0,
+            "gamma": None,
+            "configuration": {
+                "azimuth": 180,
+                "fov_left": 45,
+                "fov_right": 45,
+                "enable_blind_spot": True,
+                "blind_spot_left": 10.0,
+                "blind_spot_right": 5.0,
+                "blind_spot_elevation": None,
+                "blind_spot_elevation_mode": None,
+            },
+        }
+    )
+    entry = _make_config_entry()
+    sensor = AdaptiveCoverSunPositionSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs["blind_spot_slots"] == [
+        {
+            "range": [40.0, 35.0],
+            "elevation": None,
+            "elevation_mode": DEFAULT_BLIND_SPOT_ELEVATION_MODE,
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The sun sensor emitted only `blind_spot_range` and `blind_spot_ranges`, both pure azimuth, so the companion Lovelace card could draw the blind-spot wedge but had no way to tell when the spot is actually active. The per-slot elevation gate was already sitting in the diagnostics `configuration` dict and `_sun_position_attrs` was dropping it.

`_sun_position_attrs` now also emits `blind_spot_slots`: one entry per active slot, in the same order as `blind_spot_ranges`, pairing each range with its `elevation` and `elevation_mode`. It is built inside the same loop that builds the ranges, so the two attributes cannot drift apart. Existing attributes are byte-identical to before, and no new config option is introduced.

```python
attrs["blind_spot_slots"] = [
    {"range": [right, left], "elevation": 15.0, "elevation_mode": "above"},
    ...
]
```

`elevation_mode` coalesces a `None` as well as a missing key. `diagnostics/builder.py` materializes that key unconditionally, so a key-absent default would never fire for a blind spot configured before #702 and never re-saved. The engine already applies `below` for those via `config_types.py`, and the published gate has to match the gate actually applied. `elevation` is deliberately left uncoalesced, since `None` there correctly means "no elevation gate".

## Scope
Sensor side only. The Configuration Summary "Today : HH:MM -> HH:MM" clause from the issue body is not included here: it needs a blind-spot term in `SunGeometry.solar_times_with_position()`, which has none, and the elevation-gated window is multi-interval rather than the single contiguous window the solar line renders. I have parked that on issue #734, which already tracks exactly that masking work.

Note that issue #1291 (gamma keys missing from the diagnostics `configuration` dict) is still open. Until it lands, this attribute is empty for gamma-only blind spots, same as `blind_spot_ranges` is today. Nothing here depends on it structurally.

## Testing
- ✅ 243 tests passing

## Related Issues
Refs #1292