### PR TITLE
fix: clamp the interlock's leading target to the leader's own (#1154)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -846,6 +846,28 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     else None
                 )
             ),
+            # The raw target ACP last COMMANDED an entity to, regardless of
+            # whether it is still in flight (issue #1154). Unlike
+            # ``get_booked_target`` above, this accessor's contract is not
+            # "evidence of physical travel" — it is "what did ACP last book for
+            # this rail", used only to decide what VALUE a correction that is
+            # already going ahead should send. A failed dispatch's
+            # ``HomeAssistantError`` handler clears ``waiting`` but deliberately
+            # keeps the target (it is still the honest last-commanded value),
+            # so gating this on ``is_waiting_for_target`` the way
+            # ``get_booked_target`` is would make a correction blind to that
+            # kept value in exactly the case it must read it.
+            #
+            # NOT gated on dry_run, unlike ``get_booked_target``: dry run books
+            # a target through the identical ``set_target`` call a live cycle
+            # makes (before the dry-run gate short-circuits the actual service
+            # call), so the value is equally meaningful bookkeeping either way,
+            # and this accessor never feeds a suppression decision that a
+            # fictional "clearing" could corrupt — it only picks a number for a
+            # correction plan that ``_booked_clears`` has already decided must
+            # be built. Gating it would just make dry-run's simulated
+            # diagnostics diverge from what the same cycle does live.
+            get_command_target=lambda eid: self._cmd_svc.get_target(eid),
             get_current_tilt_position=lambda eid: state_attr(
                 self.hass, eid, "current_tilt_position"
             ),

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -270,6 +270,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # supplies no accessor: the gate then falls back on the two observation
         # signals, which is exactly the pre-#1140 behaviour.
         self._get_booked_target: Callable[[str], int | None] | None = None
+        # The unconditional counterpart of ``_get_booked_target`` above — the
+        # raw last-commanded target for a rail, gated on nothing (issue #1154).
+        # Only read by :meth:`plan_external_command_interlock`'s leader-target
+        # clamp, never by the suppression check ``_booked_clears`` makes.
+        self._get_command_target: Callable[[str], int | None] | None = None
         # Last resolved fabric blend, replayed by ``maybe_update_tilt_only`` when
         # the position axis won't fire this cycle. Cleared on every suppressed
         # branch of ``post_pipeline_resolve`` (mirrors venetian's ``_last_tilt``).
@@ -1659,6 +1664,9 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # rail, or None once it settles. Additive kwarg — every other policy
         # ignores it, and an absent one degrades to the observation signals.
         self._get_booked_target = kwargs.get("get_booked_target")
+        # Signal for the #1154 clamp: the raw, unconditional last-commanded
+        # target for a rail. Additive kwarg, same shape as the one above.
+        self._get_command_target = kwargs.get("get_command_target")
         # Model C rail-role resolution needs the instance's cover list; additive
         # kwarg, read via ``kwargs.get`` so every other policy ignores it.
         self._attached_entities = tuple(kwargs.get("entities") or ())
@@ -2480,6 +2488,36 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         plan is the seam that has to close it here, because it is the seam that
         produced the numbers.
 
