### PR TITLE
fix: log the actual pipeline winner instead of a constant (#1263)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -3747,7 +3747,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             reason = (
                 self._pipeline_result.control_method.value
                 if self._pipeline_bypasses_auto_control
-                else "solar"
+                else (self.pipeline_winner_name or "solar")
             )
         # Name the number and frame this loop fans out so the ordering view can
         # tell a raise from a lower (issue #1118). A per-cover hold verdict can

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -53,6 +53,7 @@ def _make_coordinator(
     in_startup_grace_period: bool = False,
     state_change_data_entity: str = "cover.test",
     state_change_data_position: int = 50,
+    winner_name: str | None = "solar",
 ):
     """Build a minimal mock coordinator for state-change handler tests."""
     coordinator = MagicMock()
@@ -63,6 +64,7 @@ def _make_coordinator(
     coordinator.logger = MagicMock()
     coordinator.state_change = True
     coordinator.cover_state_change = True
+    coordinator.pipeline_winner_name = winner_name
 
     if pipeline_result is None:
         pipeline_result = _make_pipeline_result()
@@ -1041,8 +1043,41 @@ class TestStateChangeWithSafetyHandlerBypass:
         assert reason == ControlMethod.WEATHER.value
 
     @pytest.mark.asyncio
-    async def test_non_safety_handler_uses_solar_as_reason(self):
-        """Non-safety handlers (solar, default, manual) use 'solar' as reason string."""
+    async def test_non_safety_handler_uses_pipeline_winner_name_as_reason(self):
+        """Non-safety winners use the real pipeline winner name as reason (#1263).
+
+        Climate's LOW_LIGHT branch deliberately reports ``control_method=DEFAULT``
+        (issue #33), so the dispatch reason must come from ``pipeline_winner_name``
+        (which reads the decision trace's matched step) rather than from
+        ``control_method`` — otherwise the climate-driven move still logs and
+        reports as something other than "climate".
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=50,
+            control_method=ControlMethod.DEFAULT,
+            bypass_auto_control=False,
+        )
+        coordinator = _make_coordinator(
+            entities=["cover.test"],
+            pipeline_result=result,
+            winner_name="climate",
+        )
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator, state=50, options={}
+        )
+
+        call = coordinator._cmd_svc.apply_position.call_args
+        reason = call.args[2]
+        assert reason == "climate"
+
+    @pytest.mark.asyncio
+    async def test_non_safety_solar_winner_still_uses_solar_as_reason(self):
+        """Regression guard: a genuine solar win still reports 'solar' as reason."""
         from custom_components.adaptive_cover_pro.coordinator import (
             AdaptiveDataUpdateCoordinator,
         )
@@ -1055,6 +1090,7 @@ class TestStateChangeWithSafetyHandlerBypass:
         coordinator = _make_coordinator(
             entities=["cover.test"],
             pipeline_result=result,
+            winner_name="solar",
         )
 
         await AdaptiveDataUpdateCoordinator.async_handle_state_change(


### PR DESCRIPTION
## Summary
The dispatch reason for any non-bypass pipeline winner was the literal `"solar"` in `coordinator.py`, so a move decided by the climate handler, the glare-zone handler or anything else still printed as `[solar] Positioning cover.x -> N%` and emitted `trigger: "solar"` on `cover_command_sent` and `cover_command_skipped`. User-submitted logs were therefore actively misleading rather than merely uninformative.

`control_method.value` is not a substitute for the winner name: climate's LOW_LIGHT branch deliberately reports `DEFAULT` to dodge a venetian-tilt side effect (issue #33), so that swap would still mislabel the exact case that motivated the report. This reuses `pipeline_winner_name`, which reads the decision trace's matched step and already backs the cover-group who-won sensor, keeping `"solar"` as the fallback when no step matched. The safety-bypass branch is untouched.

Files changed: `custom_components/adaptive_cover_pro/coordinator.py`, `tests/test_coordinator_integration.py`

## Testing
- ✅ 15082 tests passing

## Related Issues
Refs #1263