### PR TITLE
fix: give the outside-window pseudo-hold a below-everything priority (#1231)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1126,6 +1126,16 @@ CUSTOM_POSITION_SLOT_NUMBERS: tuple[int, ...] = tuple(
 # bypass the delta-position/delta-time send gates (issue #563).
 CUSTOM_POSITION_SAFETY_PRIORITY = 100
 
+# Holder priority the registry hands its outside-window pseudo-hold (issue
+# #943 item B), NOT the winning handler's own priority. A pseudo-hold is
+# scaffolding — nothing is actually holding the cover, so #463's rule that
+# composition against a computed winner is priority-independent applies here,
+# not outranking()'s real-hold tie rule. This sentinel sits below every value
+# a user can configure for a slot (priority_slider() floors at 1) and below
+# DefaultHandler's 0, so every real claim strictly outranks it and the
+# pseudo-hold can never again swallow a same-priority opt-in bound (#1231).
+PSEUDO_HOLD_HOLDER_PRIORITY = -1
+
 # Cover-group scene intents claim the pipeline at this priority (issue #790,
 # Phase 2): above manual_override (80) so "put the room in Privacy" wins over
 # a stale per-cover manual state, below weather (90) so wind/rain safety on an

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -7,7 +7,7 @@ import datetime as dt
 import logging
 from collections.abc import Mapping
 
-from ..const import AxisConstraintMode, ReasonCode
+from ..const import PSEUDO_HOLD_HOLDER_PRIORITY, AxisConstraintMode, ReasonCode
 from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
 from ..diagnostics.event_buffer import EventBuffer
 from ..position_utils import flip_if
@@ -472,27 +472,26 @@ def _as_outside_window_pseudo_hold(
     ``held_position``. Borrowing it is what makes the new capability a
     restatement of an existing rule rather than a second one.
 
-    The holder priority stays ``winning_handler.priority`` at the call site,
-    which has a consequence worth stating plainly. A REAL hold (manual override
-    at 80, a group lock at 100) never reaches here at all — ``held_position`` is
-    already set — and still beats a 77 slot through the unchanged
-    :func:`outranking` gate. But a pseudo-hold inherits its winner's priority as
-    if that winner were holding the cover, and :func:`outranking` is
-    strictly-greater. Against ``DefaultHandler`` at 0 that is inert: every
-    constraint outranks it. Against a **FIXED custom-position slot** winning at
-    the default 77, a second slot's opted-in bound at 77 does NOT outrank it and
-    is filed as ``yielded_to_hold`` — so on that configuration the opt-in is
-    inert and the user sees a ``bound_yielded_to_hold`` trace step naming a
-    holder that is not holding anything.
+    The call site does NOT hand this pseudo-hold ``winning_handler.priority``.
+    A REAL hold (manual override at 80, a group lock at 100) never reaches here
+    at all — ``held_position`` is already set — and still beats a 77 slot
+    through the unchanged :func:`outranking` gate, using the winner's own
+    priority exactly as before. But a pseudo-hold is scaffolding: nobody is
+    actually holding the cover, so #463's rule that composition against a
+    *computed* winner is priority-independent applies to it, not
+    :func:`outranking`'s real-hold tie rule. The call site therefore hands it
+    ``PSEUDO_HOLD_HOLDER_PRIORITY`` — a sentinel below every value a user can
+    configure for a slot and below ``DefaultHandler``'s 0 — so any real claim
+    (priority ≥ 1) always outranks it. Against a **FIXED custom-position slot**
+    winning at the default 77, a second slot's opted-in bound at that same 77
+    now outranks the pseudo-hold and binds, instead of being filed as
+    ``yielded_to_hold`` against a holder that isn't holding anything (#1231).
 
-    That is today's behaviour and it is pinned by
+    This resolves what used to be an open design question here, pinned by
     ``tests/test_pipeline/test_outside_window_constraints.py``
-    ``::test_pseudo_hold_ties_are_judged_against_the_winners_own_priority``.
-    Whether it is the RIGHT behaviour is a separate question left open: the
-    pseudo-hold is scaffolding, nobody is holding the cover, and #463's rule for
-    a computed winner is that composition is priority-independent — which argues
-    for handing this call site a below-everything holder priority rather than
-    the winner's own. That is a design change, so it is not made here.
+    ``::test_pseudo_hold_never_yields_to_a_tied_bound_priority``: a bound tied
+    with the winner still outranks the pseudo-hold, because nothing is
+    actually holding the cover.
 
     ``held_position`` is stripped back off before the result is returned: it is
     a user-facing field (the Target Position sensor, the Model B stash replay in
@@ -959,8 +958,22 @@ class PipelineRegistry:
         # unless the winner is holding a physical position, in which case a
         # bound must outrank the holder (#1170). Consumed by both axes; the
         # FIXED tilt overlay below deliberately reads the unfiltered list.
+        #
+        # A pseudo-hold is scaffolding, not a real hold — nothing is actually
+        # holding the cover, so #463's rule that composition against a
+        # computed winner is priority-independent applies to it, not
+        # outranking()'s real-hold tie rule. Handing it the winner's own
+        # priority let a same-priority opt-in bound lose to a "holder" that
+        # wasn't holding anything (#1231); the below-everything sentinel
+        # restores the priority-independent rule for this synthetic case
+        # while leaving every REAL hold's holder priority untouched.
+        holder_priority = (
+            PSEUDO_HOLD_HOLDER_PRIORITY
+            if outside_window_active
+            else winning_handler.priority
+        )
         bound_constraints, yielded_to_hold = _split_bounds_against_hold(
-            constraints, winner, winning_handler.priority
+            constraints, winner, holder_priority
         )
 
         # --- Position axis: bounded kinds ---

--- a/tests/test_pipeline/test_outside_window_constraints.py
+++ b/tests/test_pipeline/test_outside_window_constraints.py
@@ -27,6 +27,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_INTERP,
     CONF_INVERSE_STATE,
     CUSTOM_POSITION_SAFETY_PRIORITY,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
     AxisConstraintMode,
     ControlMethod,
     ReasonCode,
@@ -619,36 +620,75 @@ def test_admission_withheld_without_position_reads():
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    ("bound_priority", "expect_admitted"),
-    [
-        # Equal priorities: ``outranking`` is strictly-greater, so the bound
-        # loses to a holder that is not actually holding anything.
-        (77, False),
-        # One point above the winner and it binds.
-        (78, True),
-    ],
-)
-def test_pseudo_hold_ties_are_judged_against_the_winners_own_priority(
-    bound_priority, expect_admitted
-):
-    """The pseudo-hold borrows the WINNER's priority, ties included.
+def test_pseudo_hold_no_longer_yields_to_a_same_priority_bound():
+    """The reporter's exact repro (#1231): both slots at the shipped default.
 
-    Pinning today's behaviour, not endorsing it. ``_as_outside_window_pseudo_hold``
-    leaves ``holder_priority`` at ``winning_handler.priority``, so when a FIXED
+    Leaving both slots at the shipped default priority (77) is a configuration
+    a user reaches with no unusual setup, and the floor must still bind once
+    the clock window closes. ``current_cover_position=40`` sits below the
+    floor of 60, so the floor is a genuine violation that must raise the
+    dispatched position to 60 — a value the fix's holder-priority sentinel has
+    to let survive ``outranking`` for this to happen, since the bound is
+    opted-in at the same priority (77) as the pseudo-held winner.
+    """
+    sensors = [
+        _slot(1, position=30, priority=DEFAULT_CUSTOM_POSITION_PRIORITY),
+        _slot(
+            2,
+            position=60,
+            min_mode=True,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+            outside_window=True,
+        ),
+    ]
+    snap = _snapshot(
+        sensors=sensors,
+        clock_open=False,
+        policy=get_policy("cover_blind"),
+        default_position=100,
+        current_cover_position=40,
+        cover_positions={"cover.a": 40},
+    )
+    registry = PipelineRegistry(
+        [
+            CustomPositionHandler(
+                slot=1, position=30, priority=DEFAULT_CUSTOM_POSITION_PRIORITY
+            ),
+            CustomPositionHandler(
+                slot=2, position=None, priority=DEFAULT_CUSTOM_POSITION_PRIORITY
+            ),
+            DefaultHandler(),
+        ]
+    )
+    result = registry.evaluate(snap)
+
+    assert result.position == 60
+    assert result.position_constraint_applied is True
+    assert result.outside_window_constraint_active is True
+
+
+@pytest.mark.unit
+def test_pseudo_hold_never_yields_to_a_tied_bound_priority():
+    """The pseudo-hold's holder priority is below-everything (#1231).
+
+    ``_as_outside_window_pseudo_hold`` no longer borrows the winner's own
+    priority for the pseudo-hold; the call site hands ``outranking`` a
+    below-everything sentinel instead (``PSEUDO_HOLD_HOLDER_PRIORITY``). A
+    pseudo-hold is scaffolding — nothing is actually holding the cover — so a
+    bound tied with the winner still outranks it: when a FIXED
     Custom Position slot wins outside the window at the default 77, another
-    slot's opted-in bound at that same 77 is filed as ``yielded_to_hold`` and the
-    opt-in does nothing on that configuration — a reachable config, since 77 is
-    the default for every slot. Against ``DefaultHandler`` at 0 (every other test
-    in this file) the gate is inert, which is why nothing else catches it.
-
-    See ``_as_outside_window_pseudo_hold``'s docstring for the open design
-    question this locks the current answer to.
+    slot's opted-in bound at that same 77 now binds rather than being filed
+    as ``yielded_to_hold``.
     """
     sensors = [
         # The FIXED winner: an exact position, so its handler produces a result.
-        _slot(1, position=90, priority=77),
-        _slot(2, position_max=30, priority=bound_priority, outside_window=True),
+        _slot(1, position=90, priority=DEFAULT_CUSTOM_POSITION_PRIORITY),
+        _slot(
+            2,
+            position_max=30,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+            outside_window=True,
+        ),
     ]
     snap = _snapshot(
         sensors=sensors,
@@ -660,29 +700,30 @@ def test_pseudo_hold_ties_are_judged_against_the_winners_own_priority(
     )
     registry = PipelineRegistry(
         [
-            CustomPositionHandler(slot=1, position=90, priority=77),
-            CustomPositionHandler(slot=2, position=None, priority=bound_priority),
+            CustomPositionHandler(
+                slot=1, position=90, priority=DEFAULT_CUSTOM_POSITION_PRIORITY
+            ),
+            CustomPositionHandler(
+                slot=2, position=None, priority=DEFAULT_CUSTOM_POSITION_PRIORITY
+            ),
             DefaultHandler(),
         ]
     )
     result = registry.evaluate(snap)
 
     assert result.control_method is ControlMethod.CUSTOM_POSITION
-    assert result.outside_window_constraint_active is expect_admitted
+    assert result.outside_window_constraint_active is True
     yielded = [
         step
         for step in result.decision_trace
         if step.reason_payload is not None
         and step.reason_payload.code is ReasonCode.REGISTRY_BOUND_YIELDED_TO_HOLD
     ]
-    assert bool(yielded) is not expect_admitted
-    # Either way the FIXED winner's own 90 stays off the wire: a non-safety
-    # result has no licence out here, admitted or not.
+    assert yielded == []
+    # The FIXED winner's own 90 stays off the wire: a non-safety result has no
+    # licence out here, even admitted.
     verdicts = result.hold_clamp_verdicts
-    if expect_admitted:
-        assert verdicts["cover.a"].target == 30
-    else:
-        assert verdicts is None
+    assert verdicts["cover.a"].target == 30
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
The per-slot "Keep constraints active outside time window" opt-in did nothing when another Custom Position slot won the pipeline at the same priority — and 77 is every slot's default, so it was a configuration a user reaches with no unusual setup. The registry handed `_split_bounds_against_hold` the winning handler's own priority even for a *synthetic* pseudo-hold, and `outranking` is strictly-greater, so the opted-in bound yielded to a "holder" that was not holding anything. No warning, no useful trace step.

I fixed the pseudo-hold's holder priority rather than `outranking`'s tie rule. Nothing is actually holding the cover in this situation, so #463's rule that composition against a computed winner is priority-independent is the one that applies. The new `PSEUDO_HOLD_HOLDER_PRIORITY` sentinel sits below every configurable slot priority and below `DefaultHandler`'s 0, so every real claim outranks it. Loosening `outranking` instead would have reached manual override, group lock and the whole hold-clamp surface, where a tie genuinely should favour the incumbent.

The test that pinned the old behaviour is deliberately rewritten to state the new rule, and `_as_outside_window_pseudo_hold`'s docstring now records the decision instead of the open question.

## Testing
- ✅ 15127 tests passing
- New test reproduces the report's exact two-slots-at-77 configuration; it failed pre-fix with `assert 30 == 60`
- Floor-composition and hold-clamp regression guards all green, including the two tests proving a REAL hold's behaviour is unchanged

## Related Issues
Refs #1231

Follow-up to the feature that shipped in PR #1229 (not itself changed here).