### PR TITLE
fix: key rail-interlock corrections by pair, not follower (#1156)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -948,12 +948,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._custom_position_hold_unsub: Callable[[], None] | None = None
         self._sun_tracking_gate_unsub: Callable[[], None] | None = None
 
-        # Issue #1138: in-flight external-command interlock corrections, keyed
-        # by the entity whose command is being re-issued. One per follower —
-        # a fresh plan for the same follower supersedes (cancels) the previous
-        # correction rather than racing it. Entry-scoped tasks, cancelled on
-        # shutdown so nothing is left pending after an unload.
-        self._external_interlock_tasks: dict[str, asyncio.Task] = {}
+        # Issue #1138 (re-keyed for #1156 / #1144 item 2): in-flight
+        # external-command interlock corrections, keyed by the UNORDERED PAIR
+        # of entities the correction moves — not by whichever one's command is
+        # being re-issued. One per pair — a fresh plan touching either rail of
+        # an already-in-flight pair supersedes (cancels) the previous
+        # correction rather than racing it, whether the two commands named the
+        # same entity or opposite ends of the same pair. Entry-scoped tasks,
+        # cancelled on shutdown so nothing is left pending after an unload.
+        self._external_interlock_tasks: dict[frozenset[str], asyncio.Task] = {}
 
     def _make_detector_config(self, options) -> DetectorConfig:
         """Build the manual-override DetectorConfig from raw options.
@@ -1393,6 +1396,49 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     entity_id, int(my_position_value)
                 )
 
+    @staticmethod
+    def _interlock_pair_key(plan: ExternalInterlockPlan) -> frozenset[str]:
+        """Return the unordered pair of entities a correction moves (#1156 / #1144).
+
+        Derived entirely from the plan the policy already produced — no
+        cover-type knowledge, no "these are rails" — so both writers of
+        ``_external_interlock_tasks`` (and its shutdown drain) can key on the
+        pair without the coordinator learning anything cover-type-specific.
+        """
+        return frozenset({plan.leading_entity_id, plan.follower_entity_id})
+
+    def _start_interlock_task(
+        self, plan: ExternalInterlockPlan, **kwargs: Any
+    ) -> asyncio.Task:
+        """Register a correction, superseding whatever still holds this pair.
+
+        Single source of truth for the cancel-prior / register / name-the-task
+        policy (CODING_GUIDELINES.md § No Code Duplication): the external
+        listener (:meth:`_plan_external_interlock`, fire-and-forget) and the
+        user seam (:meth:`_interlock_user_command`, which awaits the returned
+        task so it can hand back the correction's own outcome) both delegate
+        here instead of each keeping its own copy of the block.
+
+        Keyed by :meth:`_interlock_pair_key`, not by ``plan.follower_entity_id``
+        alone — a command naming either end of an already-in-flight pair must
+        supersede the correction in progress, not just a second command naming
+        the same entity (#1156, subsuming #1144 item 2). ``**kwargs`` forwards
+        ``stop_follower`` / ``mark_override`` straight through to
+        :meth:`_execute_external_interlock` so a caller's distinguishing
+        arguments are never dropped by this shared seam.
+        """
+        key = self._interlock_pair_key(plan)
+        prior = self._external_interlock_tasks.get(key)
+        if prior is not None and not prior.done():
+            prior.cancel()
+        task = self.config_entry.async_create_task(
+            self.hass,
+            self._execute_external_interlock(plan, **kwargs),
+            name=f"acp_rail_interlock_{plan.follower_entity_id}",
+        )
+        self._external_interlock_tasks[key] = task
+        return task
+
     def _plan_external_interlock(
         self,
         event: Event,
@@ -1445,21 +1491,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             if plan is None:
                 continue
-            # Last writer wins, keyed by the entity whose command is being
-            # re-issued: a second genuine external command on the same pair
-            # supersedes the correction still in flight for the first rather
-            # than racing it. Entry-scoped so an unload cancels whatever is
-            # still running instead of leaking a pending task.
-            prior = self._external_interlock_tasks.get(plan.follower_entity_id)
-            if prior is not None and not prior.done():
-                prior.cancel()
-            self._external_interlock_tasks[plan.follower_entity_id] = (
-                self.config_entry.async_create_task(
-                    self.hass,
-                    self._execute_external_interlock(plan),
-                    name=f"acp_external_interlock_{plan.follower_entity_id}",
-                )
-            )
+            # Last writer wins, keyed by the pair: a second genuine external
+            # command touching either rail of this pair supersedes the
+            # correction still in flight rather than racing it. Fire-and-forget
+            # — the listener call stack must not block on a rail-clearance
+            # wait — so the task is dropped, not awaited.
+            self._start_interlock_task(plan)
 
     async def _execute_external_interlock(
         self,
@@ -4760,8 +4797,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         governs whether an EXTERNAL touch takes ownership and has no authority
         over ACP's own seams.
 
-        Returns the follower's dispatch outcome when the correction ran, or
-        ``None`` when the caller should dispatch normally.
+        **Registered, not awaited inline (#1156).** The correction runs through
+        :meth:`_start_interlock_task`, the same pair-keyed registry the
+        external listener uses — keyed by the two entities the correction
+        moves, not by whichever one's command is being re-issued, so a second
+        overlapping user command on EITHER rail of this pair, or a genuine
+        external command on either rail, supersedes this correction instead of
+        racing it. Awaiting the registered task rather than the inline
+        coroutine directly means a supersede can surface here as
+        ``asyncio.CancelledError``, which is translated to
+        ``("skipped", "interlock_superseded")`` — except when the cancellation
+        came from OUTSIDE (an entry unload, HA shutdown cancelling this very
+        service-call task), which must propagate untouched rather than read as
+        an ordinary skip.
+
+        Returns the follower's dispatch outcome when the correction ran,
+        ``("skipped", "interlock_superseded")`` when a later plan superseded it
+        first, or ``None`` when the caller should dispatch normally.
         """
         if self._cmd_svc.is_entity_unavailable(entity_id):
             return None
@@ -4776,11 +4828,31 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Nothing has reached the motor, so there is no refused-command latch to
         # clear and the follower must NOT be stopped: on an open/close-only
         # cover a stop-while-stationary is the hardware's "go to My" gesture.
-        return await self._execute_external_interlock(
+        # Registered through the SAME pair-keyed seam the external listener
+        # uses (#1156) rather than awaited inline, so a second overlapping
+        # user command — or an external command on either rail of this pair —
+        # supersedes this correction instead of racing it.
+        task = self._start_interlock_task(
             replace(plan, reason=MANUAL_INTERLOCK_REASON),
             stop_follower=False,
             mark_override=not force,
         )
+        try:
+            return await task
+        except asyncio.CancelledError:
+            # ``task.cancelled()`` is true both when a LATER plan superseded
+            # this one (the ordinary case: translate to a normal skip so the
+            # user's own command still returns one honest outcome) and when
+            # THIS service-call task was itself cancelled from outside — an
+            # entry unload or HA shutdown. ``current_task().cancelling()`` is
+            # non-zero only in the second case, and that one must propagate:
+            # swallowing it would make a torn-down integration look like an
+            # ordinary supersede instead. ``Task.cancelling()`` is 3.11+,
+            # which the project already requires.
+            current = asyncio.current_task()
+            if task.cancelled() and (current is None or not current.cancelling()):
+                return "skipped", "interlock_superseded"
+            raise
 
     async def async_apply_user_tilt(
         self,

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -9,6 +9,7 @@ pytest-homeassistant-custom-component.
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 from collections.abc import Mapping
 from typing import Any
@@ -350,6 +351,33 @@ def make_mock_policy(**attrs: Any) -> MagicMock:
     return policy
 
 
+def wire_entry_task_factory(coord: Any) -> Any:
+    """Point ``coord.config_entry.async_create_task`` at a real asyncio task.
+
+    A bare ``MagicMock`` coordinator leaves ``config_entry.async_create_task``
+    as an auto-mocked callable that returns a non-awaitable ``MagicMock``. That
+    is harmless for a fire-and-forget caller, but the user-seam interlock
+    (issue #1156) awaits the task it registers so it can return the
+    correction's own outcome — awaiting a bare ``MagicMock`` raises
+    ``TypeError``. Real HA schedules the coroutine on the entry via
+    ``ConfigEntry.async_create_task(hass, coro, name=...)``; this stand-in
+    schedules it on the running loop instead, ignoring the ``hass`` positional
+    and the ``name`` kwarg, which is exactly the part production code needs
+    from it here.
+
+    One definition, several callers (`_coord` in
+    ``tests/test_manual_command_interlock.py``, ``_user_seam_coordinator`` in
+    ``tests/test_day_night_rail_sequencing.py``, and ``bind_user_position_seam``
+    below) — see CODING_GUIDELINES.md § No Code Duplication.
+    """
+    coord.config_entry.async_create_task = MagicMock(
+        side_effect=lambda _hass, coro, name=None: (  # noqa: ARG005
+            asyncio.get_running_loop().create_task(coro)
+        )
+    )
+    return coord
+
+
 def bind_user_position_seam(coord: Any, *, interlock_plan: Any = None) -> Any:
     """Bind ``async_apply_user_position`` and the siblings it calls onto ``coord``.
 
@@ -374,14 +402,26 @@ def bind_user_position_seam(coord: Any, *, interlock_plan: Any = None) -> Any:
         AdaptiveDataUpdateCoordinator,
     )
 
+    wire_entry_task_factory(coord)
+    if not isinstance(getattr(coord, "_external_interlock_tasks", None), dict):
+        coord._external_interlock_tasks = {}  # noqa: SLF001
     for name in (
         "async_apply_user_position",
         "_interlock_user_command",
         "_execute_external_interlock",
+        "_start_interlock_task",
     ):
         setattr(
             coord, name, getattr(AdaptiveDataUpdateCoordinator, name).__get__(coord)
         )
+    # ``_interlock_pair_key`` is a ``staticmethod`` — binding it through
+    # ``.__get__(coord)`` like the instance methods above would turn it into a
+    # bound method that implicitly passes ``coord`` as the first (and only)
+    # positional argument, shadowing the real ``plan`` argument. A direct
+    # attribute assignment leaves it a plain one-argument callable.
+    coord._interlock_pair_key = (
+        AdaptiveDataUpdateCoordinator._interlock_pair_key
+    )  # noqa: SLF001
 
     # An unset `_resolved_options` is a bare MagicMock, and the seam reads
     # options through it. That is not an inert default: `MagicMock.get(...)`

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -70,6 +70,7 @@ from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
     DayNightShadePolicy,
 )
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from tests.ha_helpers import wire_entry_task_factory
 
 _BOTTOM = "cover.bottom_rail"
 _MIDDLE = "cover.middle_rail"
@@ -1389,6 +1390,8 @@ def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch, floors=())
     coord._build_position_context = lambda _entity, _options, **_kw: _rail_context(
         policy
     )  # noqa: ARG005
+    coord._external_interlock_tasks = {}
+    wire_entry_task_factory(coord)
     for name in (
         "_entity_target",
         "_to_cover_frame",
@@ -1402,12 +1405,18 @@ def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch, floors=())
         # REAL Model C policy, so the correction it plans is the production one.
         "_interlock_user_command",
         "_execute_external_interlock",
+        "_start_interlock_task",
     ):
         setattr(
             coord,
             name,
             types.MethodType(getattr(AdaptiveDataUpdateCoordinator, name), coord),
         )
+    # ``_interlock_pair_key`` is a ``staticmethod``: binding it like the
+    # instance methods above would pass ``coord`` as an implicit first
+    # argument, shadowing the real ``plan`` argument. A direct attribute
+    # assignment keeps it a plain one-argument callable.
+    coord._interlock_pair_key = AdaptiveDataUpdateCoordinator._interlock_pair_key
     monkeypatch.setattr(
         coordinator_module, "gather_active_floors", lambda _s: list(floors)
     )
@@ -3880,12 +3889,21 @@ def _interlock_coordinator(cmd_svc, policy):
             policy=policy,
         )
     )
-    for name in ("_plan_external_interlock", "_execute_external_interlock"):
+    for name in (
+        "_plan_external_interlock",
+        "_execute_external_interlock",
+        "_start_interlock_task",
+    ):
         setattr(
             coord,
             name,
             types.MethodType(getattr(AdaptiveDataUpdateCoordinator, name), coord),
         )
+    # ``_interlock_pair_key`` is a ``staticmethod``: binding it like the
+    # instance methods above would pass ``coord`` as an implicit first
+    # argument, shadowing the real ``plan`` argument. A direct attribute
+    # assignment keeps it a plain one-argument callable.
+    coord._interlock_pair_key = AdaptiveDataUpdateCoordinator._interlock_pair_key
     return coord, spawned
 
 

--- a/tests/test_external_command_interlock.py
+++ b/tests/test_external_command_interlock.py
@@ -410,10 +410,20 @@ def _listener_coordinator(*, plan=None, acp_contexts: set[str] | None = None):
     coordinator = MagicMock()
     # The listener's position branch is a real method, bound onto the duck-typed
     # self the way the rail-sequencing suite binds ``_entity_target``. Left as an
-    # auto-mock it would swallow the very dispatch under test.
+    # auto-mock it would swallow the very dispatch under test. ``_start_interlock_task``
+    # has to be real too — it holds the cancel-prior/register block
+    # ``_plan_external_interlock`` now delegates to (#1156).
     coordinator._plan_external_interlock = types.MethodType(
         AdaptiveDataUpdateCoordinator._plan_external_interlock, coordinator
     )
+    coordinator._start_interlock_task = types.MethodType(
+        AdaptiveDataUpdateCoordinator._start_interlock_task, coordinator
+    )
+    # ``_interlock_pair_key`` is a ``staticmethod``: binding it the way the
+    # instance methods above are bound would pass ``coordinator`` as an
+    # implicit first argument, shadowing the real ``plan`` argument. A direct
+    # attribute assignment keeps it a plain one-argument callable.
+    coordinator._interlock_pair_key = AdaptiveDataUpdateCoordinator._interlock_pair_key
     coordinator.entities = [_BOTTOM, _MIDDLE]
     coordinator.logger = MagicMock()
     coordinator._policy = MagicMock()
@@ -424,9 +434,19 @@ def _listener_coordinator(*, plan=None, acp_contexts: set[str] | None = None):
     )
     coordinator._external_interlock_tasks = {}
     coordinator.config_entry = MagicMock()
-    coordinator.config_entry.async_create_task = MagicMock(
-        side_effect=lambda *_a, **_kw: MagicMock()
-    )
+
+    def _spawn_task(*_a, **_kw):
+        # A fresh mock per call — not the shared ``.return_value`` — so two
+        # calls (a supersede) produce two distinct task objects, the way two
+        # real ``asyncio.Task``s would. Also parked onto ``.return_value``
+        # itself, so a test can assert identity against
+        # ``async_create_task.return_value`` right after the call it cares
+        # about, without a mock plumbing detail leaking into the assertion.
+        task = MagicMock()
+        coordinator.config_entry.async_create_task.return_value = task
+        return task
+
+    coordinator.config_entry.async_create_task = MagicMock(side_effect=_spawn_task)
     return coordinator
 
 
@@ -532,35 +552,59 @@ async def test_no_plan_spawns_no_task() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_plan_spawns_an_entry_scoped_task_keyed_by_follower() -> None:
+async def test_a_plan_spawns_an_entry_scoped_task_keyed_by_the_pair() -> None:
     """The corrective sequence runs off the listener so gate waits never block it."""
     coordinator = _listener_coordinator(plan=_plan())
 
     await _listen(coordinator, _position_event("close_cover", _MIDDLE))
 
     coordinator.config_entry.async_create_task.assert_called_once()
-    assert set(coordinator._external_interlock_tasks) == {_MIDDLE}
+    assert set(coordinator._external_interlock_tasks) == {frozenset({_BOTTOM, _MIDDLE})}
     assert (
-        coordinator._external_interlock_tasks[_MIDDLE]
+        coordinator._external_interlock_tasks[frozenset({_BOTTOM, _MIDDLE})]
         is coordinator.config_entry.async_create_task.return_value
-        or coordinator._external_interlock_tasks[_MIDDLE] is not None
     )
 
 
 @pytest.mark.asyncio
-async def test_second_plan_cancels_prior_task_for_same_follower() -> None:
+async def test_second_plan_cancels_prior_task_for_the_same_pair() -> None:
     """Last writer wins: two genuine commands in a row must not race each other."""
     coordinator = _listener_coordinator(plan=_plan())
 
     await _listen(coordinator, _position_event("close_cover", _MIDDLE))
-    first = coordinator._external_interlock_tasks[_MIDDLE]
+    first = coordinator._external_interlock_tasks[frozenset({_BOTTOM, _MIDDLE})]
     first.done.return_value = False
 
     await _listen(coordinator, _position_event("open_cover", _MIDDLE))
-    second = coordinator._external_interlock_tasks[_MIDDLE]
+    second = coordinator._external_interlock_tasks[frozenset({_BOTTOM, _MIDDLE})]
 
     first.cancel.assert_called_once()
     assert second is not first
+
+
+@pytest.mark.asyncio
+async def test_a_correction_on_either_rail_supersedes_the_other() -> None:
+    """The registry keys on the PAIR, not the follower (#1144 item 2 / #1156).
+
+    A command aimed at the middle rail and a command aimed at the bottom rail
+    plan two DIFFERENT follower entities, but they correct the SAME two
+    physical rails. Follower-only keying let both corrections live at once —
+    the registry has to supersede across the pair regardless of which rail's
+    command named the follower.
+    """
+    coordinator = _listener_coordinator(plan=_plan(follower=_MIDDLE, leader=_BOTTOM))
+
+    await _listen(coordinator, _position_event("close_cover", _MIDDLE))
+    first = next(iter(coordinator._external_interlock_tasks.values()))
+    first.done.return_value = False
+
+    coordinator._policy.plan_external_command_interlock.return_value = _plan(
+        follower=_BOTTOM, leader=_MIDDLE
+    )
+    await _listen(coordinator, _position_event("open_cover", _BOTTOM))
+
+    first.cancel.assert_called_once()
+    assert set(coordinator._external_interlock_tasks) == {frozenset({_BOTTOM, _MIDDLE})}
 
 
 @pytest.mark.asyncio
@@ -569,7 +613,7 @@ async def test_a_finished_prior_task_is_not_cancelled() -> None:
     coordinator = _listener_coordinator(plan=_plan())
 
     await _listen(coordinator, _position_event("close_cover", _MIDDLE))
-    first = coordinator._external_interlock_tasks[_MIDDLE]
+    first = coordinator._external_interlock_tasks[frozenset({_BOTTOM, _MIDDLE})]
     first.done.return_value = True
 
     await _listen(coordinator, _position_event("open_cover", _MIDDLE))

--- a/tests/test_manual_command_interlock.py
+++ b/tests/test_manual_command_interlock.py
@@ -33,6 +33,7 @@ the case the observation-based signals cannot serve.
 
 from __future__ import annotations
 
+import asyncio
 import types
 from unittest.mock import AsyncMock, MagicMock
 
@@ -43,6 +44,7 @@ from custom_components.adaptive_cover_pro.const import MANUAL_INTERLOCK_REASON
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
+from tests.ha_helpers import wire_entry_task_factory
 from tests.test_day_night_rail_sequencing import (
     _BOTTOM,
     _MIDDLE,
@@ -83,12 +85,24 @@ def _coord(cmd_svc, policy, ctx, *, dry_run=False, unavailable=()):
     coord._event_buffer = MagicMock()
     coord._build_position_context = lambda _e, _o, **_kw: ctx  # noqa: ARG005
     cmd_svc.is_entity_unavailable = lambda eid: eid in unavailable
-    for name in ("_interlock_user_command", "_execute_external_interlock"):
+    coord._external_interlock_tasks = {}
+    wire_entry_task_factory(coord)
+    for name in (
+        "_interlock_user_command",
+        "_execute_external_interlock",
+        "_start_interlock_task",
+    ):
         setattr(
             coord,
             name,
             types.MethodType(getattr(AdaptiveDataUpdateCoordinator, name), coord),
         )
+    # ``_interlock_pair_key`` is a ``staticmethod``: binding it like the
+    # instance methods above (``.__get__``-style, via ``types.MethodType``)
+    # would pass ``coord`` as an implicit first argument, shadowing the real
+    # ``plan`` argument. A direct attribute assignment keeps it a plain
+    # one-argument callable.
+    coord._interlock_pair_key = AdaptiveDataUpdateCoordinator._interlock_pair_key
     return coord
 
 
@@ -454,6 +468,93 @@ async def test_the_user_seam_returns_the_corrections_own_outcome(monkeypatch) ->
     assert outcome == ("sent", "set_cover_position")
     # Exactly one command each — the correction's, not one from each path.
     assert _sends(events) == [f"send:{_BOTTOM}", f"send:{_MIDDLE}"]
+
+
+@pytest.mark.asyncio
+async def test_a_second_user_command_supersedes_the_correction_still_in_flight(
+    monkeypatch,
+) -> None:
+    """Two drags on the same rail must not race two live corrections (#1156).
+
+    Before the pair-keyed registry, the user seam awaited its correction
+    inline and registered nothing, so a second overlapping drag ran its own
+    independent correction: two brackets open on the same rail pair, and the
+    stale first drag's target could still land on the motor. Registering the
+    task the same way the external path does lets the second drag cancel the
+    first's still-in-flight correction outright, so exactly one bracket is
+    ever open and only the live drag's target is ever dispatched.
+    """
+    cmd_svc, policy, _rails, events = _harness(
+        monkeypatch, script={_BOTTOM: [100] * 6 + [70], _MIDDLE: [100]}, position=40
+    )
+    coord = _user_seam_coordinator(
+        cmd_svc, policy, entities=[_BOTTOM, _MIDDLE], monkeypatch=monkeypatch
+    )
+    coord.manual_ignore_external = False
+    coord._event_buffer = MagicMock()
+    cmd_svc.is_entity_unavailable = lambda _eid: False
+
+    with _patch_caps():
+        first, second = await asyncio.gather(
+            coord.async_apply_user_position(_MIDDLE, 40, trigger="set_axes"),
+            coord.async_apply_user_position(_MIDDLE, 70, trigger="set_axes"),
+        )
+
+    assert first == ("skipped", "interlock_superseded")
+    assert second == ("sent", "set_cover_position")
+    # Both writes land under the same pair key, so the dict never grows past
+    # one live entry — the second write replaces the first's rather than
+    # adding beside it.
+    assert set(coord._external_interlock_tasks) == {frozenset({_BOTTOM, _MIDDLE})}
+
+
+@pytest.mark.asyncio
+async def test_an_outer_cancellation_is_not_swallowed_as_a_supersede(
+    monkeypatch,
+) -> None:
+    """Entry unload / HA shutdown must not read as an ordinary supersede (#1156).
+
+    ``task.cancelled()`` is true both when a LATER command supersedes this one
+    and when the SERVICE-CALL task itself is cancelled from outside (an entry
+    unload, HA shutdown). Only the first case may return a normal
+    ``("skipped", ...)`` tuple; the second must propagate ``CancelledError``
+    untouched — swallowing it would make an unload look like an ordinary skip
+    instead of a torn-down integration. The discriminator is
+    ``asyncio.current_task().cancelling()``: non-zero only when the awaiting
+    task (this one) was itself asked to cancel.
+    """
+    cmd_svc, policy, _rails, _events = _harness(
+        monkeypatch, script={_BOTTOM: [100] * 4 + [40], _MIDDLE: [100]}, position=40
+    )
+    coord = _user_seam_coordinator(
+        cmd_svc, policy, entities=[_BOTTOM, _MIDDLE], monkeypatch=monkeypatch
+    )
+    coord.manual_ignore_external = False
+    coord._event_buffer = MagicMock()
+    cmd_svc.is_entity_unavailable = lambda _eid: False
+
+    # Hang the FOLLOWER's own re-dispatch in the clearance gate deterministically
+    # — no wall-clock race — while leaving the LEADING rail's gate real, since
+    # the leading rail of any plan is always clear by construction.
+    real_gate = policy.await_dispatch_clearance
+    parked = asyncio.Event()
+
+    async def _gate(entity_id, **kwargs):
+        if entity_id == _MIDDLE:
+            parked.set()
+            await asyncio.sleep(3600)
+        return await real_gate(entity_id, **kwargs)
+
+    policy.await_dispatch_clearance = _gate
+
+    with _patch_caps():
+        outer = asyncio.create_task(
+            coord.async_apply_user_position(_MIDDLE, 40, trigger="set_axes")
+        )
+        await parked.wait()
+        outer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`_interlock_user_command` (the user seam PR #1152 added) awaited `_execute_external_interlock` inline and never registered in `_external_interlock_tasks`, so the supersede/cancel guarantee the external listener has never extended to ACP's own commands. Two overlapping user corrections, or a user correction and an external one, could hold the same Model C rail pair at once.

The cancel-prior/register block is now a single shared `_start_interlock_task` that both writers delegate to, keyed by the unordered pair of entities the correction moves (`_interlock_pair_key`) rather than by the follower alone. Follower keying only caught a second command naming the same entity; the pair key also catches a correction on one rail overlapping one on the other. The user seam awaits the registered task and translates a supersede-cancel into `("skipped", "interlock_superseded")`, re-raising when `current_task().cancelling()` shows the cancellation came from an entry unload or HA shutdown rather than from a later plan.

Re-keying by pair also closes items 2 and 3 of issue #1144 (pair-keyed supersession, and the vacuous `or ... is not None` assertion). Items 1 and 4 of that issue are NOT fixed here and it stays open for them.

Not fixed here: the "a slider drag queues N commands that all flush together" behaviour noted on issue #1151 is a separate condition at the user seam, since a drag the policy does not consider blocked returns no plan and never reaches this registry.

## Testing
- ✅ 15128 tests passing (4 skipped, 1 xfailed); interlock files 141 passed, up from a 138 baseline
- New guards: `test_a_second_user_command_supersedes_the_correction_still_in_flight`, `test_a_correction_on_either_rail_supersedes_the_other`, `test_an_outer_cancellation_is_not_swallowed_as_a_supersede`

## Related Issues
Refs #1156