### PR TITLE
fix: correct the cloud-suppression summary and outside-window explanation

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1788,6 +1788,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "cloud.coverage": "cloud > {thresh}%",
     "cloud.coverage_no_thresh": "cloud ({entity})",
     "cloud.weather_in": "weather not in {{{states}}}",
+    "cloud.weather_fallback": " (falls back to {weather})",
     "cloud.when": " when {parts}",
     "cloud.fallback_cloudy": "cloudy position {pos}%",
     "cloud.fallback_default": "default ({default_pos}%)",
@@ -2867,8 +2868,23 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             if is_template_string(config.get(CONF_IS_SUNNY_TEMPLATE))
             else None
         )
+        # The weather-state list is not an independent OR trigger — it's the
+        # lowest rung of _read_sunny's resolution ladder, only reached when no
+        # is_sunny sensor/template is configured or it has never yet produced
+        # an opinion (issue #1302). Build it once and nest it as an in-place
+        # fallback qualifier on the is_sunny fragment when one is configured;
+        # only render it as a peer trigger when it's the sole is_sunny source.
+        wx_states = config.get(CONF_WEATHER_STATE) or []
+        wx_fragment = (
+            L["cloud.weather_in"].format(states=", ".join(wx_states))
+            if wx_states and config.get(CONF_WEATHER_ENTITY)
+            else ""
+        )
         if is_sunny_value:
-            cloud_parts.append(L["cloud.is_sunny"].format(value=is_sunny_value))
+            is_sunny_part = L["cloud.is_sunny"].format(value=is_sunny_value)
+            if wx_fragment:
+                is_sunny_part += L["cloud.weather_fallback"].format(weather=wx_fragment)
+            cloud_parts.append(is_sunny_part)
         if v := config.get(CONF_LUX_ENTITY):
             t = config.get(CONF_LUX_THRESHOLD)
             cloud_parts.append(
@@ -2890,11 +2906,8 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 if t is not None
                 else L["cloud.coverage_no_thresh"].format(entity=v)
             )
-        wx_states = config.get(CONF_WEATHER_STATE) or []
-        if wx_states and config.get(CONF_WEATHER_ENTITY):
-            cloud_parts.append(
-                L["cloud.weather_in"].format(states=", ".join(wx_states))
-            )
+        if wx_fragment and not is_sunny_value:
+            cloud_parts.append(wx_fragment)
         cloud_str = (
             L["cloud.when"].format(parts=", ".join(cloud_parts)) if cloud_parts else ""
         )

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -5082,6 +5082,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 else "live"
             ),
             check_adaptive_time=self.check_adaptive_time,
+            clock_window_open=self.clock_window_open,
             after_start_time=self.after_start_time,
             before_end_time=self.before_end_time,
             start_time=self._time_mgr.start_time_value,

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -575,20 +575,43 @@ class DiagnosticsBuilder:
         # plus "commands paused" over a dispatched command is simply false
         # (issue #1308). Those fall through to the normal render below, which
         # names the real winner and its real position.
+        #
+        # The note is composed once and then either stands alone or trails the
+        # winner's chain — see the DEFAULT carve-out below.
+        window_note: str | None = None
         if not ctx.clock_window_open and not result.acts_outside_clock_window:
-            pos = result.default_position
             pos_label = Reason(
                 ReasonCode.FRAGMENT_SUNSET_POSITION
                 if result.is_sunset_active
                 else ReasonCode.FRAGMENT_DEFAULT_POSITION
             )
