### PR TITLE
fix: declare and reach the motion_status holding state (#1162)

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -923,7 +923,11 @@ def _motion_status_value(s: _ACPDiagnosticSensor) -> str:
     mgr = s.coordinator._motion_mgr  # noqa: SLF001
     if mgr.is_motion_timeout_active:
         pr = getattr(s.coordinator, "_pipeline_result", None)
-        if pr is not None and pr.skip_command and pr.control_method.value == "motion":
+        if (
+            pr is not None
+            and pr.skip_command
+            and pr.control_method == ControlMethod.MOTION
+        ):
             return "holding"
         return "no_motion"
     if mgr.last_motion_time is None:

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -1564,6 +1564,7 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
             "timeout_pending",
             "no_motion",
             "waiting_for_data",
+            "holding",
         ),
         should_poll=False,
         value_fn=_motion_status_value,

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -852,6 +852,47 @@ def test_motion_status_sensor_no_motion():
     assert sensor.native_value == "no_motion"
 
 
+def test_motion_status_sensor_holding_state_is_declared_option():
+    """Sensor returns holding when its own branch condition is satisfied.
+
+    Regression for issue #1162: ``_motion_status_value`` has a
+    ``return "holding"`` branch guarded by
+    ``pr.skip_command and pr.control_method.value == "motion"``, but the
+    ``motion_status`` spec's declared ``options`` tuple never gained a
+    matching entry. HA's SensorEntity validates every reported ENUM value
+    against ``options`` and raises ValueError instead of publishing the
+    state, so this asserts both the value function's return AND that the
+    value is a declared option.
+
+    ``_pipeline_result`` is a duck-typed stand-in (not the real
+    ``PipelineResult`` + ``ControlMethod.MOTION``) because
+    ``ControlMethod.MOTION.value`` is ``"motion_timeout"``, not
+    ``"motion"`` — the branch's own literal comparison, so this test
+    satisfies the condition exactly as written rather than asserting
+    something the real enum cannot produce.
+    """
+    from custom_components.adaptive_cover_pro.sensor import _DIAGNOSTIC_SPECS
+
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=1700000000.0,
+        timeout_active=True,
+    )
+    coordinator._pipeline_result = SimpleNamespace(
+        skip_command=True,
+        control_method=SimpleNamespace(value="motion"),
+    )
+
+    sensor = _make_motion_status_sensor(coordinator)
+    assert sensor.native_value == "holding"
+
+    spec = next(s for s in _DIAGNOSTIC_SPECS if s.suffix == "motion_status")
+    assert "holding" in spec.options, (
+        "'holding' is a reachable _motion_status_value return but is missing "
+        f"from the motion_status spec's declared options: {spec.options!r}"
+    )
+
+
 def test_motion_status_sensor_waiting_for_data_fallback():
     """Sensor returns waiting_for_data when neither active nor pending.
 

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -793,6 +793,32 @@ def _make_motion_status_sensor(coordinator, motion_sensors=None):
     return sensor
 
 
+def _make_motion_timeout_coordinator(*, skip_command: bool, position: int = 42):
+    """Coordinator with an active motion timeout and a MOTION-method pipeline result.
+
+    Mirrors what ``MotionTimeoutHandler`` actually produces (issue #1162's
+    second bug): both its hold branch and its return-to-default branch stamp
+    ``control_method=ControlMethod.MOTION`` (``pipeline/handlers/motion_timeout.py``
+    lines 60-67 and 75-90) — only ``skip_command`` distinguishes them. Callers
+    pick which branch to simulate via ``skip_command``.
+    """
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=1700000000.0,
+        timeout_active=True,
+    )
+    coordinator._pipeline_result = PipelineResult(
+        position=position,
+        control_method=ControlMethod.MOTION,
+        reason="occupancy timeout",
+        skip_command=skip_command,
+    )
+    return coordinator
+
+
 def test_motion_status_sensor_not_configured():
     """Sensor returns not_configured when no motion sensors are set up."""
     coordinator = MagicMock()
@@ -853,35 +879,30 @@ def test_motion_status_sensor_no_motion():
 
 
 def test_motion_status_sensor_holding_state_is_declared_option():
-    """Sensor returns holding when its own branch condition is satisfied.
+    """Sensor returns holding when the motion-timeout hold branch wins.
 
     Regression for issue #1162: ``_motion_status_value`` has a
     ``return "holding"`` branch guarded by
-    ``pr.skip_command and pr.control_method.value == "motion"``, but the
+    ``pr.skip_command and pr.control_method == ControlMethod.MOTION``, but the
     ``motion_status`` spec's declared ``options`` tuple never gained a
     matching entry. HA's SensorEntity validates every reported ENUM value
     against ``options`` and raises ValueError instead of publishing the
     state, so this asserts both the value function's return AND that the
     value is a declared option.
 
-    ``_pipeline_result`` is a duck-typed stand-in (not the real
-    ``PipelineResult`` + ``ControlMethod.MOTION``) because
-    ``ControlMethod.MOTION.value`` is ``"motion_timeout"``, not
-    ``"motion"`` — the branch's own literal comparison, so this test
-    satisfies the condition exactly as written rather than asserting
-    something the real enum cannot produce.
+    ``_pipeline_result`` is a real ``PipelineResult`` with the real
+    ``ControlMethod.MOTION`` enum member and ``skip_command=True`` — exactly
+    what ``MotionTimeoutHandler``'s hold branch constructs
+    (``pipeline/handlers/motion_timeout.py`` lines 60-67). A prior version of
+    this test used a ``SimpleNamespace`` duck-type comparing
+    ``control_method.value == "motion"``, which encoded a second, independent
+    bug: no ``ControlMethod`` member has the value ``"motion"`` (the real
+    member's value is ``"motion_timeout"``), so that comparison could never
+    be satisfied by the real enum and the "holding" branch was dead code.
     """
     from custom_components.adaptive_cover_pro.sensor import _DIAGNOSTIC_SPECS
 
