### PR TITLE
fix: publish blind-spot gamma keys in diagnostics config

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -1223,7 +1223,14 @@ class DiagnosticsBuilder:
                 **{
                     keys[sub]: options.get(keys[sub])
                     for keys in BLIND_SPOT_SLOTS.values()
-                    for sub in ("left", "right", "elevation", "elevation_mode")
+                    for sub in (
+                        "left",
+                        "right",
+                        "left_gamma",
+                        "right_gamma",
+                        "elevation",
+                        "elevation_mode",
+                    )
                 },
                 "min_position": options.get(CONF_MIN_POSITION),
                 "min_position_sun_tracking": options.get(

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -20,6 +20,7 @@ from custom_components.adaptive_cover_pro.pipeline.types import (
     PipelineResult,
 )
 from custom_components.adaptive_cover_pro.const import (
+    BLIND_SPOT_SLOTS,
     CONF_CLOUD_SUPPRESSION,
     CONF_CLOUDY_POSITION,
     FORECAST_STEP_MINUTES,
@@ -944,7 +945,41 @@ class TestConfigurationDiagnostics:
             "is_sunny_source",
             "templated_thresholds",
         }
+        # Signed-gamma sub-keys (issue #247's primary storage) per slot — sourced
+        # from BLIND_SPOT_SLOTS rather than hardcoded, per the no-magic-values
+        # guideline (#1291: these were missing, leaving the gamma-preferred
+        # branch in sensor.py dead on the diagnostics path).
+        expected_keys |= {
+            keys[sub]
+            for keys in BLIND_SPOT_SLOTS.values()
+            for sub in ("left_gamma", "right_gamma")
+        }
         assert expected_keys == set(config.keys())
+
+    def test_configuration_forwards_gamma_only_slot1_values(
+        self, builder: DiagnosticsBuilder
+    ):
+        """A gamma-only slot-1 options dict (today's only write shape, #1291)
+        forwards left_gamma/right_gamma into diag['configuration'].
+
+        Today's options flow (BLIND_SPOT_FORM_KEYS) writes signed-gamma keys
+        only, never the legacy left/right pair — so this is the real shape a
+        configured blind spot has in production.
+        """
+        diag, _ = builder.build(
+            _base_ctx(
+                config_options={
+                    "blind_spot": True,
+                    "blind_spot_left_gamma": 35,
+                    "blind_spot_right_gamma": 40,
+                    "fov_left": 45,
+                    "fov_right": 45,
+                }
+            )
+        )
+        config = diag["configuration"]
+        assert config["blind_spot_left_gamma"] == 35
+        assert config["blind_spot_right_gamma"] == 40
 
     def test_configuration_reflects_context(self, builder: DiagnosticsBuilder):
         """Configuration reflects pipeline result and context state values.

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.components.sensor import SensorDeviceClass
 
 from custom_components.adaptive_cover_pro.const import CONF_SENSOR_TYPE, CoverType
+from custom_components.adaptive_cover_pro.diagnostics.builder import DiagnosticsBuilder
 from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverClimateStatusSensor,
     AdaptiveCoverControlStatusSensor,
@@ -17,6 +18,8 @@ from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverSunPositionSensor,
     _DIAGNOSTIC_SPECS,
 )
+
+from tests.test_diagnostics.test_builder import _base_ctx
 
 
 def _make_config_entry(sensor_type=CoverType.BLIND):
@@ -314,6 +317,89 @@ def test_sun_position_attributes_blind_spot_ranges_multi_slot():
     # New multi-slot attr: slot 1 then slot 2.
     # slot 2: left_edge = 45 - 20 = 25, right_edge = 45 - 15 = 30
     assert attrs["blind_spot_ranges"] == [[40.0, 35.0], [30.0, 25.0]]
+
+
+def _build_diagnostics_for_config_options(config_options: dict) -> dict:
+    """Run the REAL ``DiagnosticsBuilder`` over the given raw options.
+
+    Unlike the hand-fed ``configuration`` dicts above (which prove only that
+    ``_sun_position_attrs`` branches correctly on whatever keys it's handed),
+    this drives the actual production chain — options -> DiagnosticsBuilder
+    -> diagnostics['configuration'] — so a bug in the builder's key-forwarding
+    (#1291) is actually caught.
+    """
+    diag, _ = DiagnosticsBuilder().build(_base_ctx(config_options=config_options))
+    return diag
+
+
+@pytest.mark.unit
+def test_sun_position_attrs_gamma_only_slot1_publishes_blind_spot_ranges():
+    """A gamma-only slot-1 entry (today's only write shape) publishes
+    blind_spot_range/blind_spot_ranges through the real DiagnosticsBuilder
+    (#1291 regression guard).
+
+    Before the fix, ``_build_configuration`` forwarded only the legacy
+    left/right sub-keys, so a gamma-only options dict produced an empty
+    ``ranges`` list in ``_sun_position_attrs`` and neither attribute was
+    emitted, even though the calculation engine (which reads raw options
+    independently) computed the position correctly.
+    """
+    diag = _build_diagnostics_for_config_options(
+        {
+            "blind_spot": True,
+            "blind_spot_left_gamma": 35,
+            "blind_spot_right_gamma": 40,
+            "fov_left": 45,
+            "fov_right": 45,
+            "azimuth": 180,
+        }
+    )
+    coord = _make_coordinator(diagnostics=diag)
+    entry = _make_config_entry()
+    sensor = AdaptiveCoverSunPositionSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs["blind_spot_ranges"] == [[-40, 35]]
+    assert attrs["blind_spot_range"] == [-40, 35]
+
+
+@pytest.mark.unit
+def test_sun_position_attrs_unconfigured_slot_publishes_no_spurious_range():
+    """Slot 1 gamma-only configured; slots 2/3 entirely absent (no gamma AND
+    no legacy keys) must not leak a spurious range for the unconfigured slots.
+
+    #1071 regression guard extended to the widened builder tuple (#1291):
+    the length-1 result proves an absent slot's ``None``/``None`` pair still
+    ``continue``s rather than producing e.g. ``[None, None]``.
+    """
+    diag = _build_diagnostics_for_config_options(
+        {
+            "blind_spot": True,
+            "blind_spot_left_gamma": 35,
+            "blind_spot_right_gamma": 40,
+            "fov_left": 45,
+            "fov_right": 45,
+            "azimuth": 180,
+        }
+    )
+    coord = _make_coordinator(diagnostics=diag)
+    entry = _make_config_entry()
+    sensor = AdaptiveCoverSunPositionSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs["blind_spot_ranges"] == [[-40, 35]]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`_build_configuration` in `diagnostics/builder.py` copied only `left`, `right`, `elevation` and `elevation_mode` per blind-spot slot into the diagnostics `configuration` dict, so `left_gamma`/`right_gamma` never reached it. The sun sensor's gamma-preferred branch in `_sun_position_attrs` was therefore dead on that path, and since the options flow has written gamma keys only since v3.8, the legacy fallback found nothing either — every configured blind spot published no `blind_spot_range` or `blind_spot_ranges` at all, while the engine (which reads raw entry options) kept computing the correct position. That is why the card's sky compass showed no wedge while the position was right.

Widening the tuple activates the already-correct gamma branch. No sensor change and no card change needed.

The new sensor tests drive a gamma-only entry through the real `DiagnosticsBuilder` instead of hand-feeding the `configuration` dict — that hand-fed pattern is the test gap that let this survive.

Migrated pre-v3.8 entries hold both key sets, so gamma now wins over legacy in the attribute (matching the engine already). That can shift a drawn wedge by up to `clamp_gamma_pair`'s 1° repair sliver — correct, but visible when comparing before and after.

## Testing
- ✅ 13714 tests passing (4 skipped, 1 xfailed, 0 failures)
- Targeted blind-spot/diagnostics/sensor suite: 276 passing (was 273)
- Regression guards green and untouched: `test_slot_left_zero_is_not_treated_as_missing` (#868), `test_delete_slot_step_clears_only_its_slot` (#1071), `test_blind_spot_range_from_new_keys_matches_legacy_emission`

## Related Issues
Refs #1291

Prerequisite for issue #1292, which layers a `blind_spot_slots` attribute on top of `blind_spot_ranges`. Not fixed here.