### PR TITLE
fix: revoke stale is_safety on an external stop's My booking (#1225)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1339,6 +1339,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # Update target so the next reconciliation compares against
             # My rather than the stale calculated state.
             self._cmd_svc.set_target(entity_id, int(my_position_value))
+            # Issue #1225: an external stop is a user action, not a safety
+            # decision, so revoke any safety licence the row still carries
+            # from an earlier, still-in-flight safety dispatch — unconditional
+            # on ``engaged``, since the My number now booked is a user action
+            # either way.
+            self._cmd_svc.revoke_safety_verdict(entity_id)
             # Issue #888: when the stop actually engaged the #875 override (not a
             # mid-move stop), record My as the display-only assumed position so
             # the card shows My. Confined to covers with no native position axis

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -574,6 +574,25 @@ class CoverCommandService:
         for entity_id in list(self._state):
             self._revoke_safety_verdict(entity_id)
 
+    def revoke_safety_verdict(self, entity_id: str) -> None:
+        """Revoke one entity's safety licence for a booking no safety decision made.
+
+        Public sibling of :meth:`_revoke_safety_verdict`, for callers outside
+        this module — the coordinator, specifically — that need to invalidate
+        a single row's licence without reaching across the module boundary
+        into the private funnel. Same unconditional contract: not gated on
+        the booked target, not on the flag's current value.
+
+        Motivating caller: ``coordinator.async_check_cover_service_call``'s
+        external ``stop_cover`` handling (#1225). An external stop is a user
+        action, not a safety decision, so the My target it books is a pure
+        revoke — never a grant, mirroring the asymmetry
+        ``_record_safety_verdict`` already establishes for the
+        pipeline-routed dispatch path (revoke unconditionally, grant only
+        against that cycle's own ``routed_target``).
+        """
+        self._revoke_safety_verdict(entity_id)
+
     # ------------------------------------------------------------------ #
     # Assumed display position (issue #888) — display-only fallback for
     # open/close-only covers with no native position feedback.

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -297,22 +297,25 @@ class PerEntityState:
     # is not one of them: it assigns this cycle's verdict either way, as part
     # of booking, rather than taking a licence away.)
     #
-    # FIVE other sites write ``target`` and leave the verdict exactly as they
+    # FOUR other sites write ``target`` and leave the verdict exactly as they
     # found it, so a row can pair a fresh target with an older decision's
     # verdict:
     #
     # * ``CoverCommandService.restore_target`` — rehydration after a reload.
     # * ``CoverCommandService.send_my_position`` — books the configured My
     #   percent (no production caller today).
-    # * ``coordinator.py``'s two external-stop -> My paths. Step 2 of
-    #   ``run_reconciliation_pass`` drops an entity under manual override
-    #   before it ever reads this field, but only one site gets that for free:
-    #   ``async_apply_user_stop`` (``coordinator.py:4608``) books below an
-    #   unconditional ``mark_user_command``. ``async_check_cover_service_call``
-    #   (``coordinator.py:1288``) books whether or not
-    #   ``handle_stop_service_call`` engaged the override — it RETURNS that
-    #   answer and the booking ignores it — so an untracked cover, or one the
-    #   #875 wait-for-target gate declined, books with no override behind it.
+    # * ``coordinator.py``'s ``async_apply_user_stop`` (external-stop -> My)
+    #   books below an unconditional ``mark_user_command``, so
+    #   ``run_reconciliation_pass`` step 2 drops the entity under manual
+    #   override before it ever reads this field — the inherited verdict is
+    #   inert there. Its sibling, ``async_check_cover_service_call``, used to
+    #   share this gap: it booked whether or not ``handle_stop_service_call``
+    #   engaged the override, so an untracked cover, or one the #875
+    #   wait-for-target gate declined, booked with no override behind it.
+    #   Fixed (#1225): that site now calls the public
+    #   ``revoke_safety_verdict(entity_id)`` wrapper unconditionally alongside
+    #   its ``set_target`` — an external stop is a user action, not a safety
+    #   decision, so it is a pure revoke, never a grant.
     # * ``cover_types/venetian/sequencer.py``'s carriage rebase — pushes the
     #   observed carriage position back through ``set_commanded_position``
     #   (== ``set_target``) after a tilt-only send back-drives it.
@@ -320,7 +323,7 @@ class PerEntityState:
     # Today's blast radius is small, but the inheritance is real, and it is why
     # ``_record_safety_verdict`` declines to GRANT on a row with nothing
     # booked: an unbooked True is inert against both readers, yet any of the