-            return render(
+            window_note = render(
                 Reason(
                     ReasonCode.BUILDER_OUTSIDE_WINDOW,
-                    {"pos_label": pos_label, "pos": pos},
+                    {"pos_label": pos_label, "pos": result.default_position},
                 ),
                 labels,
             )
+            # The note IS the DEFAULT winner's account — "the default/sunset
+            # position, and nothing was sent" is the whole of what
+            # ``DefaultHandler`` resolved — so out here it renders alone, as it
+            # always has (the EN/DE byte-identical locks in
+            # ``tests/test_diagnostics/test_reason_localization.py`` pin that).
+            #
+            # No other winner is redundant with it. MANUAL, MOTION,
+            # CUSTOM_POSITION (a slot below safety priority), GROUP_LOCK and
+            # GROUP_SCENE are the ones that can still win on a closed clock,
+            # and each carries a reason the note cannot express — a held
+            # position, an occupancy timeout, a slot number. Returning the note
+            # in their place discarded it, which put the explanation at odds
+            # with ``control_status``: ``_METHOD_TO_STATUS`` answers
+            # MANUAL_OVERRIDE / MOTION_TIMEOUT for the same cycle (deliberately
+            # — ``sensor._control_status_attrs`` and triage rule 23 key on that
+            # answer), so the two fields told different stories. They now
+            # compose: the winner leads, the note trails, and both truths — who
+            # decided, and that nothing reached the cover — survive.
+            if result.control_method is ControlMethod.DEFAULT:
+                return window_note
 
         # Base explanation is the pipeline reason (already human-readable). Prefer
         # the structured payload so the base localizes; fall back to the legacy
@@ -646,6 +669,11 @@ class DiagnosticsBuilder:
             parts.append(
                 render(Reason(ReasonCode.BUILDER_INVERSED, {"final": final}), labels)
             )
+
+        # Last word, after the value transforms: the winner and its post-processing
+        # describe the number, this describes what happened to it — nothing.
+        if window_note is not None:
+            parts.append(window_note)
 
         return " → ".join(parts)
 

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -108,6 +108,16 @@ class DiagnosticContext:
     automatic_control: bool
     # True while a travel-time calibration run holds the covers.
     calibrating: bool = False
+    # Whether the user's start/end CLOCK window is open, ignoring the daytime
+    # gate — mirrors ``TimeWindowManager.clock_window_open`` /
+    # ``coordinator.clock_window_open``, NOT ``check_adaptive_time``
+    # (``is_active``, which also folds in the gate). The two deliberately
+    # diverge at night on a gate-configured install (#656): a dark gate makes
+    # ``check_adaptive_time`` False even while the clock window is still open,
+    # and the real dispatch guard reads this field, not that one (issue
+    # #1310). Defaults True so contexts built without it (tests, older
+    # callers) are unaffected.
+    clock_window_open: bool = True
     last_cover_action: dict = field(default_factory=dict)
     last_skipped_action: dict = field(default_factory=dict)
     min_change: int = 1
@@ -550,13 +560,22 @@ class DiagnosticsBuilder:
 
         # Outside time window — pipeline ran but commands are gated.
         #
+        # Reads ``clock_window_open`` (start/end clock only), NOT
+        # ``check_adaptive_time`` (which also folds in the daytime gate) — a
+        # gate-configured install can read dark while the user's clock window
+        # is still open (#656), and the real dispatch guard
+        # (``coordinator.clock_window_open``) is not blocking anything on that
+        # cycle either. Keying this off the gate-inclusive flag mis-reported
+        # the winner's own reason as a paused default/sunset position (issue
+        # #1310).
+        #
         # Only when the winner has NO licence to move a cover out here. A
         # safety result (weather, a priority-100 slot) or an admitted #943-B
         # constraint IS commanding, and reporting the default/sunset position
         # plus "commands paused" over a dispatched command is simply false
         # (issue #1308). Those fall through to the normal render below, which
         # names the real winner and its real position.
-        if not ctx.check_adaptive_time and not result.acts_outside_clock_window:
+        if not ctx.clock_window_open and not result.acts_outside_clock_window:
             pos = result.default_position
             pos_label = Reason(
                 ReasonCode.FRAGMENT_SUNSET_POSITION

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -666,7 +666,15 @@ class DiagnosticsBuilder:
             if status != ControlStatus.ACTIVE:
                 return status
 
-        if not ctx.check_adaptive_time:
+        # Reads ``clock_window_open`` (start/end clock only), NOT
+        # ``check_adaptive_time`` (which also folds in the daytime gate) —
+        # same rationale as ``_build_position_explanation`` above (#1310). A
+        # winner licensed to act outside the clock (``acts_outside_clock_window``
+        # — a safety result or an admitted #943-B constraint) is also excused
+        # here, mirroring the explanation's early-return guard exactly, so the
+        # two fields cannot disagree on the licensed-winner-outside-clock case.
+        licensed_outside_clock = result is not None and result.acts_outside_clock_window
+        if not ctx.clock_window_open and not licensed_outside_clock:
             return ControlStatus.OUTSIDE_TIME_WINDOW
 
         if ctx.cover and not ctx.cover.valid:
@@ -847,6 +855,12 @@ class DiagnosticsBuilder:
                 "before_end_time": ctx.before_end_time,
                 "start_time": ctx.start_time,
                 "end_time": ctx.end_time,
+                # Whether the user's start/end CLOCK window is open, ignoring
+                # the daytime gate — the field the explanation and (#1310
+                # audit finding #1) control_status both key on. Published
+                # alongside ``check_adaptive_time`` so a triager can see why
+                # the two disagree on a gate-dark cycle (#1310 finding #2).
+                "clock_window_open": ctx.clock_window_open,
                 # Issue #943 item B — whether an opted-in slot's min/max
                 # constraint was ADMITTED to act outside the clock window this
                 # cycle. The single most useful field for triaging "my

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -112,6 +112,7 @@
     "coverage": "Bewölkung > {thresh}%",
     "coverage_no_thresh": "Bewölkung ({entity})",
     "weather_in": "Wetter nicht in {{{states}}}",
+    "weather_fallback": " (greift zurück auf {weather})",
     "when": " wenn {parts}",
     "fallback_cloudy": "bewölkte Position {pos}%",
     "fallback_default": "Standard ({default_pos}%)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -112,6 +112,7 @@
     "coverage": "cloud > {thresh}%",
     "coverage_no_thresh": "cloud ({entity})",
     "weather_in": "weather not in {{{states}}}",
+    "weather_fallback": " (falls back to {weather})",
     "when": " when {parts}",
     "fallback_cloudy": "cloudy position {pos}%",
     "fallback_default": "default ({default_pos}%)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -112,6 +112,7 @@
     "coverage": "nuages > {thresh}%",
     "coverage_no_thresh": "nuages ({entity})",
     "weather_in": "météo hors de {{{states}}}",
+    "weather_fallback": " (se replie sur {weather})",
     "when": " quand {parts}",
     "fallback_cloudy": "position nuageux {pos}%",
     "fallback_default": "défaut ({default_pos}%)",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -112,7 +112,7 @@
     "coverage": "nuages > {thresh}%",
     "coverage_no_thresh": "nuages ({entity})",
     "weather_in": "météo hors de {{{states}}}",
-    "weather_fallback": " (se replie sur {weather})",
+    "weather_fallback": " (repli sur {weather})",
     "when": " quand {parts}",
     "fallback_cloudy": "position nuageux {pos}%",
     "fallback_default": "défaut ({default_pos}%)",

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3148,6 +3148,83 @@ def test_weather_state_list_in_cloud_line():
     assert "weather not in {cloudy, rainy}" in summary
 
 
+def test_weather_state_renders_as_is_sunny_fallback_when_sensor_configured():
+    """With an is_sunny sensor AND a weather entity configured, the weather-state
+    list is not a peer OR trigger — it's the lowest rung _read_sunny falls
+    through to only when the sensor holds no opinion (issue #1302). The summary
+    must nest it as an in-place qualifier on the is_sunny fragment, not append it
+    as a fourth independent trigger.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE
+
+    cfg = {
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_IS_SUNNY_SENSOR: "binary_sensor.x",
+        CONF_WEATHER_ENTITY: "weather.home",
+        CONF_WEATHER_STATE: ["sunny", "clear"],
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert (
+        "is_sunny=binary_sensor.x (falls back to weather not in {sunny, clear})"
+        in summary
+    )
+    assert "is_sunny=binary_sensor.x, weather not in" not in summary
+
+
+def test_weather_state_stays_a_peer_trigger_without_is_sunny_source():
+    """With no is_sunny sensor/template configured, the weather-state list IS
+    the sole is_sunny source, so it renders as a plain peer fragment — no
+    'falls back to' qualifier should appear.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE
+
+    cfg = {
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_WEATHER_ENTITY: "weather.home",
+        CONF_WEATHER_STATE: ["sunny", "clear"],
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "weather not in {sunny, clear}" in summary
+    assert "falls back to" not in summary
+
+
+def test_is_sunny_template_gets_weather_fallback_qualifier():
+    """A template-only is_sunny source also gets the weather fragment nested
+    as a fallback qualifier, not appended as a peer.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE
+
+    cfg = {
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_IS_SUNNY_TEMPLATE: "{{ is_state('sun.sun', 'above_horizon') }}",
+        CONF_WEATHER_ENTITY: "weather.home",
+        CONF_WEATHER_STATE: ["sunny", "clear"],
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert (
+        "is_sunny=[template] (falls back to weather not in {sunny, clear})" in summary
+    )
+
+
+def test_weather_fallback_qualifier_stays_adjacent_to_is_sunny():
+    """When a lux sensor is also configured, the weather fallback qualifier
+    must stay adjacent to the is_sunny fragment it qualifies rather than
+    drifting to the end of the trigger list behind lux (issue #1302, state D).
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE
+
+    cfg = {
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_IS_SUNNY_SENSOR: "binary_sensor.x",
+        CONF_WEATHER_ENTITY: "weather.home",
+        CONF_WEATHER_STATE: ["sunny", "clear"],
+        CONF_LUX_ENTITY: "sensor.lux",
+        CONF_LUX_THRESHOLD: 100,
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert summary.index("falls back to") < summary.index("lux < 100 lx")
+
+
 def test_outside_threshold_shown_on_climate_line():
     """CONF_OUTSIDE_THRESHOLD annotates the outside temp entity on the climate line."""
     cfg = {

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3222,7 +3222,10 @@ def test_weather_fallback_qualifier_stays_adjacent_to_is_sunny():
         CONF_LUX_THRESHOLD: 100,
     }
     summary = _build_config_summary(cfg, CoverType.BLIND)
-    assert summary.index("falls back to") < summary.index("lux < 100 lx")
+    assert (
+        "is_sunny=binary_sensor.x (falls back to weather not in {sunny, clear}), "
+        "lux < 100 lx" in summary
+    )
 
 
 def test_outside_threshold_shown_on_climate_line():

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -342,6 +342,7 @@ class TestControlStatus:
             ControlMethod.MOTION,
             ControlMethod.CUSTOM_POSITION,
             ControlMethod.GROUP_SCENE,
+            ControlMethod.GROUP_LOCK,
         ],
     )
     def test_status_and_explanation_agree_across_the_window_matrix(
@@ -391,7 +392,15 @@ class TestControlStatus:
         if withheld:
             assert diag["control_status"] != ControlStatus.ACTIVE
 
-        if control_method is not ControlMethod.DEFAULT:
+        # DEFAULT collapses to the window note alone only in the genuinely
+        # -closed quadrant (clock_open=False, licensed=False) — the same
+        # quadrant ``withheld`` already identifies, since DEFAULT's own
+        # ``acts_outside_clock_window`` tracks ``licensed`` one-for-one here
+        # (no #943-B constraint is admitted). In the other three quadrants it
+        # falls through to the normal render and still starts with its own
+        # reason, like every other method.
+        collapsed_default = control_method is ControlMethod.DEFAULT and withheld
+        if not collapsed_default:
             assert pr.reason in explanation
 
 

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -244,8 +244,17 @@ class TestControlStatus:
         assert diag["control_status"] == ControlStatus.MANUAL_OVERRIDE
 
     def test_outside_time_window(self, builder: DiagnosticsBuilder):
-        """Returns OUTSIDE_TIME_WINDOW when not in adaptive time."""
-        diag, _ = builder.build(_base_ctx(check_adaptive_time=False))
+        """Returns OUTSIDE_TIME_WINDOW when the clock window is genuinely closed.
+
+        ``clock_window_open=False`` is required alongside ``check_adaptive_time``
+        (#1310 audit finding #1) — ``control_status`` now keys on the clock
+        window, not the gate-inclusive flag, so a merely gate-dark cycle with
+        the clock still open no longer reports OUTSIDE_TIME_WINDOW (see
+        ``test_gate_dark_clock_open_reports_active_not_outside_window`` above).
+        """
+        diag, _ = builder.build(
+            _base_ctx(check_adaptive_time=False, clock_window_open=False)
+        )
         assert diag["control_status"] == ControlStatus.OUTSIDE_TIME_WINDOW
 
     def test_sun_not_visible(self, builder: DiagnosticsBuilder):
@@ -264,6 +273,63 @@ class TestControlStatus:
         """ControlMethod.FORCE is no longer mapped to a status (deprecated, #563)."""
         pr = _make_pr(control_method=ControlMethod.FORCE)
         diag, _ = builder.build(_base_ctx(pipeline_result=pr))
+        assert diag["control_status"] == ControlStatus.ACTIVE
+
+    def test_gate_dark_clock_open_reports_active_not_outside_window(
+        self, builder: DiagnosticsBuilder
+    ):
+        """Gate reads dark but the clock window is open — control_status must
+        agree with the explanation (issue #1310 audit finding #1).
+
+        ``_build_position_explanation`` already reads ``clock_window_open``
+        (commit 0c205bb1) and, on this exact cycle, renders the DEFAULT
+        winner's own reason rather than "commands paused" — nothing is
+        actually being withheld. ``control_status`` must not contradict that
+        by reporting OUTSIDE_TIME_WINDOW for the same cycle.
+        """
+        pr = _make_pr(
+            control_method=ControlMethod.DEFAULT,
+            reason="default position 30% — gate dark",
+            default_position=30,
+        )
+        diag, _ = builder.build(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=False,
+                clock_window_open=True,
+            )
+        )
+        assert diag["control_status"] != ControlStatus.OUTSIDE_TIME_WINDOW
+        assert diag["control_status"] == ControlStatus.ACTIVE
+
+    def test_admitted_constraint_outside_closed_clock_reports_active(
+        self, builder: DiagnosticsBuilder
+    ):
+        """A licensed winner outside a genuinely closed clock is still ACTIVE.
+
+        Mirrors ``test_explanation_names_an_admitted_constraint_outside_the_window``
+        in ``tests/test_position_explanation.py``: an admitted #943-item-B
+        bound lets a DEFAULT winner reach the hardware with ``is_safety``
+        False even while the user's start/end clock is closed. The
+        explanation names the real winner in this case (it does not fall
+        into the "commands paused" branch, because
+        ``result.acts_outside_clock_window`` is True), so control_status
+        must not contradict it by reporting OUTSIDE_TIME_WINDOW.
+        """
+        pr = _make_pr(
+            control_method=ControlMethod.DEFAULT,
+            is_safety=False,
+        )
+        pr = replace(pr, outside_window_constraint_active=True)
+        assert pr.acts_outside_clock_window is True
+        diag, _ = builder.build(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=False,
+                clock_window_open=False,
+            )
+        )
+        assert diag["control_status"] != ControlStatus.OUTSIDE_TIME_WINDOW
         assert diag["control_status"] == ControlStatus.ACTIVE
 
 
@@ -484,6 +550,21 @@ class TestTimeWindowDiagnostics:
         assert "before_end_time" in tw
         assert "start_time" in tw
         assert "end_time" in tw
+        assert "clock_window_open" in tw
+
+    def test_clock_window_open_reflects_context(self, builder: DiagnosticsBuilder):
+        """``clock_window_open`` is published alongside ``check_adaptive_time`` (#1310 audit finding #2).
+
+        A triager reading a diagnostics dump needs to see why the gate-inclusive
+        flag and the explanation/control_status (which both key on
+        ``clock_window_open``) can disagree on a gate-dark cycle.
+        """
+        diag, _ = builder.build(
+            _base_ctx(check_adaptive_time=False, clock_window_open=True)
+        )
+        tw = diag["time_window"]
+        assert tw["check_adaptive_time"] is False
+        assert tw["clock_window_open"] is True
 
 
 class TestEndOfWindowDiagnostics:

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -332,6 +332,68 @@ class TestControlStatus:
         assert diag["control_status"] != ControlStatus.OUTSIDE_TIME_WINDOW
         assert diag["control_status"] == ControlStatus.ACTIVE
 
+    @pytest.mark.parametrize("licensed", [True, False])
+    @pytest.mark.parametrize("clock_open", [True, False])
+    @pytest.mark.parametrize(
+        "control_method",
+        [
+            ControlMethod.DEFAULT,
+            ControlMethod.MANUAL,
+            ControlMethod.MOTION,
+            ControlMethod.CUSTOM_POSITION,
+            ControlMethod.GROUP_SCENE,
+        ],
+    )
+    def test_status_and_explanation_agree_across_the_window_matrix(
+        self,
+        builder: DiagnosticsBuilder,
+        control_method: ControlMethod,
+        clock_open: bool,
+        licensed: bool,
+    ):
+        """The two fields must describe the same cycle (#1310).
+
+        Every winner that can reach a closed clock, crossed with the clock
+        state and the outside-window licence. Three properties, none of which
+        restates the implementation:
+
+        1. "commands paused" is claimed exactly when the dispatch guard is
+           shut — closed clock AND no licence (``coordinator``'s position-update
+           guard reads that same pair).
+        2. ``control_status`` never answers OUTSIDE_TIME_WINDOW on a cycle the
+           explanation does not call paused, and never answers ACTIVE on one it
+           does.
+        3. The winner's own reason survives the closed clock. DEFAULT is the
+           one exception: the paused note already says everything its reason
+           would, so it collapses to the note alone.
+        """
+        pr = _make_pr(
+            control_method=control_method,
+            reason=f"{control_method.value} winner — position 40%",
+            position=40,
+            raw_calculated_position=40,
+            default_position=70,
+            is_safety=licensed,
+        )
+        diag, explanation = builder.build(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=clock_open,
+                clock_window_open=clock_open,
+            )
+        )
+
+        withheld = not clock_open and not licensed
+        assert ("commands paused" in explanation) is withheld
+
+        if diag["control_status"] == ControlStatus.OUTSIDE_TIME_WINDOW:
+            assert withheld
+        if withheld:
+            assert diag["control_status"] != ControlStatus.ACTIVE
+
+        if control_method is not ControlMethod.DEFAULT:
+            assert pr.reason in explanation
+
 
 # ---------------------------------------------------------------------------
 # Control state reason

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -345,7 +345,9 @@ class TestPositionExplanation:
             default_position=20, is_sunset_active=True, configured_sunset_pos=20
         )
         _, explanation = builder.build(
-            _base_ctx(pipeline_result=pr, check_adaptive_time=False)
+            _base_ctx(
+                pipeline_result=pr, check_adaptive_time=False, clock_window_open=False
+            )
         )
         assert "sunset position" in explanation.lower()
         assert "20%" in explanation