-    coordinator = MagicMock()
-    coordinator._motion_mgr = _make_motion_mgr(
-        last_motion_time=1700000000.0,
-        timeout_active=True,
-    )
-    coordinator._pipeline_result = SimpleNamespace(
-        skip_command=True,
-        control_method=SimpleNamespace(value="motion"),
-    )
+    coordinator = _make_motion_timeout_coordinator(skip_command=True)
 
     sensor = _make_motion_status_sensor(coordinator)
     assert sensor.native_value == "holding"
@@ -891,6 +912,23 @@ def test_motion_status_sensor_holding_state_is_declared_option():
         "'holding' is a reachable _motion_status_value return but is missing "
         f"from the motion_status spec's declared options: {spec.options!r}"
     )
+
+
+def test_motion_status_sensor_return_to_default_is_not_holding():
+    """Motion timeout active + ControlMethod.MOTION but skip_command=False → no_motion.
+
+    Pins the discriminator in the opposite direction from the test above.
+    ``MotionTimeoutHandler``'s return-to-default branch
+    (``pipeline/handlers/motion_timeout.py`` lines 75-90) also stamps
+    ``control_method=ControlMethod.MOTION`` — it's the same handler — but
+    leaves ``skip_command`` at its dataclass default of ``False``. Only the
+    hold branch (``skip_command=True``) should report "holding"; this branch
+    must still report "no_motion".
+    """
+    coordinator = _make_motion_timeout_coordinator(skip_command=False)
+
+    sensor = _make_motion_status_sensor(coordinator)
+    assert sensor.native_value == "no_motion"
 
 
 def test_motion_status_sensor_waiting_for_data_fallback():

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -26,9 +26,15 @@ When you add a new sensor spec with a translation_key:
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
+import textwrap
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
+
+from homeassistant.components.sensor import SensorDeviceClass
 
 from custom_components.adaptive_cover_pro.binary_sensor import (
     _BINARY_SENSOR_SPECS,
@@ -348,3 +354,148 @@ class TestSwitchTranslationKeys:
             f"_SwitchSpec key: {sorted(orphaned)}\n"
             "Remove the orphaned entry or add a matching _SwitchSpec."
         )