-    # five would hand it straight to the next target.
+    # four would hand it straight to the next target.
     #
     # A reconciliation resend RESTATES the recorded value rather than
     # re-deciding it (#1134), because a resend makes no new verdict.

--- a/tests/test_services_stop.py
+++ b/tests/test_services_stop.py
@@ -376,6 +376,74 @@ async def test_external_stop_no_assumed_when_ignore_external() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Issue #1225: an external stop must not inherit a stale safety licence onto
+# the My booking it makes, regardless of whether the #875 override engaged.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_external_stop_revokes_stale_is_safety_when_not_engaged() -> None:
+    """A declined #875 override (mid-move stop) still revokes a stale safety licence.
+
+    Reproduces #1225: a safety dispatch (weather / force-override / safety
+    custom-position slot) still in flight when the user presses stop can leave
+    ``is_safety=True`` on the row. The #875 wait-for-target gate declines to
+    engage the override here (``engaged=False``), but the My booking still
+    happens — and until this fix, ``set_target`` alone left the stale licence
+    in place, letting a later cycle resend the safety target with automatic
+    control off or outside the time window.
+    """
+    from unittest.mock import patch
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = _make_coord_for_assumed(my_position=50, engaged=False)
+    entity_id = "cover.test_blind"
+    coord._cmd_svc.state(entity_id).is_safety = True
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+            coord, _stop_event()
+        )
+
+    assert coord._cmd_svc.is_safety_target(entity_id) is False
+
+
+@pytest.mark.asyncio
+async def test_external_stop_revokes_stale_is_safety_when_engaged() -> None:
+    """An engaged external stop also revokes a stale safety licence.
+
+    Companion to the declined case above: an external stop is a user action,
+    not a safety decision, either way — so the revoke is unconditional, not
+    gated on whether the #875 override engaged.
+    """
+    from unittest.mock import patch
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = _make_coord_for_assumed(my_position=50, engaged=True)
+    entity_id = "cover.test_blind"
+    coord._cmd_svc.state(entity_id).is_safety = True
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+            coord, _stop_event()
+        )
+
+    assert coord._cmd_svc.is_safety_target(entity_id) is False
+
+
+# ---------------------------------------------------------------------------
 # Issue #888 follow-up: the ACP `stop` service (card stop button) records My
 # for open/close-only covers, mirroring the external stop→My path above.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`async_check_cover_service_call` books a My target when an external `stop_cover` arrives, and the booking wrote nothing to `is_safety`, so the new target inherited whatever verdict the previous one left on that row. The booking also ignores `handle_stop_service_call`'s return value, which reports whether the #875 override actually engaged. That call declines whenever `is_waiting_for_target` is true, the ordinary in-flight flag set by every ACP dispatch, so a user pressing stop while a safety dispatch is still mid-move books a My number onto a row still carrying `is_safety=True`, with no manual override behind it for `run_reconciliation_pass` step 2 to drop. The stale licence then survives `clear_non_safety_targets()` and is eligible for resend with automatic control off or outside the time window.

An external stop is a user action, not a safety decision, so I revoke unconditionally at the booking rather than trying to decide a verdict there. Not gated on `engaged`: the My number is a user action either way, and gating it would leave the declined case, the only one that can actually inherit, as the one path that still does.

The coordinator calls a new public `revoke_safety_verdict(entity_id)` rather than the private `_revoke_safety_verdict` funnel it wraps. The plural `revoke_safety_verdicts()` already existed for the blanket sweep; this is its per-entity sibling, so the write still lands in exactly one place and the coordinator stops reaching across the module boundary for it.

The `is_safety` field comment in `state_store.py` enumerated five verdict-blind booking sites. This was one of them, so it is now four.

Sibling gaps in the same field are tracked separately: issue #1313 covers force-send's closed-clock early return and is NOT fixed here.

## Testing
- ✅ 14943 tests passing (4 skipped, 1 xfailed)

Two new tests in `tests/test_services_stop.py`, both confirmed failing first for the expected reason (`assert True is False` on `is_safety_target`): `test_external_stop_revokes_stale_is_safety_when_not_engaged` and `test_external_stop_revokes_stale_is_safety_when_engaged`. Regression guards re-run green: `tests/test_position_reconciliation.py` (the is_safety revoke/grant suite covering #1165/#1134/#1311), `tests/test_override_expiry_time_window.py`, `tests/test_integration_enabled_kill_switch.py`.

## Related Issues
Refs #1225