@@ -355,7 +357,9 @@ class TestPositionExplanation:
         """Outside time window with no sunset_pos → shows 'default position'."""
         pr = _make_pr(default_position=10, is_sunset_active=False)
         _, explanation = builder.build(
-            _base_ctx(pipeline_result=pr, check_adaptive_time=False)
+            _base_ctx(
+                pipeline_result=pr, check_adaptive_time=False, clock_window_open=False
+            )
         )
         assert "default position" in explanation.lower()
         assert "10%" in explanation

--- a/tests/test_diagnostics/test_reason_localization.py
+++ b/tests/test_diagnostics/test_reason_localization.py
@@ -119,7 +119,12 @@ def test_position_explanation_outside_window_renders_de_with_fragment() -> None:
         default_position=30,
         is_sunset_active=True,
     )
-    ctx = _ctx(pipeline_result=pr, check_adaptive_time=False, reason_labels=_FAKE_DE)
+    ctx = _ctx(
+        pipeline_result=pr,
+        check_adaptive_time=False,
+        clock_window_open=False,
+        reason_labels=_FAKE_DE,
+    )
     result = DiagnosticsBuilder._build_position_explanation(ctx)
     assert result == (
         "Außerhalb des Zeitfensters → Sonnenuntergangsposition 30% (Befehle pausiert)"
@@ -253,7 +258,7 @@ def test_position_explanation_outside_window_en_byte_identical() -> None:
         default_position=30,
         is_sunset_active=True,
     )