+
+
+# ---------------------------------------------------------------------------
+# ENUM sensor options-coverage guard (issue #1162)
+# ---------------------------------------------------------------------------
+#
+# A static source scan over every ENUM sensor spec's ``value_fn``: every
+# string literal it can return must be a declared member of the spec's
+# ``options`` tuple. This is what would have caught #1162 — the
+# ``motion_status`` spec's ``_motion_status_value`` had a reachable
+# ``return "holding"`` that was never added to ``options``, so HA raised
+# ValueError instead of publishing the state.
+#
+# Deliberately a static scan, not a dynamic reachability prover: it only
+# collects literal string returns, never computed expressions (attribute
+# access, calls — e.g. ``result.control_method.value``,
+# ``climate_mode_from_diagnostics(...)``). Those sensors build their
+# ``options`` directly from the same vocabulary their value_fn reads
+# (decision_trace, travel_calibration, climate_status) and are correct by
+# construction; a heuristic for computed expressions would create noise,
+# not safety.
+
+
+def _literal_strings_in_expr(node: ast.expr) -> set[str]:
+    """Collect string-literal constants out of an expression.
+
+    Follows the branches of a ternary (``a if cond else b``) so a value_fn
+    that picks between literals via a single conditional expression is still
+    fully covered. Anything else (attribute access, calls, names — computed
+    expressions) contributes nothing: chasing those is not feasible in
+    general, see the module-level note above.
+    """
+    if isinstance(node, ast.IfExp):
+        return _literal_strings_in_expr(node.body) | _literal_strings_in_expr(
+            node.orelse
+        )
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return {node.value}
+    return set()
+
+
+def _extract_lambda_expr(source: str, value_fn: Any) -> ast.Lambda:
+    """Isolate a standalone-parseable lambda expression out of raw source.
+
+    ``inspect.getsource`` on a lambda that is one of several keyword
+    arguments on the same source line (e.g. ``value_fn=lambda e: ..., ``)
+    returns the surrounding statement, which is not valid Python on its own,
+    so a direct ``ast.parse`` of it can raise ``SyntaxError``. Find the
+    ``lambda`` token and progressively trim trailing characters (a comma, an
+    enclosing call's closing paren, …) until what remains parses as a
+    standalone expression whose body is a ``Lambda`` node.
+
+    Raises AssertionError naming ``value_fn`` if no such expression can be
+    recovered, so an unprocessable spec fails loudly instead of silently
+    reporting zero literals (and therefore vacuously "passing").
+    """
+    idx = source.find("lambda")
+    assert idx != -1, f"No 'lambda' token found in source for {value_fn!r}: {source!r}"
+    candidate = source[idx:]
+    for end in range(len(candidate), 0, -1):
+        snippet = candidate[:end]
+        try:
+            parsed = ast.parse(snippet, mode="eval")
+        except SyntaxError:
+            continue
+        if isinstance(parsed.body, ast.Lambda):
+            return parsed.body
+    raise AssertionError(
+        f"Could not isolate a parseable lambda expression for {value_fn!r} "
+        f"from source: {source!r}"
+    )
+
+
+def _string_literals_returned(value_fn: Any) -> set[str]:
+    """Every string-literal value ``value_fn`` can return.
+
+    Handles both plain ``def`` functions (walk every ``ast.Return`` node)
+    and lambdas — whose body has no ``Return`` node at all, since it is a
+    bare expression, so the expression itself (and any ternary branches
+    within it) is inspected directly.
+
+    Fails loudly (an AssertionError naming ``value_fn``) if the source
+    cannot be retrieved or parsed, rather than swallowing the exception and
+    silently reporting no findings for a spec the scan can no longer see
+    into.
+    """
+    try:
+        source = textwrap.dedent(inspect.getsource(value_fn))
+    except (OSError, TypeError) as exc:
+        raise AssertionError(
+            f"Could not retrieve source for value_fn {value_fn!r}: {exc}"
+        ) from exc
+
+    if getattr(value_fn, "__name__", None) == "<lambda>":
+        lambda_node = _extract_lambda_expr(source, value_fn)
+        return _literal_strings_in_expr(lambda_node.body)
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise AssertionError(
+            f"Could not parse source for value_fn {value_fn!r}: {exc}\n{source}"
+        ) from exc
+
+    literals: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Return) and node.value is not None:
+            literals |= _literal_strings_in_expr(node.value)
+    return literals
+
+
+class TestEnumSensorOptionsCoverage:
+    """Every ENUM sensor's literal value_fn returns must be declared options."""
+
+    def test_enum_sensor_literal_returns_are_declared_options(self) -> None:
+        """Regression guard for issue #1162.
+
+        For every sensor spec with ``device_class is SensorDeviceClass.ENUM``,
+        every string literal its ``value_fn`` can return must be a member of
+        the spec's declared ``options`` tuple — otherwise HA's SensorEntity
+        raises ValueError instead of publishing the state the first time that
+        branch fires in production.
+        """
+        all_specs = (*_STANDARD_SPECS, *_DIAGNOSTIC_SPECS)
+        enum_specs = [
+            spec for spec in all_specs if spec.device_class is SensorDeviceClass.ENUM
+        ]
+        assert enum_specs, (
+            "Expected at least one ENUM sensor spec to scan. An empty list "
+            "means the scan mechanism itself broke (e.g. every value_fn "
+            "became a functools.partial), not that there is nothing left to "
+            "check — a vacuous pass here would hide that."
+        )
+
+        failures = []
+        for spec in enum_specs:
+            literals = _string_literals_returned(spec.value_fn)
+            undeclared = literals - set(spec.options or ())
+            if undeclared:
+                failures.append(
+                    f"{spec.suffix!r} value_fn returns literal(s) "
+                    f"{sorted(undeclared)} not present in its declared "
+                    f"options {spec.options!r}"
+                )
+        assert not failures, "\n".join(failures)


