### PR TITLE
feat: defer cloud suppression during the extreme-heat hold (#1272)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -2197,6 +2197,7 @@ class ReasonCode(StrEnum):
     SKIP_NO_GLARE_ZONES = "skip.no_glare_zones"
     SKIP_CLOUD_SKIPPED = "skip.cloud_skipped"
     SKIP_CLOUD_INACTIVE = "skip.cloud_inactive"
+    SKIP_CLOUD_DEFERRED_EXTREME_HEAT = "skip.cloud_deferred_extreme_heat"
     SKIP_WEATHER_NOT_ACTIVE = "skip.weather_not_active"
     SKIP_CUSTOM_NOT_ACTIVE = "skip.custom_not_active"
     SKIP_ALWAYS_MATCHES = "skip.always_matches"

--- a/custom_components/adaptive_cover_pro/engine/climate_crossings.py
+++ b/custom_components/adaptive_cover_pro/engine/climate_crossings.py
@@ -146,3 +146,23 @@ def extreme_heat_crossing(
         return False, True
     activate = value > fthreshold
     return _pair(activate, value, release_threshold, lambda v, r: v <= r)
+
+
+def resolve_extreme_heat_active(
+    outside_temperature: float | str | None,
+    temp_extreme_heat: float | None,
+    smoothed: bool | None,
+) -> bool:
+    """Resolve whether the extreme-heat hold is active this cycle (issue #1272).
+
+    Exact extraction of the smoothed-flag-else-raw-crossing fallback that
+    already lives on ``ClimateCoverData.is_extreme_heat``: the smoothed flag
+    wins when the coordinator's ``ClimateSmoothingManager`` has resolved one
+    (issue #917); otherwise falls back to ``extreme_heat_crossing``'s raw
+    single-crossing ``activate_met``. Shared by ``ClimateCoverData.is_extreme_heat``
+    and ``SnapshotBuilder`` (for the cloud-suppression carve-out) so both
+    consumers agree on the same resolved boolean without recomputing it.
+    """
+    if smoothed is not None:
+        return smoothed
+    return extreme_heat_crossing(outside_temperature, temp_extreme_heat, None)[0]

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -15,9 +15,9 @@ import numpy as np
 from ...cover_types import get_policy
 from ...cover_types.base import AXIS_NAME_TILT, CoverTypePolicy
 from ...engine.climate_crossings import (
-    extreme_heat_crossing,
     outside_high_crossing,
     resolve_current_temperature,
+    resolve_extreme_heat_active,
     summer_warm_crossing,
     winter_crossing,
 )
@@ -161,11 +161,9 @@ class ClimateCoverData:
         False when the feature is off (threshold None), the outside reading is
         unavailable (None), or either value is non-numeric.
         """
-        if self.extreme_heat_active is not None:
-            return self.extreme_heat_active
-        return extreme_heat_crossing(
-            self.outside_temperature, self.temp_extreme_heat, None
-        )[0]
+        return resolve_extreme_heat_active(
+            self.outside_temperature, self.temp_extreme_heat, self.extreme_heat_active
+        )
 
     @property
     def is_low_light(self) -> bool:

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -48,6 +48,13 @@ class CloudSuppressionHandler(OverrideHandler):
             return None
         if not snapshot.cover.direct_sun_valid:
             return None
+        if snapshot.climate_extreme_heat_active:
+            # Issue #1272: a narrow carve-out, not a priority reordering. Cloud
+            # suppression (60) still outranks climate (50) for every other
+            # branch; only when climate would produce EXTREME_HEAT this same
+            # cycle does suppression stand down so the heat hold isn't briefly
+            # overridden by the default/cloudy position.
+            return None
         if not snapshot.cloud_suppression_active:
             return None
 
@@ -110,4 +117,6 @@ class CloudSuppressionHandler(OverrideHandler):
             return Reason(ReasonCode.SKIP_OUTSIDE_WINDOW)
         if not snapshot.cover.direct_sun_valid:
             return Reason(ReasonCode.SKIP_CLOUD_SKIPPED)
+        if snapshot.climate_extreme_heat_active:
+            return Reason(ReasonCode.SKIP_CLOUD_DEFERRED_EXTREME_HEAT)
         return Reason(ReasonCode.SKIP_CLOUD_INACTIVE)

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -115,6 +115,7 @@ from ..const import (
     DEFAULT_TEMPLATE_COMBINE_MODE,
 )
 from ..cover_types.base import axis_inverted
+from ..engine.climate_crossings import resolve_extreme_heat_active
 from ..helpers import (
     _read_current_effective_default,
     custom_position_slot_configured,
@@ -827,6 +828,25 @@ class PipelineSnapshotBuilder:
         )
         solar_floor_active = not all_positionable
 
+        # Already-gated, already-resolved extreme-heat condition (issue #1272):
+        # the same smoothed-or-raw fallback ClimateCoverData.is_extreme_heat
+        # uses, AND gated on climate_mode_enabled so a Climate-Mode-off install
+        # can never get a spurious cloud-suppression defer.
+        climate_options = self.build_climate_options(options)
+        climate_extreme_heat_active = bool(
+            self._toggles.switch_mode
+            and climate_readings is not None
+            and resolve_extreme_heat_active(
+                climate_readings.outside_temperature,
+                climate_options.temp_extreme_heat,
+                (
+                    climate_temp_flags.extreme_heat
+                    if climate_temp_flags is not None
+                    else None
+                ),
+            )
+        )
+
         return PipelineSnapshot(
             cover=cover_data,
             config=cover_data.config,
@@ -839,7 +859,8 @@ class PipelineSnapshotBuilder:
             # never accessible to pipeline handler logic.
             climate_readings=climate_readings,
             climate_mode_enabled=self._toggles.switch_mode,
-            climate_options=self.build_climate_options(options),
+            climate_options=climate_options,
+            climate_extreme_heat_active=climate_extreme_heat_active,
             manual_override_active=manual_override_active,
             motion_timeout_active=motion_timeout_active,
             weather_override_active=weather_override_active,

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -580,6 +580,18 @@ class PipelineSnapshot:
     # comparison for its crossing.
     climate_temp_flags: ClimateTempFlags | None = None
 
+    # Already-gated, already-resolved extreme-heat condition (issue #1272).
+    # Resolved once per cycle by SnapshotBuilder via the same
+    # ``engine.climate_crossings.resolve_extreme_heat_active`` helper
+    # ``ClimateCoverData.is_extreme_heat`` delegates to (smoothed flag when
+    # present, else the raw outside-temperature crossing) — AND gated on
+    # ``climate_mode_enabled`` (the master Climate Mode switch), which
+    # ``climate_temp_flags`` alone does not carry. CloudSuppressionHandler
+    # reads this directly to defer to the extreme-heat hold; never recompute
+    # it elsewhere. Defaults False so snapshots that don't set it behave
+    # exactly as before.
+    climate_extreme_heat_active: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Output types

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -222,6 +222,9 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
     ReasonCode.SKIP_CLOUD_INACTIVE: (
         "cloud suppression inactive (direct sun present or feature disabled)"
     ),
+    ReasonCode.SKIP_CLOUD_DEFERRED_EXTREME_HEAT: (
+        "cloud suppression deferred — extreme-heat hold takes precedence"
+    ),
     ReasonCode.SKIP_WEATHER_NOT_ACTIVE: "weather override not active",
     ReasonCode.SKIP_CUSTOM_NOT_ACTIVE: "custom position #{slot} not active",
     ReasonCode.SKIP_ALWAYS_MATCHES: "always matches",

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -114,6 +114,7 @@
     "no_glare_zones": "keine aktiven Blendungszonen oder Sonne außerhalb des Akzeptanzwinkels",
     "cloud_skipped": "Wolkenunterdrückung übersprungen (Sonne außerhalb des Akzeptanzwinkels)",
     "cloud_inactive": "Wolkenunterdrückung inaktiv (direkte Sonne vorhanden oder Funktion deaktiviert)",
+    "cloud_deferred_extreme_heat": "Wolkenunterdrückung zurückgestellt — Extremhitze-Halteposition hat Vorrang",
     "weather_not_active": "Wetter-Außerkraftsetzung nicht aktiv",
     "custom_not_active": "benutzerdefinierte Position #{slot} nicht aktiv",
     "always_matches": "entspricht immer",

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -114,6 +114,7 @@
     "no_glare_zones": "no active glare zones or sun outside acceptance angle",
     "cloud_skipped": "cloud suppression skipped (sun outside acceptance angle)",
     "cloud_inactive": "cloud suppression inactive (direct sun present or feature disabled)",
+    "cloud_deferred_extreme_heat": "cloud suppression deferred — extreme-heat hold takes precedence",
     "weather_not_active": "weather override not active",
     "custom_not_active": "custom position #{slot} not active",
     "always_matches": "always matches",

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -114,6 +114,7 @@
     "no_glare_zones": "aucune zone d'éblouissement active ou soleil en dehors de l'angle d'acceptation",
     "cloud_skipped": "suppression nuages ignorée (soleil en dehors de l'angle d'acceptation)",
     "cloud_inactive": "suppression nuages inactive (soleil direct présent ou fonction désactivée)",
+    "cloud_deferred_extreme_heat": "suppression nuages différée — le maintien chaleur extrême est prioritaire",
     "weather_not_active": "dérogation météo non active",
     "custom_not_active": "position personnalisée #{slot} non active",
     "always_matches": "toujours valide",

--- a/tests/test_engine/test_climate_crossings.py
+++ b/tests/test_engine/test_climate_crossings.py
@@ -19,6 +19,7 @@ from custom_components.adaptive_cover_pro.engine.climate_crossings import (
     extreme_heat_crossing,
     outside_high_crossing,
     resolve_current_temperature,
+    resolve_extreme_heat_active,
     summer_warm_crossing,
     winter_crossing,
 )
@@ -253,6 +254,63 @@ class TestExtremeHeatCrossing:
         )
         assert act is False
         assert cleared is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_extreme_heat_active — smoothed flag wins; else raw crossing (#1272)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveExtremeHeatActive:
+    """resolve_extreme_heat_active: the shared smoothed-or-raw fallback.
+
+    Exact extraction of the two-line fallback already living on
+    ``ClimateCoverData.is_extreme_heat`` — used both by that property AND by
+    ``SnapshotBuilder`` to resolve ``PipelineSnapshot.climate_extreme_heat_active``
+    for the cloud-suppression carve-out (issue #1272), so both consumers agree
+    on the same answer without recomputing it.
+    """
+
+    def test_resolve_extreme_heat_active_prefers_smoothed_flag(self):
+        """A non-None smoothed flag wins over what the raw crossing would say."""
+        # Raw crossing would be False here (10.0 <= 40.0), smoothed says True.
+        assert (
+            resolve_extreme_heat_active(
+                outside_temperature=10.0, temp_extreme_heat=40.0, smoothed=True
+            )
+            is True
+        )
+        # Raw crossing would be True here (45.0 > 40.0), smoothed says False.
+        assert (
+            resolve_extreme_heat_active(
+                outside_temperature=45.0, temp_extreme_heat=40.0, smoothed=False
+            )
+            is False
+        )
+
+    def test_resolve_extreme_heat_active_falls_back_to_raw_crossing(self):
+        """smoothed=None falls back to extreme_heat_crossing's activate_met."""
+        assert (
+            resolve_extreme_heat_active(
+                outside_temperature=41.0, temp_extreme_heat=40.0, smoothed=None
+            )
+            is True
+        )
+        assert (
+            resolve_extreme_heat_active(
+                outside_temperature=39.0, temp_extreme_heat=40.0, smoothed=None
+            )
+            is False
+        )
+
+    def test_resolve_extreme_heat_active_false_when_threshold_unset(self):
+        """Feature off (threshold None) with no smoothed flag → False."""
+        assert (
+            resolve_extreme_heat_active(
+                outside_temperature=50.0, temp_extreme_heat=None, smoothed=None
+            )
+            is False
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_1272_cloud_vs_extreme_heat.py
+++ b/tests/test_issue_1272_cloud_vs_extreme_heat.py
@@ -1,0 +1,137 @@
+"""Issue #1272 — cloud suppression must defer to an active extreme-heat hold.
+
+``CloudSuppressionHandler`` (priority 60) and ``ClimateHandler`` (priority 50)
+evaluate independently every cycle. While the sun is still in the window's FOV
+and a cloud/low-light trigger is latched, cloud suppression used to win the
+pipeline and command the default/cloudy position — opening the cover — even
+though ``ClimateCoverData.is_extreme_heat`` was also true that same cycle; the
+EXTREME_HEAT rule was only marked ``REGISTRY_OUTPRIORITIZED`` in the trace,
+never consulted. ~15 minutes later the sun leaves the FOV, cloud suppression's
+own ``direct_sun_valid`` guard (#417) makes it return ``None``, and
+``ClimateHandler`` becomes the top match — its extreme-heat force-hold closes
+the cover again. Net effect: a spurious open window at the hottest part of the
+day, right when the room is still taking direct sun.
+
+The fix (see ``PipelineSnapshot.climate_extreme_heat_active`` and
+``CloudSuppressionHandler.evaluate``) is a narrow carve-out: cloud suppression
+defers — returns ``None`` — only when climate would independently produce
+EXTREME_HEAT this same cycle, so ``ClimateHandler`` wins on both sides of the
+FOV boundary and the commanded position no longer flip-flops.
+
+Modeled on ``tests/test_issue_1238_cloud_hold_vs_climate.py``.
+"""
+
+from __future__ import annotations
+
+from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.handlers import (
+    ClimateHandler,
+    DefaultHandler,
+    SolarHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
+    CloudSuppressionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import ClimateOptions
+from custom_components.adaptive_cover_pro.state.climate_provider import ClimateReadings
+from tests.test_pipeline.conftest import make_snapshot
+
+DEFAULT_POS = 80  # what cloud suppression would command (opening the cover)
+EXTREME_HEAT_POS = 0  # the configured extreme-heat hold position
+SOLAR_POS = 45
+
+
+def _full_pipeline() -> PipelineRegistry:
+    """Build the reporter's install: cloud → climate → solar → default, in order."""
+    return PipelineRegistry(
+        [
+            CloudSuppressionHandler(),
+            ClimateHandler(),
+            SolarHandler(),
+            DefaultHandler(),
+        ]
+    )
+
+
+def _readings() -> ClimateReadings:
+    """Hot outside, intermediate inside (neither summer nor winter), not sunny.
+
+    ``is_sunny=False`` is the cloud-suppression trigger; ``outside_temperature``
+    is above the extreme-heat threshold.
+    """
+    return ClimateReadings(
+        outside_temperature=40.0,
+        inside_temperature=22.0,
+        is_presence=True,
+        is_sunny=False,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+
+
+def _options() -> ClimateOptions:
+    return ClimateOptions(
+        temp_low=18.0,
+        temp_high=26.0,
+        temp_switch=False,
+        transparent_blind=False,
+        temp_summer_outside=None,
+        cloud_suppression_enabled=True,
+        winter_close_insulation=False,
+        temp_extreme_heat=35.0,
+        extreme_heat_position=EXTREME_HEAT_POS,
+    )
+
+
+def _snapshot(*, direct_sun_valid: bool):
+    return make_snapshot(
+        direct_sun_valid=direct_sun_valid,
+        calculate_percentage_return=SOLAR_POS,
+        default_position=DEFAULT_POS,
+        climate_mode_enabled=True,
+        climate_readings=_readings(),
+        climate_options=_options(),
+        cloud_suppression_active=True,
+        climate_extreme_heat_active=True,
+    )
+
+
+class TestCloudDefersToExtremeHeat:
+    """The reporter's scenario: extreme heat active on both sides of the FOV edge."""
+
+    def test_climate_wins_while_sun_is_still_in_fov(self) -> None:
+        """Sun in FOV + cloud suppression latched + extreme heat active → EXTREME_HEAT wins.
+
+        Before the fix this resolved to ControlMethod.CLOUD (the default/open
+        position) — exactly the reported bug.
+        """
+        result = _full_pipeline().evaluate(_snapshot(direct_sun_valid=True))
+        assert result.control_method == ControlMethod.EXTREME_HEAT
+        assert result.position == EXTREME_HEAT_POS
+
+    def test_climate_still_wins_once_sun_leaves_fov_with_the_same_position(
+        self,
+    ) -> None:
+        """Sun outside FOV (#417 makes cloud return None) → same winner, same position.
+
+        This is the actual user-visible complaint: the commanded position must
+        not flip-flop across the FOV boundary. Before the fix, the FOV-in case
+        above commanded ``DEFAULT_POS`` while this FOV-out case already
+        commanded ``EXTREME_HEAT_POS`` — a spurious ~15-minute open window.
+        """
+        result = _full_pipeline().evaluate(_snapshot(direct_sun_valid=False))
+        assert result.control_method == ControlMethod.EXTREME_HEAT
+        assert result.position == EXTREME_HEAT_POS
+
+    def test_position_is_identical_across_the_fov_boundary(self) -> None:
+        """Direct pin: the two FOV states must agree, closing the reported gap."""
+        in_fov = _full_pipeline().evaluate(_snapshot(direct_sun_valid=True))
+        out_fov = _full_pipeline().evaluate(_snapshot(direct_sun_valid=False))
+        assert (
+            in_fov.control_method
+            == out_fov.control_method
+            == ControlMethod.EXTREME_HEAT
+        )
+        assert in_fov.position == out_fov.position == EXTREME_HEAT_POS

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -104,6 +104,7 @@ def make_snapshot(
     group_intent=None,
     cloud_suppression_active: bool | None = None,
     climate_temp_flags=None,
+    climate_extreme_heat_active: bool = False,
     # Convenience: configure mock cover
     direct_sun_valid: bool = False,
     calculate_percentage_return: float = 50.0,
@@ -187,4 +188,5 @@ def make_snapshot(
         group_intent=group_intent,
         cloud_suppression_active=cloud_suppression_active,
         climate_temp_flags=climate_temp_flags,
+        climate_extreme_heat_active=climate_extreme_heat_active,
     )

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -566,3 +566,60 @@ class TestCloudHandlerResolvedBoolGate:
             in_time_window=False,
         )
         assert self.handler.evaluate(snap) is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #1272 — cloud suppression defers to an active extreme-heat hold
+# ---------------------------------------------------------------------------
+
+
+class TestCloudHandlerExtremeHeatCarveOut:
+    """CloudSuppressionHandler stands down when climate would hit EXTREME_HEAT.
+
+    A narrow carve-out, not a priority reordering: cloud suppression (60) still
+    outranks climate (50) for every other climate branch. Only when the
+    already-resolved ``climate_extreme_heat_active`` flag is True does the
+    handler return ``None`` so ClimateHandler's EXTREME_HEAT rule can win.
+    """
+
+    handler = CloudSuppressionHandler()
+
+    def test_defers_when_extreme_heat_active_even_with_sun_in_fov_and_suppression_active(
+        self,
+    ) -> None:
+        """Extreme heat active → defer, even though every other gate says fire."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            cloud_suppression_active=True,
+            climate_extreme_heat_active=True,
+        )
+        assert self.handler.evaluate(snap) is None
+
+    def test_still_fires_when_extreme_heat_inactive(self) -> None:
+        """The carve-out is narrow: extreme heat inactive → fires normally."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            cloud_suppression_active=True,
+            climate_extreme_heat_active=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.CLOUD
+
+    def test_describe_skip_reports_extreme_heat_deferral(self) -> None:
+        """describe_skip() names the extreme-heat deferral as the stand-down reason."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            in_time_window=True,
+            climate_extreme_heat_active=True,
+        )
+        assert (
+            self.handler.describe_skip(snap).code
+            == ReasonCode.SKIP_CLOUD_DEFERRED_EXTREME_HEAT
+        )

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -28,6 +28,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_SUNRISE_TIME_ENTITY,
     CONF_SUNSET_POS,
     CONF_SUNSET_TIME_ENTITY,
+    CONF_TEMP_EXTREME_HEAT,
     CONF_TEMP_HIGH,
     CONF_TEMP_LOW,
     CONF_TRACKING_SEASONS,
@@ -972,6 +973,101 @@ def test_build_climate_temp_flags_default_none():
         is_sunset_active=False,
     )
     assert snapshot.climate_temp_flags is None
+
+
+@pytest.mark.unit
+def test_build_threads_climate_extreme_heat_active():
+    """build() resolves climate_extreme_heat_active when Climate Mode is on (#1272).
+
+    The carve-out CloudSuppressionHandler reads must be gated on Climate Mode
+    (``switch_mode``) so an install with Climate Mode off can never get a
+    spurious defer — see the sibling ``_disabled`` test.
+    """
+    builder, _, _ = _make_builder(switch_mode=True)
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    readings = ClimateReadings(
+        outside_temperature=40.0,
+        inside_temperature=22.0,
+        is_presence=True,
+        is_sunny=True,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+    snapshot = builder.build(
+        {CONF_DEFAULT_HEIGHT: 0, CONF_TEMP_EXTREME_HEAT: 35.0},
+        cover_data=cover_data,
+        cover_type="cover_blind",
+        climate_readings=readings,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda idx: True,
+        effective_default=0,
+        is_sunset_active=False,
+    )
+    assert snapshot.climate_extreme_heat_active is True
+
+
+@pytest.mark.unit
+def test_build_climate_extreme_heat_active_false_when_climate_mode_disabled():
+    """Climate Mode off must never produce a spurious defer (#1272)."""
+    builder, _, _ = _make_builder(switch_mode=False)
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    readings = ClimateReadings(
+        outside_temperature=40.0,
+        inside_temperature=22.0,
+        is_presence=True,
+        is_sunny=True,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+    snapshot = builder.build(
+        {CONF_DEFAULT_HEIGHT: 0, CONF_TEMP_EXTREME_HEAT: 35.0},
+        cover_data=cover_data,
+        cover_type="cover_blind",
+        climate_readings=readings,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda idx: True,
+        effective_default=0,
+        is_sunset_active=False,
+    )
+    assert snapshot.climate_extreme_heat_active is False
+
+
+@pytest.mark.unit
+def test_build_climate_extreme_heat_active_default_false():
+    """No climate config at all → climate_extreme_heat_active stays False (#1272)."""
+    builder, _, _ = _make_builder()
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    snapshot = builder.build(
+        {CONF_DEFAULT_HEIGHT: 0},
+        cover_data=cover_data,
+        cover_type="cover_blind",
+        climate_readings=None,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda idx: True,
+        effective_default=0,
+        is_sunset_active=False,
+    )
+    assert snapshot.climate_extreme_heat_active is False
 
 
 @pytest.mark.unit

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -438,6 +438,11 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
         {},
         "cloud suppression inactive (direct sun present or feature disabled)",
     ),
+    (
+        ReasonCode.SKIP_CLOUD_DEFERRED_EXTREME_HEAT,
+        {},
+        "cloud suppression deferred — extreme-heat hold takes precedence",
+    ),
     (ReasonCode.SKIP_WEATHER_NOT_ACTIVE, {}, "weather override not active"),
     (
         ReasonCode.SKIP_CUSTOM_NOT_ACTIVE,


### PR DESCRIPTION
## Summary

Cloud suppression runs at priority 60 and the climate handler at 50, so on an overcast but hot afternoon suppression could win and open the cover to its default position while the sun was still in the window's field of view, which is exactly when the room is hottest and still taking direct sun. About fifteen minutes later the sun left FOV, the FOV guard stood suppression down, climate became the top match, and the extreme-heat hold closed the cover again. Reporters saw that open/close flip.

Cloud suppression now defers when the climate handler would produce an `EXTREME_HEAT` result on the same cycle. The condition is resolved once per cycle in `SnapshotBuilder` as `climate_extreme_heat_active`, gated on climate mode being enabled so a Climate-Mode-off install can never defer, and the handler reads it directly rather than rebuilding climate data of its own. `ClimateCoverData.is_extreme_heat` delegates to the same shared helper so the threshold rule lives in one place. The decision trace reports `skip.cloud_deferred_extreme_heat`, keeping the deferral visible in diagnostics instead of looking like a handler that silently went missing.

Handler priorities are unchanged. Suppression still wins over summer cooling, winter heating, and the low-light path on an overcast day, which is why this is a scoped carve-out rather than a global reordering. The new check sits strictly after the field-of-view guard from issue #417 and strictly before the resolved-bool gate from issue #864, so neither prior fix becomes reachable differently.

This is unconditional, with no new config option.

## Testing

- ✅ 13729 tests passing (12 new, 0 failures, 4 skipped, 1 xfailed)
- Regression guards re-run and green, unmodified: `TestCloudHandlerFOVGate`, `TestCloudHandlerResolvedBoolGate`, `TestClimateHandlerExtremeHeat`, `tests/test_extreme_heat.py`, and the issue #917 `climate_temp_flags` snapshot-builder tests
- New end-to-end test `tests/test_issue_1272_cloud_vs_extreme_heat.py` pins the reported scenario and that the position no longer changes across the FOV boundary

## Related Issues

Refs #1272