-    ctx = _ctx(pipeline_result=pr, check_adaptive_time=False)
+    ctx = _ctx(pipeline_result=pr, check_adaptive_time=False, clock_window_open=False)
     assert DiagnosticsBuilder._build_position_explanation(ctx) == (
         "Outside time window → sunset position 30% (commands paused)"
     )

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -660,7 +660,9 @@ class TestBuildPositionExplanation:
             default_position=30, is_sunset_active=True, configured_sunset_pos=30
         )
         result = DiagnosticsBuilder._build_position_explanation(
-            _base_ctx(pipeline_result=pr, check_adaptive_time=False)
+            _base_ctx(
+                pipeline_result=pr, check_adaptive_time=False, clock_window_open=False
+            )
         )
         assert "sunset position" in result.lower()
         assert "30%" in result
@@ -670,7 +672,9 @@ class TestBuildPositionExplanation:
         """Outside time window, no sunset_pos → shows 'default position' label."""
         pr = _make_pr(default_position=100, is_sunset_active=False)
         result = DiagnosticsBuilder._build_position_explanation(
-            _base_ctx(pipeline_result=pr, check_adaptive_time=False)
+            _base_ctx(
+                pipeline_result=pr, check_adaptive_time=False, clock_window_open=False
+            )
         )
         assert "default position" in result.lower()
         assert "100%" in result