### PR DESCRIPTION
## Summary
Two related bugs in `_motion_status_value` (`custom_components/adaptive_cover_pro/sensor.py`).

The `motion_status` ENUM spec declared five options but the value function can return `"holding"`, so HA's `SensorEntity` would reject that state with a `ValueError` rather than publish it. Added the missing option.

Writing the test for that surfaced a second bug: the `"holding"` branch was guarded by `pr.control_method.value == "motion"`, and no `ControlMethod` member has that value. The intended member is `MOTION`, whose value is `"motion_timeout"`. The branch was therefore dead code since PR #335 introduced it, and the sensor reported `no_motion` where it should have reported `holding`. The comparison now tests the enum directly, matching `coordinator.py:5179` and `diagnostics/builder.py:511`.

Behavior change: `motion_status` now reports `holding` in the motion-timeout hold-position case where it previously reported `no_motion`.

Also adds the ENUM options-coverage guard requested in the issue: a static scan over every ENUM sensor spec that fails when a `value_fn` can return a string literal absent from its declared `options`. It handles both `def` functions and lambdas, fails loudly rather than skipping a spec it cannot parse, and asserts it scanned at least one spec so it cannot pass vacuously. The scan found no other drift: `decision_trace`, `travel_calibration` and `climate_status` are correct by construction.

## Testing
- ✅ 15128 tests passing (4 skipped, 1 xfailed)

## Related Issues
Refs #1162