### PR TITLE
fix: revoke stale licences on force-send's closed-clock exit (#1313)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -315,6 +315,44 @@ _INSTANCE_MEAN_POSITION_HOLDS: frozenset[ControlMethod] = frozenset(
 )
 
 
+def _revoke_stale_closed_clock_licences(cmd_svc) -> None:
+    """Retire both outside-window licences on a "nothing admitted" exit.
+
+    Shared by every closed-clock exit that returns before ``apply_position``
+    runs — currently ``async_handle_state_change`` (#1311/#1312) and
+    ``_async_force_send_pipeline_position`` (#1313). Neither ``is_safety``
+    writer runs on those exits, so a booking made before the clock closed
+    would otherwise ride forward licensed forever and reconciliation step 4
+    resends it overnight.
+
+    Two licences expire here, in this exact order:
+
+    1. The safety verdict (#1311). This call is the same unconditional
+       revoke the three hysteresis gates apply; it strips the flag and
+       leaves every target, exactly as a cycle that HAD reached
+       same_position would.
+    2. The outside-window constraint licence (#943 item B): the slot
+       released or the bound is already satisfied, and target and licence
+       die together.
+
+    Order matters. A row carrying both flags is spared by the sweeper while
+    it still reads as safety, and would keep an outside-window licence that
+    step 4 admits just as readily. Revoking first lets the sweeper see the
+    truth and retire both in one cycle instead of leaking until the next
+    one.
+
+    A module-level function rather than a coordinator method: both call
+    sites are exercised by unit tests that drive
+    ``AdaptiveDataUpdateCoordinator`` methods with a bare ``MagicMock()`` as
+    ``self`` (see ``tests/test_override_expiry_time_window.py``). A
+    ``self.<name>()`` call against that kind of double resolves to an inert
+    auto-mock, not this body — taking ``cmd_svc`` directly keeps the shared
+    logic real under that test technique.
+    """
+    cmd_svc.revoke_safety_verdicts()
+    cmd_svc.clear_outside_window_targets()
+
+
 class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     """Adaptive cover data update coordinator."""
 
@@ -3340,6 +3378,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # opted-in constraint that actually clamped this cycle (#943 B).
             and not self._pipeline_acts_outside_clock_window
         ):
+            # Nothing is admitted this cycle — the same "nothing admitted"
+            # exit async_handle_state_change's closed-clock branch handles,
+            # reached here instead via _dispatch_for_cycle's auto_expired
+            # branch (#1313). See _revoke_stale_closed_clock_licences for the
+            # ordering rationale.
+            _revoke_stale_closed_clock_licences(self._cmd_svc)
             self.logger.debug(
                 "Force-send requested for %s but outside the clock window — "
                 "skipping reposition (pipeline position was %s; will apply when "
@@ -3631,26 +3675,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self._custom_position_template_trigger = False
             # Nothing is admitted this cycle — this is "the next closed-clock
             # cycle that finds nothing admitted" the reconciliation docstring
-            # names. Two licences expire here, in this order:
-            #
-            # 1. The safety verdict (#1311). apply_position is never reached
-            #    on this branch, so neither is_safety writer runs, and a
-            #    booking made before the clock closed rides forward licensed
-            #    forever — reconciliation step 4 resends it overnight. This
-            #    call is the same unconditional revoke the three hysteresis
-            #    gates apply; it strips the flag and leaves every target,
-            #    exactly as a cycle that HAD reached same_position would.
-            # 2. The outside-window constraint licence: the slot released or
-            #    the bound is already satisfied, and target and licence die
-            #    together.
-            #
-            # Order matters. A row carrying both flags is spared by the
-            # sweeper while it still reads as safety, and would keep an
-            # outside-window licence that step 4 admits just as readily.
-            # Revoking first lets the sweeper see the truth and retire both
-            # in one cycle instead of leaking until the next one.
-            self._cmd_svc.revoke_safety_verdicts()
-            self._cmd_svc.clear_outside_window_targets()
+            # names. See _revoke_stale_closed_clock_licences for the ordering
+            # rationale (#1311/#1312).
+            _revoke_stale_closed_clock_licences(self._cmd_svc)
             self.logger.debug("Outside the clock window — skipping position update")
             return
 

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -738,6 +738,64 @@ async def test_force_send_admits_constraint_outside_clock_window():
 
 
 @pytest.mark.asyncio
+async def test_force_send_outside_time_window_revokes_stale_safety_verdicts():
+    """Issue #1313: force-send's closed-clock exit must revoke stale safety
+    verdicts too, not just async_handle_state_change's (#1311/#1312).
+
+    Reachable via _dispatch_for_cycle's auto_expired branch: a manual-override
+    auto-expiry cycle outside the clock window, with no tracked-entity
+    state-change edge this cycle, takes THIS exit instead of
+    async_handle_state_change's. A safety booking made by an earlier cycle
+    would otherwise ride forward unrevoked past this exit specifically —
+    reconciliation step 4 admits it because acts_outside_clock_window is the
+    OR of is_safety and outside_window_constraint.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(check_adaptive_time=False)
+
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
+        coordinator, state=0, options={}
+    )
+
+    coordinator._cmd_svc.revoke_safety_verdicts.assert_called_once_with()
+    coordinator._cmd_svc.clear_outside_window_targets.assert_called_once_with()
+    coordinator._cmd_svc.apply_position.assert_not_called()
+
+    names = [c[0] for c in coordinator._cmd_svc.mock_calls]
+    assert names.index("revoke_safety_verdicts") < names.index(
+        "clear_outside_window_targets"
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_send_admitted_outside_clock_window_keeps_its_verdict():
+    """The revoke is gated at the call site, not inside the method.
+
+    With acts_outside_clock_window True the guard's admission condition is
+    satisfied, so this closed-clock exit never runs and the blanket revoke
+    cannot reach a licence that is still being earned — parity with
+    test_live_safety_result_outside_the_clock_window_keeps_its_verdict.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(
+        check_adaptive_time=False,
+        acts_outside_clock_window=True,
+    )
+
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
+        coordinator, state=40, options={}
+    )
+
+    coordinator._cmd_svc.revoke_safety_verdicts.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_first_refresh_sends_admitted_constraint_outside_window():
     """A restart at 03:00 re-establishes an admitted clamp instead of idling."""
     from custom_components.adaptive_cover_pro.coordinator import (


### PR DESCRIPTION
## Summary
`_async_force_send_pipeline_position`'s closed-clock early return asked the same admission question as the main dispatch path (`not clock_window_open and not _pipeline_acts_outside_clock_window`) but returned without revoking. An override-expiry cycle outside the clock window — reached via `_dispatch_for_cycle`'s `auto_expired` branch — therefore left a stale per-entity `is_safety` licence standing, and reconciliation step 4 admitted it.

Both closed-clock "nothing admitted" exits now call a shared `_revoke_stale_closed_clock_licences(cmd_svc)` helper, so the revoke and its ordering rationale live in one place rather than a second literal call site. The helper covers `clear_outside_window_targets()` alongside `revoke_safety_verdicts()` — same step-4 mechanism, so revoking only half would leave the root condition live.

The helper is a module-level function taking `cmd_svc` rather than a coordinator method: the tests around these exits drive the coordinator with a bare `MagicMock` as `self`, where a `self.<name>()` call resolves to an inert auto-mock instead of the real body.

Sibling gap to issue #1311; behaviour added there is preserved unchanged.

## Testing
- ✅ 14943 tests passing (14941 baseline + 2 new)

## Related Issues
Refs #1313