### PR TITLE
fix: negate the cloud suppression weather condition (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1487,7 +1487,7 @@ def _cover_type_label(
 # forbids a custom ``config_summary`` top-level category.
 #
 # Each value is a Python ``str.format`` template. Literal ``{`` / ``}`` that are
-# NOT format fields (the cloud "weather in {set}" notation) are escaped as
+# NOT format fields (the cloud "weather not in {set}" notation) are escaped as
 # ``{{`` / ``}}``. Priority badges are NOT baked in — ``_badge(N)`` is prepended
 # AFTER ``.format()`` so handler-priority integers stay imported, never
 # duplicated into translation strings.
@@ -1612,7 +1612,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "cloud.irradiance_no_thresh": "irradiance ({entity})",
     "cloud.coverage": "cloud > {thresh}%",
     "cloud.coverage_no_thresh": "cloud ({entity})",
-    "cloud.weather_in": "weather in {{{states}}}",
+    "cloud.weather_in": "weather not in {{{states}}}",
     "cloud.when": " when {parts}",
     "cloud.fallback_cloudy": "cloudy position {pos}%",
     "cloud.fallback_default": "default ({default_pos}%)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -104,7 +104,7 @@
     "irradiance_no_thresh": "Strahlung ({entity})",
     "coverage": "Bewölkung > {thresh}%",
     "coverage_no_thresh": "Bewölkung ({entity})",
-    "weather_in": "Wetter in {{{states}}}",
+    "weather_in": "Wetter nicht in {{{states}}}",
     "when": " wenn {parts}",
     "fallback_cloudy": "bewölkte Position {pos}%",
     "fallback_default": "Standard ({default_pos}%)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -104,7 +104,7 @@
     "irradiance_no_thresh": "irradiance ({entity})",
     "coverage": "cloud > {thresh}%",
     "coverage_no_thresh": "cloud ({entity})",
-    "weather_in": "weather in {{{states}}}",
+    "weather_in": "weather not in {{{states}}}",
     "when": " when {parts}",
     "fallback_cloudy": "cloudy position {pos}%",
     "fallback_default": "default ({default_pos}%)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -104,7 +104,7 @@
     "irradiance_no_thresh": "rayonnement ({entity})",
     "coverage": "nuages > {thresh}%",
     "coverage_no_thresh": "nuages ({entity})",
-    "weather_in": "météo dans {{{states}}}",
+    "weather_in": "météo hors de {{{states}}}",
     "when": " quand {parts}",
     "fallback_cloudy": "position nuageux {pos}%",
     "fallback_default": "défaut ({default_pos}%)",

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -2889,7 +2889,7 @@ def test_custom_position_tilt_only_no_warning_when_alone():
 
 
 def test_weather_state_list_in_cloud_line():
-    """CONF_WEATHER_STATE list renders as 'weather in {state, state}' on the cloud line."""
+    """CONF_WEATHER_STATE list renders as 'weather not in {state, state}' on the cloud line."""
     from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE
 
     cfg = {
@@ -2898,7 +2898,7 @@ def test_weather_state_list_in_cloud_line():
         CONF_WEATHER_STATE: ["cloudy", "rainy"],
     }
     summary = _build_config_summary(cfg, CoverType.BLIND)
-    assert "weather in {cloudy, rainy}" in summary
+    assert "weather not in {cloudy, rainy}" in summary
 
 
 def test_outside_threshold_shown_on_climate_line():


### PR DESCRIPTION
## Summary

The Configuration Summary's cloud-suppression line rendered "skips sun tracking when weather in {sunny, partlycloudy, clear}", which states the trigger backwards.

`ClimateProvider._read_sunny` sets `is_sunny = weather_state in weather_condition`, and the priority-60 handler suppresses on `not r.is_sunny`, so suppression fires when the live weather state is NOT in the configured set. The summary told users the exact opposite of what their configuration does.

`cloud.weather_in` now reads "weather not in {...}". German and French carried the same inverted wording, so all three shipped bundles are corrected together.

v2026.8.2 carries the inverted strings in all three languages, so this is live for every stable install that has a weather entity configured for cloud suppression.

## Testing

- ✅ 12584 tests passing on main (4 skipped, 17 xfailed)
- Cherry-picked cleanly with no conflicts

## Related Issues

Refs #1301

Follow-up filed from the audit, not resolved by this PR: #1302

Cherry-picked from #1303 for a hotfix release.