@@ -694,7 +698,9 @@ class TestBuildPositionExplanation:
             is_safety=True,
         )
         result = DiagnosticsBuilder._build_position_explanation(
-            _base_ctx(pipeline_result=pr, check_adaptive_time=False)
+            _base_ctx(
+                pipeline_result=pr, check_adaptive_time=False, clock_window_open=False
+            )
         )
         assert "weather override active" in result.lower()
         assert "commands paused" not in result
@@ -729,7 +735,9 @@ class TestBuildPositionExplanation:
         assert pr.acts_outside_clock_window is True
 
         result = DiagnosticsBuilder._build_position_explanation(
-            _base_ctx(pipeline_result=pr, check_adaptive_time=False)
+            _base_ctx(
+                pipeline_result=pr, check_adaptive_time=False, clock_window_open=False
+            )
         )
         assert "ceiling lowered" in result.lower()
         assert "30%" in result
@@ -737,6 +745,33 @@ class TestBuildPositionExplanation:
         # The default position (100%) is what the old unconditional return
         # would have reported instead of the clamp edge.
         assert "default position" not in result.lower()
+
+    def test_gate_dark_clock_open_reports_actual_winner(self, builder):
+        """Gate reads dark but the user's clock window is still open (issue #1310).
+
+        ``check_adaptive_time``/``is_active`` folds in the daytime gate, so it
+        goes False the moment a configured gate sensor reads dark — even while
+        ``clock_window_open`` (start/end clock only) is still True and the real
+        dispatch guard (``coordinator.clock_window_open`` at
+        ``coordinator.py``) is NOT blocking anything this cycle. The old guard
+        keyed off ``check_adaptive_time`` alone and would report the default
+        position with a false "commands paused" instead of the pipeline
+        winner's real reason.
+        """
+        pr = _make_pr(
+            control_method=ControlMethod.DEFAULT,
+            reason="default position 30% — gate dark",
+            default_position=30,
+        )
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=False,
+                clock_window_open=True,
+            )
+        )
+        assert "commands paused" not in result
+        assert "default position 30% — gate dark" in result
 
     def test_sunset_offset_with_sunset_position(self, builder):
         """In window, is_sunset_active=True → reason from default handler mentions sunset."""