+        **The leader-target clamp (issue #1154).** Once a correction is going
+        ahead — ``blocked`` is True and :meth:`_booked_clears` has already
+        answered False — the plan still has to pick a VALUE for the leader,
+        and it is not always safe to reuse ``wire_target`` (the follower's own
+        target) there. A leading rail's dispatch may have failed with a
+        ``HomeAssistantError``; the handler in
+        :meth:`CoverCommandService.apply_position` clears ``waiting`` there but
+        deliberately KEEPS the target, because it is still the honest
+        last-commanded value — just no longer evidence of anything in flight.
+        That is exactly the state that makes ``_get_booked_target`` (gated on
+        ``is_waiting_for_target``) answer None and :meth:`_booked_clears`
+        correctly decline to suppress, but blindly sending ``wire_target``
+        anyway then overwrites a kept, still-valid target with the follower's
+        own — the reported bug. ``self._get_command_target`` is the
+        unconditional counterpart of ``_get_booked_target`` (no ``waiting``
+        gate) that reads it. Three cases, all resolved through the same
+        :meth:`_rail_blocks` inequality :meth:`_booked_clears` already applies
+        — never restated:
+
+        * a target IS recorded AND it clears the follower — use it. This is
+          the fix: the leader's kept, still-honest target survives the
+          correction instead of being overwritten by ``wire_target``.
+        * a target IS recorded but does NOT clear the follower (a stale
+          target, #1151) — fall through to ``wire_target``, exactly as before
+          this clamp existed. Reusing the leader's own value here regardless
+          of clearance would silently reintroduce the #1151 stall this very
+          correction exists to break.
+        * no target is recorded at all (a cold start, or no accessor
+          supplied) — fall through to ``wire_target``, exactly as before.
+
         Returns ``None`` — nothing to correct — for every non-Model-C instance,
         every entity outside the pair, a degenerate pair the gate is itself inert
         for, an unreadable partner rail (no reading, no evidence of a collision),
@@ -2556,9 +2594,24 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             wire_target,
             leading_rail,
         )
+        # The leader-target clamp (issue #1154) — see the docstring's "leader-
+        # target clamp" section above for the three cases and why each falls
+        # out the way it does. Reuses ``_rail_blocks`` (never restated), the
+        # same inequality ``_booked_clears`` above already applies.
+        leader_target = (
+            self._get_command_target(leading_rail) if self._get_command_target else None
+        )
+        leading_target = (
+            leader_target
+            if leader_target is not None
+            and not self._rail_blocks(
+                leader_target, target_open, inverse, is_middle=is_middle
+            )
+            else wire_target
+        )
         return ExternalInterlockPlan(
             leading_entity_id=leading_rail,
-            leading_target=wire_target,
+            leading_target=leading_target,
             follower_entity_id=entity_id,
             follower_target=wire_target,
             reason=EXTERNAL_INTERLOCK_REASON,

--- a/tests/test_manual_command_interlock.py
+++ b/tests/test_manual_command_interlock.py
@@ -73,6 +73,11 @@ def _coord(cmd_svc, policy, ctx, *, dry_run=False, unavailable=()):
         if dry_run
         else (cmd_svc.get_target(eid) if cmd_svc.is_waiting_for_target(eid) else None)
     )
+    # Signal for the #1154 clamp: the raw, unconditional target ACP last
+    # commanded a rail to, independent of whether it is still "in flight"
+    # (unlike ``_get_booked_target`` above). Mirrors the production wiring in
+    # ``coordinator.py``'s ``attach()`` call.
+    policy._get_command_target = lambda eid: cmd_svc.get_target(eid)  # noqa: SLF001
     coord = MagicMock()
     coord.logger = MagicMock()
     coord._policy = policy
@@ -227,6 +232,14 @@ async def test_a_stale_in_flight_target_does_not_suppress_the_correction(
     83. Suppressing on "the middle rail is busy" left the correction declining
     (it believed the blocker was moving) and the gate refusing (61 does not
     clear 83) — the command was dropped by both halves, with no skip logged.
+
+    The value assertion below is the #1154 clamp's clearance-gating branch,
+    exercised: MIDDLE's own recorded 61 does NOT clear 83 (it is the stale
+    target this whole test is about), so the correction must fall through to
+    the follower's ``wire_target`` (83), exactly as before the clamp existed.
+    A naive clamp that unconditionally preferred MIDDLE's own recorded target
+    over ``wire_target`` — with no clearance check — would send 61 here and
+    silently reintroduce the #1151 stall this test guards against.
     """
     cmd_svc, policy, _rails, events = _harness(
         monkeypatch, script={_BOTTOM: [59], _MIDDLE: [69] * 4 + [83]}, position=83
@@ -235,11 +248,23 @@ async def test_a_stale_in_flight_target_does_not_suppress_the_correction(
     cmd_svc.set_target(_MIDDLE, 61)  # does NOT clear 83
     cmd_svc.set_waiting(_MIDDLE, True)
 
+    payloads: list[tuple[str, int | None]] = []
+    hass = cmd_svc._hass  # noqa: SLF001
+    inner = hass.services.async_call.side_effect
+
+    async def _record(domain, service, data, context=None):
+        await inner(domain, service, data, context=context)
+        payloads.append((data["entity_id"], data.get("position")))
+
+    hass.services.async_call = AsyncMock(side_effect=_record)
+
     with _patch_caps():
         outcome = await coord._interlock_user_command(_BOTTOM, 83, dispatch_token=False)
 
     assert outcome is not None
     assert _sends(events) == [f"send:{_MIDDLE}", f"send:{_BOTTOM}"]
+    assert (_MIDDLE, 83) in payloads, payloads
+    assert (_MIDDLE, 61) not in payloads, payloads
 
 
 @pytest.mark.asyncio
@@ -325,6 +350,75 @@ async def test_a_dry_run_target_is_not_evidence_of_motion(monkeypatch) -> None:
         outcome = await cmd_svc.apply_position(_MIDDLE, 40, "solar", ctx)
 
     assert outcome == ("skipped", "policy_deferred")
+
+
+@pytest.mark.asyncio
+async def test_a_kept_target_after_a_failed_dispatch_is_not_overwritten(
+    monkeypatch,
+) -> None:
+    """The reported failure (#1154): a correction must not clobber a kept target.
+
+    The bottom rail's own dispatch to 40 failed with a ``HomeAssistantError``.
+    PR #1152's handler clears ``waiting`` but deliberately keeps the booked
+    target at 40 — a legitimate, still-clearing target, not evidence of
+    anything in flight. A SECOND command then lands on the middle rail (target
+    70) and triggers a correction on the bottom rail; that correction must read
+    the bottom rail's own kept 40, not overwrite it with the middle rail's own
+    target, because 40 already clears 70 (and 70 does not need to "clear"
+    itself).
+    """
+    cmd_svc, policy, _rails, _events = _harness(
+        monkeypatch, script={_BOTTOM: [100] * 4 + [40], _MIDDLE: [100]}, position=70
+    )
+    coord = _coord(cmd_svc, policy, _rail_context(policy))
+    cmd_svc.set_target(_BOTTOM, 40)
+    cmd_svc.set_waiting(_BOTTOM, False)
+
+    payloads: list[tuple[str, int | None]] = []
+    hass = cmd_svc._hass  # noqa: SLF001
+    inner = hass.services.async_call.side_effect
+
+    async def _record(domain, service, data, context=None):
+        await inner(domain, service, data, context=context)
+        payloads.append((data["entity_id"], data.get("position")))
+
+    hass.services.async_call = AsyncMock(side_effect=_record)
+
+    with _patch_caps():
+        outcome = await coord._interlock_user_command(_MIDDLE, 70, dispatch_token=False)
+
+    assert outcome is not None
+    assert (_BOTTOM, 40) in payloads, payloads
+    assert (_BOTTOM, 70) not in payloads, payloads
+    assert cmd_svc.get_target(_BOTTOM) == 40
+
+
+@pytest.mark.asyncio
+async def test_a_waiting_kept_target_after_a_failed_dispatch_declines_the_correction(
+    monkeypatch,
+) -> None:
+    """The control for the test above — already passes today, and must keep passing.
+
+    Same numbers, but ``waiting`` was never cleared: the bottom rail is
+    genuinely in flight to 40, which clears the middle rail's 70, so
+    ``_booked_clears`` suppresses the correction outright and the gate is left
+    to do its job. This documents the existing-good path and guards
+    ``_booked_clears``'s own ``waiting`` gate (``get_booked_target``) against a
+    future regression from the #1154 clamp reading a DIFFERENT, unconditional
+    accessor.
+    """
+    cmd_svc, policy, _rails, events = _harness(
+        monkeypatch, script={_BOTTOM: [100] * 4 + [40], _MIDDLE: [100]}, position=70
+    )
+    coord = _coord(cmd_svc, policy, _rail_context(policy))
+    cmd_svc.set_target(_BOTTOM, 40)
+    cmd_svc.set_waiting(_BOTTOM, True)
+
+    with _patch_caps():
+        outcome = await coord._interlock_user_command(_MIDDLE, 70, dispatch_token=False)
+
+    assert outcome is None
+    assert _sends(events) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`plan_external_command_interlock` built every Model C correction with `leading_target=wire_target`, so the leading rail was always sent the *follower's* target. When a leading rail's dispatch had failed with a `HomeAssistantError`, the handler cleared `waiting` while deliberately keeping the target, and because `get_booked_target` is gated on `is_waiting_for_target` that kept value went invisible to `_booked_clears`. The suppression check correctly declined, and the correction then overwrote the user's target with the follower's.

I clamp the leading target through the same `_rail_blocks` inequality `_booked_clears` already applies, so all three cases fall out of one rule: a recorded target that clears the follower is used, one that does not clear falls through to `wire_target`, and no recorded target falls through unchanged. The middle case is load-bearing: reusing the leader's value regardless of clearance would silently reintroduce the stall the correction exists to break (issue #1151).

`get_command_target` is the unconditional counterpart of `get_booked_target`, without the `waiting` gate and, deliberately, without a dry-run gate: it only picks a value for a correction already decided on.

Also strengthens `test_a_stale_in_flight_target_does_not_suppress_the_correction` to assert the value sent rather than merely that a send happened. Without that it could not have caught a naive clamp.

## Testing
- ✅ 447 tests passing

## Related Issues
Refs #1154