@@ -896,6 +931,7 @@ class TestPositionExplanationChangeDetection:
         coord._weather_readings = None
         coord._pipeline_result = _make_pr()
         type(coord).check_adaptive_time = PropertyMock(return_value=True)
+        type(coord).clock_window_open = PropertyMock(return_value=True)
         type(coord).after_start_time = PropertyMock(return_value=True)
         type(coord).before_end_time = PropertyMock(return_value=True)
         coord._time_mgr = MagicMock()

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -773,6 +773,94 @@ class TestBuildPositionExplanation:
         assert "commands paused" not in result
         assert "default position 30% — gate dark" in result
 
+    def test_manual_winner_survives_the_closed_clock_note(self, builder):
+        """A MANUAL winner on a genuinely closed clock keeps its own account.
+
+        ``_determine_control_status`` answers MANUAL_OVERRIDE here — the
+        ``_METHOD_TO_STATUS`` early return fires before the clock check, and
+        ``sensor._control_status_attrs`` / triage rule 23 both key on that
+        answer, so it is deliberate. The explanation used to replace the
+        winner's reason with the generic default/sunset note, leaving the two
+        fields telling different stories about the same cycle.
+
+        Nothing IS dispatched out here (``coordinator`` skips the position
+        update once ``clock_window_open`` is False without a licence), so
+        "commands paused" is true and must survive too — both truths, not
+        either one.
+        """
+        pr = _make_pr(
+            control_method=ControlMethod.MANUAL,
+            reason="manual override active — holding 45% (solar would-be 62%)",
+            position=62,
+            raw_calculated_position=62,
+            default_position=50,
+        )
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=False,
+                clock_window_open=False,
+            )
+        )
+        # The real winner leads the chain — not a default/sunset position it
+        # never resolved.
+        assert result.split(" → ")[0] == (
+            "manual override active — holding 45% (solar would-be 62%)"
+        )
+        # …and the paused half of the truth is still stated.
+        assert "commands paused" in result
+
+    def test_motion_winner_survives_the_closed_clock_note(self, builder):
+        """Same for a MOTION winner — the other ``_METHOD_TO_STATUS`` entry.
+
+        Outside the clock window ``MotionTimeoutHandler`` always takes its
+        return-to-default branch (the hold branch gates on ``in_time_window``),
+        so the *position* the old note reported happened to be right — but the
+        "occupancy timeout" attribution was thrown away while ``control_status``
+        still said ``motion_timeout``.
+        """
+        pr = _make_pr(
+            control_method=ControlMethod.MOTION,
+            reason="occupancy timeout active — default position 30%",
+            position=30,
+            default_position=30,
+        )
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=False,
+                clock_window_open=False,
+            )
+        )
+        assert result.split(" → ")[0] == (
+            "occupancy timeout active — default position 30%"
+        )
+        assert "commands paused" in result
+
+    def test_default_winner_still_collapses_to_the_closed_clock_note(self, builder):
+        """The DEFAULT winner keeps the collapsed one-liner (the counterpart).
+
+        Its own reason says nothing the note does not already say — the note
+        was written for exactly this winner — so it is the one control method
+        that still renders alone. Pins the narrowing so a future widening
+        cannot quietly turn every night into a two-clause chain (the EN/DE
+        byte-identical locks in ``test_reason_localization`` depend on it).
+        """
+        pr = _make_pr(
+            control_method=ControlMethod.DEFAULT,
+            reason="no active condition — default position 40%",
+            position=40,
+            default_position=40,
+        )
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                pipeline_result=pr,
+                check_adaptive_time=False,
+                clock_window_open=False,
+            )
+        )
+        assert result == "Outside time window → default position 40% (commands paused)"
+
     def test_sunset_offset_with_sunset_position(self, builder):
         """In window, is_sunset_active=True → reason from default handler mentions sunset."""
         pr = _make_pr(

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -402,7 +402,9 @@ async def test_self_referencing_gate_template_refresh_is_bounded(
     attributes``, state value aside. And HA's template ``RenderInfo`` tracks
     dependencies at the entity level, not the attribute level:
     ``is_state_attr`` collects the entity into ``RenderInfo.entities`` exactly
-    like ``is_state`` does (both go through ``TemplateStateBase.attributes``),
+    like ``is_state`` does — they read different properties
+    (``TemplateStateBase.attributes`` vs ``.state``), but each one calls
+    ``_collect_state()``, which adds the *entity_id* and nothing finer —
     so ``_event_triggers_rerender`` treats this attribute-only flip as a
     reason to re-render, same as it always did for the state-based version.
 

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -346,12 +346,19 @@ async def test_unload_cancels_the_coalescer_pending_trailing_run(
         )
 
 
-#: The canonical reachable self-reference loop (issue #1159 review). The gate
-#: template reads ``control_status``; a True verdict opens the time window,
-#: which makes ``control_status`` stop reporting ``outside_time_window``, which
-#: renders the template False, which closes the window again. A true 2-cycle
-#: with no fixed point.
-_LOOPING_GATE_TEMPLATE = "{{ is_state(acp.control_status, 'outside_time_window') }}"
+#: The canonical reachable self-reference loop (issue #1159 review; rewired
+#: for #1310). The gate template reads ``control_status``'s
+#: ``time_window_status`` *attribute*, not its state: #1310 keyed the
+#: sensor's own state on ``clock_window_open`` (gate-independent) precisely so
+#: the gate can no longer flip it, which severed the original state-based
+#: loop. The attribute is still built from ``check_adaptive_time`` (gate-
+#: dependent) in ``sensor.py:_control_status_attrs``, so the cycle still
+#: closes through it: a True verdict opens the time window, which clears
+#: "Outside Window" from the attribute, which renders the template False,
+#: which closes the window again. A true 2-cycle with no fixed point.
+_LOOPING_GATE_TEMPLATE = (
+    "{{ is_state_attr(acp.control_status, 'time_window_status', 'Outside Window') }}"
+)
 
 #: Refreshes past this many mean the loop is running away. The counting stub
 #: stops calling through at the cap instead of letting an unguarded regression
@@ -362,21 +369,58 @@ _REFRESH_CAP = 60
 async def test_self_referencing_gate_template_refresh_is_bounded(
     hass: HomeAssistant, freezer
 ) -> None:
-    """The real control_status feedback loop settles at one refresh per window.
+    """The real time_window_status feedback loop settles at one refresh per window.
 
     Everything here is production wiring: the real daytime-gate template, the
-    real tracker, the real ``sensor.…_control_status``, the real coordinator
-    refresh. Only two things are instrumented — a counter around
-    ``async_refresh`` (which stops calling through at ``_REFRESH_CAP`` so a
-    regression fails fast instead of hanging), and one asynchronously-dispatched
-    consumer of the control-status sensor.
+    real tracker, the real ``sensor.…_control_status`` and its diagnostic
+    attributes, the real coordinator refresh. Only two things are
+    instrumented — a counter around ``async_refresh`` (which stops calling
+    through at ``_REFRESH_CAP`` so a regression fails fast instead of
+    hanging), and one asynchronously-dispatched consumer of the
+    control-status sensor.
+
+    The self-reference is deliberately wired through the
+    ``time_window_status`` *attribute*, not the sensor's own state. Since
+    #1310, ``control_status``'s state reads ``clock_window_open`` — the
+    start/end clock only, gate-independent — so the daytime gate can never
+    flip the sensor's own state and the original state-based loop no longer
+    closes. The ``time_window_status`` attribute
+    (``sensor.py:_control_status_attrs``) still reads ``check_adaptive_time``,
+    which folds the gate back in, so the attribute — not the state — is what
+    re-establishes the cycle: a True gate verdict clears "Outside Window" from
+    the attribute, the template (which reads that attribute) renders False,
+    the gate reports "not daytime", ``check_adaptive_time`` goes False, the
+    attribute flips back to "Outside Window", and the template renders True
+    again. A true 2-cycle with no fixed point — the same shape as the
+    pre-#1310 loop, reattached one field over.
+
+    HA still fires a full ``state_changed`` event for this: the sensor's main
+    ``state`` value never changes over the run (``clock_window_open`` is
+    stable for the whole window), but its ``attributes`` dict does, and
+    ``StateMachine.async_set_internal`` fires ``EVENT_STATE_CHANGED`` — not
+    the lighter ``EVENT_STATE_REPORTED`` — whenever ``old_state.attributes !=
+    attributes``, state value aside. And HA's template ``RenderInfo`` tracks
+    dependencies at the entity level, not the attribute level:
+    ``is_state_attr`` collects the entity into ``RenderInfo.entities`` exactly
+    like ``is_state`` does (both go through ``TemplateStateBase.attributes``),
+    so ``_event_triggers_rerender`` treats this attribute-only flip as a
+    reason to re-render, same as it always did for the state-based version.
 
     That consumer matters. A real install always has one (the recorder, a
     template sensor, an automation), and it is what keeps every flip visible to
     the tracker. With only synchronous callbacks on the bus the loop happens to
     die out after a handful of iterations and the test would pass vacuously;
-    with one, the *unguarded* loop is unbounded — measured at >9000 refreshes
-    before the harness timed out, versus the five below.
+    with one, the *unguarded* loop is unbounded. The original state-based
+    version of this loop measured >9000 refreshes before the harness timed
+    out; this attribute-based rewiring was re-measured the same way (real
+    ``async_setup`` + real consumer, ``_coalesce_namespace_refreshes`` swapped
+    for an identity passthrough so every flip calls the tracked action
+    directly) and drove *more than 5000* refreshes inside the single
+    ``await hass.async_block_till_done()`` that follows ``async_setup`` —
+    the measurement was capped there only to keep the run fast, not because
+    the loop showed any sign of settling. Both loops are the same shape: a
+    boolean with no fixed point, re-rendering every time its own effect
+    changes.
 
     A real start/end window is configured, with hours of slack on both sides:
     the ``hass`` fixture puts HA in US/Pacific, so the frozen 17:00 UTC instant


### PR DESCRIPTION
## Summary

Two diagnostic surfaces that described their own logic incorrectly.

**#1302.** The cloud-suppression line in the Configuration Summary joined its trigger fragments with commas, so an `is_sunny` sensor and a weather-state list read as two independent OR triggers. They are not independent: `ClimateProvider._read_sunny` resolves a single value in priority order, and a working sensor means the weather list never runs. The weather fragment is now a suffix qualifier on the `is_sunny` fragment when both are configured, and stays a peer when weather is the sole source (which it genuinely is in that case).

The wording deliberately avoids "if the sensor is unavailable". `_read_sunny` has three outcomes, not two: a configured-but-invalid source holds its last valid value and still never consults weather, so that phrasing would have been a subtler version of the same lie. The new `cloud.weather_fallback` key is a pure suffix, which is what keeps the existing `is_sunny` assertions intact. DE and FR were propagated through the translation tooling.

**#1310.** `_build_position_explanation` took its "outside time window" early return from `check_adaptive_time` (clock AND daytime gate) while every guard deciding whether a cover may actually move reads `clock_window_open` (clock only). On a gate-dark but clock-open cycle the sensor claimed "commands paused" while the position was in fact being dispatched.

Fixing that surfaced two more facets:

- `_determine_control_status` carried the identical wrong claim one field over, so the payload contradicted itself. It now mirrors the full guard, including the licence term, rather than just the clock operand.
- The outside-window note was *replacing* the winner's reason rather than qualifying it. Manual overrides, motion timeouts, custom positions, group locks and group scenes all had their reason discarded and a default position invented. Commands genuinely are paused out there, so that half was true and survives; the note is now a trailing clause on the existing arrow chain.

`_determine_control_status`'s method mapping was left in place on purpose. It looks like the same shape of bug, but the sensor gates its `manual_covers` attribute on that status and a triage rule keys on it, so hoisting the clock check above the mapping would strip both on every closed-clock cycle.

## Note on the debouncer stress test

Making `control_status` gate-independent severed the feedback loop that the self-referencing template test relied on: its gate template read `control_status`, which read the gate back. The cycle vanished and the test began passing while measuring nothing. It is repointed at the `time_window_status` attribute, which is still gate-derived, and the loop was confirmed real (unguarded it drives over 5000 refreshes before the coalescer bounds it to one per window). Background in issue #1159, which this does not change.

Not fixed here: `sensor.py`'s `time_window_status` attribute still reads `check_adaptive_time`. Issue #1308 is also untouched; its weather-override facet shipped separately.

## Testing

- ✅ 14970 tests passing, 0 failing
- Three audit passes over the diff, no must-fix findings

## Related Issues

Refs #1302
Refs #1310