### PR TITLE
fix: judge position bounds in the logical frame under interpolation (#1230)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2956,11 +2956,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         a shade reading device 0 under a 20–80 curve un-maps to logical 0
         (``np.interp`` clamps to the endpoint), and re-mapping that opens it to
         20. The short-circuit fires there — the target equals the read, because
-        both clamped to the same end — and the cover stays put. It is also what
-        absorbs the one-point round-trip miss a locally EXPANDING multi-point
+        both clamped to the same end — and the cover stays put. It does NOT
+        absorb the one-point round-trip miss a locally EXPANDING multi-point
         curve can produce (``position_utils.from_cover_frame`` states that
-        bound). Every ``interp_start``/``interp_end`` pair contracts, so that
-        case needs a hand-built control-point list to reach. Removing the branch
+        bound): the branch compares a logical target against a device read, so
+        on that curve's expanding leg the two differ and it does not fire —
+        device 11 judges to logical 51 and re-maps to 12. The delta gate is what
+        absorbs that one point, not this branch. Every
+        ``interp_start``/``interp_end`` pair contracts, so the case needs a
+        hand-built control-point list to reach at all. Removing the branch
         as "redundant post-#1230" would put a phantom carriage move back into
         exactly the tilt-only command this whole path exists to keep
         positionally inert (#1170 / #1174).

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2926,39 +2926,43 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     def _verdict_dispatch_target(self, verdict: HoldClampVerdict) -> int:
         """Map ONE per-cover hold verdict onto the wire.
 
-        ``HoldClampVerdict.target`` is not one frame, it is two, and they only
-        coincide while no calibration curve is configured:
+        Every ``HoldClampVerdict.target`` is now a LOGICAL value — either a
+        composed bound edge for a cover a bound moved, or the cover's own read
+        un-mapped back onto the linear scale for one nothing moved. Issue #1230
+        made the second half true: the registry judges through
+        ``position_utils.from_cover_frame``, the full inverse of
+        :meth:`_to_cover_frame`, so what comes back here is on the logical side
+        of the same mapping rather than a raw device number wearing a logical
+        label. :meth:`_to_cover_frame` is therefore the whole mapping for both
+        — which is what issue #469 was about, where skipping the transforms for
+        a floor made "minimum 25 % open" drive an inverse cover to 75 %.
 
-        * **a composed bound edge**, for a cover a bound actually moved. That is
-          a user-configured LOGICAL value like any other, so it is calibrated
-          and inverted like any other — issue #469 skipped both transforms for a
-          floor and made "minimum 25 % open" drive an inverse cover to 75 %.
-          :meth:`_to_cover_frame` is the whole mapping and stays the whole
-          mapping.
-        * **this cover's own read**, for one nothing moved — which is what makes
-          a command forced by the TILT axis a positional no-op the same-position
-          gate turns into a pure secondary-axis call (#1170 / #1174). That value
-          entered the pipeline as a RAW device-frame number and had exactly one
-          transform applied to it, ``flip_if`` (the #1036 conversion). It owes
-          exactly that one back. Running it through the calibration curve as
-          well re-maps a position nobody asked to change: on a 20–80 curve a
-          shade sitting at 80 was commanded to 68.
+        **The ``own_read`` short-circuit below is REDUNDANT for a read inside
+        the calibrated travel, and load-bearing for one outside it.** Keep it.
+        Inside the travel the un-mapping is exact — the inverse of a contraction
+        curve expands, so rounding the logical value moves the re-mapped device
+        value by less than half a point — and ``_to_cover_frame(target)``
+        returns the read the branch would have returned anyway. Outside it there
+        is nothing to be exact about: a shade reading device 0 under a 20–80
+        curve un-maps to logical 0 (``np.interp`` clamps to the endpoint), and
+        re-mapping that opens it to 20. The short-circuit fires there — the
+        target equals the read, because both clamped to the same end — and the
+        cover stays put. Removing the branch as "redundant post-#1230" would put
+        a phantom carriage move back into exactly the tilt-only command this
+        whole path exists to keep positionally inert (#1170 / #1174).
 
-        The verdict itself says which case this is, and says it in the frame the
-        comparison has to happen in: the target equals the cover's own logical
-        read precisely when no bound moved it — the same ``fin != eff`` the
-        registry evaluated to set ``released``, before
+        The equality test is also what tells the two cases apart, and it says it
+        in the frame the comparison has to happen in: the target equals the
+        cover's own logical read precisely when no bound moved it — the same
+        ``fin != eff`` the registry evaluated to set ``released``, before
         ``_command_every_held_cover`` overwrote that field so a tilt clamp could
         command the whole group. Where a bound edge lands exactly on the cover's
-        own read the test cannot tell the two cases apart — and does not need
-        to: the equality itself proves the clamp moved this cover nowhere, so
-        the read IS the right answer and taking the first branch is correct.
-        The two branches do NOT agree there under interpolation (``own_read``
-        versus ``interpolate(own_read)``), which is precisely why the tie must
-        fall this way rather than the other.
+        own read the test cannot tell the two apart — and does not need to: the
+        equality itself proves the clamp moved this cover nowhere.
 
-        Uncalibrated installs are unaffected: ``_to_cover_frame`` reduces to the
-        same ``flip_if``, so both branches return the same number.
+        Uncalibrated installs are unaffected: ``_to_cover_frame`` and
+        ``from_cover_frame`` both reduce to the same ``flip_if``, so both
+        branches return the same number.
         """
         own_read = verdict.held_position
         if own_read is not None and verdict.target == flip_if(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -384,6 +384,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._climate_mode = self.config_entry.options.get(CONF_CLIMATE_MODE, False)
         self._inverse_state = self.config_entry.options.get(CONF_INVERSE_STATE, False)
         self._inverse_tilt = self.config_entry.options.get(CONF_INVERSE_TILT, False)
+        # Read once and never refreshed — unlike start_value/end_value/
+        # normal_list/new_list, which _update_options re-reads every cycle. Safe
+        # only because CONF_INTERP is not in _RUNTIME_APPLICABLE_OPTIONS, so
+        # changing it reloads the config entry and re-runs this __init__. That
+        # matters more since #1230: PipelineSnapshotBuilder reads CONF_INTERP
+        # fresh out of options on every build, and a stale flag here would have
+        # the judge un-map a read that _to_cover_frame then declines to re-map.
+        # Pinned by test_snapshot_builder.py::
+        # test_toggling_interpolation_reloads_rather_than_patching_a_live_coordinator.
         self._use_interpolation = self.config_entry.options.get(CONF_INTERP, False)
         self._track_end_time = self.config_entry.options.get(CONF_RETURN_SUNSET)
         # Toggle state manager (switch entities delegate here)
@@ -2938,18 +2947,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         a floor made "minimum 25 % open" drive an inverse cover to 75 %.
 
         **The ``own_read`` short-circuit below is REDUNDANT for a read inside
-        the calibrated travel, and load-bearing for one outside it.** Keep it.
-        Inside the travel the un-mapping is exact — the inverse of a contraction
-        curve expands, so rounding the logical value moves the re-mapped device
-        value by less than half a point — and ``_to_cover_frame(target)``
-        returns the read the branch would have returned anyway. Outside it there
-        is nothing to be exact about: a shade reading device 0 under a 20–80
-        curve un-maps to logical 0 (``np.interp`` clamps to the endpoint), and
-        re-mapping that opens it to 20. The short-circuit fires there — the
-        target equals the read, because both clamped to the same end — and the
-        cover stays put. Removing the branch as "redundant post-#1230" would put
-        a phantom carriage move back into exactly the tilt-only command this
-        whole path exists to keep positionally inert (#1170 / #1174).
+        the calibrated travel of a contracting curve, and load-bearing
+        everywhere else.** Keep it. Inside such a travel the un-mapping is exact
+        — the inverse of a contraction expands, so rounding the logical value
+        moves the re-mapped device value by less than half a point — and
+        ``_to_cover_frame(target)`` returns the read the branch would have
+        returned anyway. Outside the travel there is nothing to be exact about:
+        a shade reading device 0 under a 20–80 curve un-maps to logical 0
+        (``np.interp`` clamps to the endpoint), and re-mapping that opens it to
+        20. The short-circuit fires there — the target equals the read, because
+        both clamped to the same end — and the cover stays put. It is also what
+        absorbs the one-point round-trip miss a locally EXPANDING multi-point
+        curve can produce (``position_utils.from_cover_frame`` states that
+        bound). Every ``interp_start``/``interp_end`` pair contracts, so that
+        case needs a hand-built control-point list to reach. Removing the branch
+        as "redundant post-#1230" would put a phantom carriage move back into
+        exactly the tilt-only command this whole path exists to keep
+        positionally inert (#1170 / #1174).
 
         The equality test is also what tells the two cases apart, and it says it
         in the frame the comparison has to happen in: the target equals the

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from ..const import AxisConstraintMode, ReasonCode
 from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
 from ..diagnostics.event_buffer import EventBuffer
-from ..position_utils import flip_if
+from ..position_utils import from_cover_frame
 from ..reason_i18n import Reason, render_en
 from .axis_constraints import (
     bound_label,
@@ -278,13 +278,23 @@ def _judge_position_axis(
 
     **Frames.** Held positions are RAW cover-frame reads and the bounds are
     logical user values, so each is converted before comparing — the #1036
-    conversion, now applied per cover instead of once to the mean. A policy's
-    reference arrives ALREADY LOGICAL: the reduction is the inverse of the whole
-    dispatch chain, wire decoding included, so the policy un-flips and decodes
-    it itself and this function must not flip it a second time. Every ``target``
-    is on the logical side of that conversion, matching
-    ``PipelineResult.position``, so the coordinator maps it to the wire through
-    the same ``_to_cover_frame`` seam it already uses for the shared value.
+    conversion, applied per cover instead of once to the mean since #1174. That
+    conversion is ``position_utils.from_cover_frame``, the FULL inverse of
+    ``coordinator._to_cover_frame``: inversion undone *and* the calibration
+    curve un-mapped. Inversion alone was not the whole map, and because
+    ``axis_inverted`` suppresses inversion on an interpolated axis it was not
+    even part of it — on a calibrated install the old ``flip_if`` was the
+    identity and a device read was compared straight against a logical bound
+    (#1230). A policy's reference arrives ALREADY LOGICAL: the reduction is the
+    inverse of the whole dispatch chain, wire decoding included, so the policy
+    un-flips and decodes it itself and this function must not convert it a
+    second time — and that exemption covers the curve leg too, deliberately.
+    ``CoverTypePolicy.hold_reference_position`` states that it does not unwind
+    interpolation and reserves that to #925; running the reference through this
+    conversion would un-map a value that was never mapped. Every ``target`` is
+    on the logical side of the conversion, matching ``PipelineResult.position``,
+    so the coordinator maps it to the wire through the same ``_to_cover_frame``
+    seam it already uses for the shared value.
 
     For a hold, ``effective_winner_pos`` names the *violating* cover — the
     lowest judged position when a floor raised, the highest when a ceiling
@@ -318,7 +328,8 @@ def _judge_position_axis(
     entries: list[tuple[str | None, int | None, int]]
     if per_entity is None and reference is not None:
         # Already LOGICAL — the policy un-flipped and decoded it itself, so the
-        # #1036 conversion below must NOT run a second time on this value.
+        # conversion below must NOT run a second time on this value. Both legs
+        # of it: the #1036 inversion and #1230's curve un-mapping.
         entries = [(None, None, reference)]
     else:
         # #1174's per-entity set, or the legacy single pseudo-entry on the mean.
@@ -330,7 +341,15 @@ def _judge_position_axis(
         for entity_id, position in judged.items():
             raw = position if position is not None else winner.held_position
             entries.append(
-                (entity_id, raw, flip_if(raw, inverted=snapshot.position_axis_inverted))
+                (
+                    entity_id,
+                    raw,
+                    from_cover_frame(
+                        raw,
+                        inverted=snapshot.position_axis_inverted,
+                        curve=snapshot.interp_curve,
+                    ),
+                )
             )
     verdicts: dict[str, HoldClampVerdict] = {}
     effective_positions: list[int] = []
@@ -363,7 +382,11 @@ def _judge_position_axis(
         effective_winner_pos = (
             reference
             if reference is not None
-            else flip_if(winner.held_position, inverted=snapshot.position_axis_inverted)
+            else from_cover_frame(
+                winner.held_position,
+                inverted=snapshot.position_axis_inverted,
+                curve=snapshot.interp_curve,
+            )
         )
     return PositionAxisJudgment(
         effective_winner_pos=effective_winner_pos,
@@ -420,6 +443,13 @@ def _release_hold_for_tilt_clamp(
     tilt bound forcing the dispatch while the position axis stayed inert — or
     yielded to the hold (#1170) — would otherwise send that shadow and move a
     cover the user had just placed by hand.
+
+    ``effective_winner_pos`` is where the cover is in the LOGICAL frame, not the
+    device read it was derived from: ``coordinator.state`` maps whatever lands
+    in ``position`` back out through ``_to_cover_frame``, so handing it a raw
+    read means the curve is applied to a value that already carries it. That is
+    the singular-path half of #1230 — on a 20–80 curve a shade held at device 42
+    was commanded to 45 by a tilt-only clamp.
 
     Since #943 item B the "hold" may be a PSEUDO one
     (:func:`_as_outside_window_pseudo_hold`): outside the clock window a

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -54,6 +54,11 @@ from ..const import (
     CONF_SUN_TRACKING_GATE_TEMPLATE,
     CONF_SUN_TRACKING_GATE_TEMPLATE_MODE,
     DEFAULT_CONDITION_GATE_GRACE_SECONDS,
+    CONF_INTERP,
+    CONF_INTERP_END,
+    CONF_INTERP_LIST,
+    CONF_INTERP_LIST_NEW,
+    CONF_INTERP_START,
     CONF_IRRADIANCE_ENTITY,
     CONF_IRRADIANCE_RELEASE_THRESHOLD,
     CONF_IRRADIANCE_THRESHOLD,
@@ -128,6 +133,7 @@ from ..helpers import (
 )
 from ..managers.common.graceful_source import GracefulSource, SourceResolution
 from ..managers.common.condition_gate import ConditionGate
+from ..position_utils import InterpolationCurve
 from ..templates import combine_with_mode, is_template_string, render_condition_or_none
 from .types import (
     ClimateOptions,
@@ -923,6 +929,21 @@ class PipelineSnapshotBuilder:
             current_cover_position=current_cover_position,
             cover_positions=cover_positions,
             position_axis_inverted=axis_inverted(self._policy.axes[0], options),
+            # The calibration curve, carried as data so the pure registry can
+            # un-map a held cover's raw read before judging it against a
+            # logical bound (#1230). Gated on the master enable exactly as
+            # ``coordinator._to_cover_frame`` gates the forward map, so a stray
+            # start/end left behind by a disabled curve arrives as ``None``.
+            interp_curve=(
+                InterpolationCurve(
+                    start_value=options.get(CONF_INTERP_START),
+                    end_value=options.get(CONF_INTERP_END),
+                    normal_list=options.get(CONF_INTERP_LIST),
+                    new_list=options.get(CONF_INTERP_LIST_NEW),
+                )
+                if bool(options.get(CONF_INTERP))
+                else None
+            ),
             policy=self._policy,
             group_intent=group_intent,
             minimize_movements=bool(

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -14,6 +14,7 @@ from ..const import (
     GroupIntentKind,
     GroupScene,
 )
+from ..position_utils import InterpolationCurve
 from ..reason_i18n import Reason, render_en
 
 if TYPE_CHECKING:
@@ -567,7 +568,9 @@ class PipelineSnapshot:
     # manual-override / group-lock holds as a presentation value. It is a
     # *summary*: no per-cover decision consumes it — the registry judges each
     # held cover against its own entry in ``cover_positions`` below (#1174).
-    # This is a RAW cover-frame read — see position_axis_inverted below.
+    # This is a RAW cover-frame read — see position_axis_inverted and
+    # interp_curve below for the two transforms standing between it and the
+    # logical frame every user-facing bound is expressed in.
     current_cover_position: int | None = None
 
     # Per-entity RAW cover-frame positions — the same frame and the same source
@@ -583,10 +586,24 @@ class PipelineSnapshot:
     # (inverse-state configured and not suppressed by interpolation, per
     # ``cover_types.base.axis_inverted``). A handler that puts a raw cover read
     # such as ``current_cover_position`` into ``PipelineResult.position`` must
-    # convert it to the logical frame first (``position_utils.flip_if``),
-    # because ``coordinator.state`` maps every winner through
-    # ``_to_cover_frame`` on the way out — no flag exempts one (#1028 / #1036).
+    # convert it to the logical frame first (``position_utils.from_cover_frame``,
+    # which folds this flag together with ``interp_curve`` below), because
+    # ``coordinator.state`` maps every winner through ``_to_cover_frame`` on the
+    # way out — no flag exempts one (#1028 / #1036 / #1230).
     position_axis_inverted: bool = False
+
+    # This install's position calibration curve, or None when interpolation is
+    # switched off. The other half of the same frame question
+    # ``position_axis_inverted`` answers: ``coordinator._to_cover_frame`` maps a
+    # logical value to the wire by interpolating and THEN inverting, so undoing
+    # it needs both halves and inversion alone is not the whole map (#1230).
+    # Carried as plain data so the pure pipeline can un-map a raw read without
+    # reaching for a coordinator; the registry consumes it via
+    # ``position_utils.from_cover_frame``, the inverse of that whole chain.
+    # ``None`` on a legacy / test snapshot means "no curve", which reduces that
+    # helper to exactly ``flip_if`` and leaves every uncalibrated install
+    # byte-identical.
+    interp_curve: InterpolationCurve | None = None
 
     # The CoverTypePolicy chosen at coordinator startup. Handlers should consult
     # this for cover-type-aware decisions (axis routing, intent → position

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -586,10 +586,19 @@ class PipelineSnapshot:
     # (inverse-state configured and not suppressed by interpolation, per
     # ``cover_types.base.axis_inverted``). A handler that puts a raw cover read
     # such as ``current_cover_position`` into ``PipelineResult.position`` must
-    # convert it to the logical frame first (``position_utils.from_cover_frame``,
-    # which folds this flag together with ``interp_curve`` below), because
-    # ``coordinator.state`` maps every winner through ``_to_cover_frame`` on the
-    # way out — no flag exempts one (#1028 / #1036 / #1230).
+    # convert it to the logical frame first, because ``coordinator.state`` maps
+    # every winner through ``_to_cover_frame`` on the way out — no flag exempts
+    # one (#1028 / #1036).
+    #
+    # The two handlers that do this — ``motion_timeout``'s hold and
+    # ``group_lock``'s freeze — convert with ``position_utils.flip_if``, i.e.
+    # with THIS FLAG ALONE. That is the whole map only while no curve is
+    # configured; under one, ``_to_cover_frame`` re-interpolates the held motor
+    # read and the published target drifts. Pre-existing, unchanged by #1230,
+    # and stated in place at ``motion_timeout.py`` since #1028, which reserves
+    # it to #925. The registry's hold judge is the one caller that takes the
+    # FULL inverse, via ``position_utils.from_cover_frame`` — that helper folds
+    # this flag together with ``interp_curve`` below (#1230).
     position_axis_inverted: bool = False
 
     # This install's position calibration curve, or None when interpolation is

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -66,10 +68,16 @@ def flip_if(value: float, *, inverted: bool) -> float:
       entity and hands it to a logical-frame field.
       ``PipelineResult.position`` is logical for every winner, so a handler
       holding a raw read (``MotionTimeoutHandler``'s hold,
-      ``GroupLockHandler``'s freeze) must convert first, and the registry must
-      convert before comparing a held position against a user-configured bound.
+      ``GroupLockHandler``'s freeze) must convert first.
     * **logical → cover** — a consumer turning a pipeline value into the number
       actually dispatched to, or recorded as held on, the entity.
+
+    Inversion is the whole map only where no calibration curve is configured. A
+    caller undoing the full ``coordinator._to_cover_frame`` chain — the registry
+    comparing a held read against a user-configured bound — wants
+    :func:`from_cover_frame` instead, which composes this with the curve leg
+    (#1230). Reaching for ``flip_if`` there is what made that comparison silently
+    frame-mixed on every calibrated install.
 
     The name is deliberately direction-free: while this helper carried a
     directional name, every caller converting the other way hand-rolled the
@@ -96,6 +104,63 @@ def _proportional_remap(value: int, lo: int, hi: int) -> int:
     return round(lo_eff + (hi_eff - lo_eff) * (v / 100))
 
 
+@dataclass(frozen=True)
+class InterpolationCurve:
+    """One install's position calibration curve, as plain data (issue #1230).
+
+    The four option values ``coordinator._to_cover_frame`` reads
+    (``interp_start`` / ``interp_end``, or the ``interp_list`` /
+    ``interp_list_new`` control-point pair), carried together so the pure
+    pipeline can un-map a device read without holding a coordinator. A grouped
+    multi-field value is a frozen dataclass rather than a tuple
+    (CODING_GUIDELINES § "Prefer Dataclasses Over Multi-Field Tuples"), and
+    ``None`` everywhere — the all-default instance — expresses no curve at all,
+    which is what lets ``PipelineSnapshot.interp_curve`` default to ``None``
+    and leave every uncalibrated install byte-identical.
+    """
+
+    start_value: float | None = None
+    end_value: float | None = None
+    normal_list: Sequence[float] | None = None
+    new_list: Sequence[float] | None = None
+
+
+def _interp_ranges(
+    start_value: float | None,
+    end_value: float | None,
+    normal_list: Sequence[float] | None,
+    new_list: Sequence[float] | None,
+) -> tuple[list, list] | None:
+    """Resolve the ``(normal_range, new_range)`` sample pair a curve expresses.
+
+    The one place the two supported wire shapes — a simple start/end pair and a
+    multi-point control-point list, with the list winning when both are set —
+    become ``np.interp`` sample points. Both the forward map
+    (:func:`interpolate_position`) and its inverse (:func:`from_cover_frame`)
+    delegate here, because they are the same curve read in two directions and
+    a second copy of this precedence would drift (CODING_GUIDELINES §
+    "Single-Source-of-Truth Helpers for Repeated Formulas").
+
+    ``None`` means no curve is configured, and the caller returns its input
+    untouched.
+    """
+    normal_range = [0, 100]
+    new_range: list = []
+    if start_value is not None and end_value is not None:
+        new_range = [start_value, end_value]
+    if normal_list and new_list:
+        normal_range = list(map(int, normal_list))
+        new_range = list(map(int, new_list))
+    if not new_range:
+        return None
+    return normal_range, new_range
+
+
+def _strictly_increasing(values: Sequence[float]) -> bool:
+    """Whether *values* ascends with no repeated or descending step."""
+    return all(b > a for a, b in zip(values, values[1:], strict=False))
+
+
 def interpolate_position(
     state: float,
     start_value: float | None,
@@ -120,16 +185,89 @@ def interpolate_position(
         interpolation configured
 
     """
-    normal_range = [0, 100]
-    new_range: list = []
-    if start_value is not None and end_value is not None:
-        new_range = [start_value, end_value]
-    if normal_list and new_list:
-        normal_range = list(map(int, normal_list))
-        new_range = list(map(int, new_list))
-    if new_range:
-        state = float(np.interp(state, normal_range, new_range))
-    return state
+    ranges = _interp_ranges(start_value, end_value, normal_list, new_list)
+    if ranges is None:
+        return state
+    normal_range, new_range = ranges
+    return float(np.interp(state, normal_range, new_range))
+
+
+def _un_interpolate(value: float, curve: InterpolationCurve) -> float:
+    """Map a calibrated device value back onto the linear 0-100 scale (#1230).
+
+    :func:`interpolate_position` read backwards: the same sample points with
+    the two ranges swapped. ``np.interp`` needs its sample abscissae ascending,
+    so the device range decides what is possible:
+
+    * strictly **increasing** — swap the ranges and interpolate;
+    * strictly **decreasing** — reverse BOTH ranges first, which restores the
+      ascending order without changing the curve (a ``start=80, end=20`` pair
+      and a descending control-point list are the same case, since the pair is
+      just a two-element list by the time it reaches here);
+    * anything else — a flat segment or a fold makes the forward map
+      non-injective, so there is no inverse to compute and the value is
+      returned untouched.
+
+    That last branch is a deliberate degradation, not an oversight. This runs
+    inside the judge on every update cycle in a pure module: raising would
+    brick the update loop for an install whose forward map has "worked" for
+    years, and clamping would invent data. Skipping reproduces exactly the
+    pre-#1230 treatment of that value, so no install gains a new failure mode.
+    Validating a non-monotonic control-point list at config-flow time is a
+    separate question, deliberately out of scope here.
+
+    A read outside the calibrated travel lands on the nearest end —
+    ``np.interp``'s native endpoint behaviour, mirroring the clamping the
+    forward map already does.
+    """
+    ranges = _interp_ranges(
+        curve.start_value, curve.end_value, curve.normal_list, curve.new_list
+    )
+    if ranges is None:
+        return value
+    normal_range, new_range = ranges
+    if _strictly_increasing(new_range):
+        return float(np.interp(value, new_range, normal_range))
+    if _strictly_increasing(new_range[::-1]):
+        return float(np.interp(value, new_range[::-1], normal_range[::-1]))
+    return value
+
+
+def from_cover_frame(
+    value: float,
+    *,
+    inverted: bool,
+    curve: InterpolationCurve | None = None,
+) -> int:
+    """Map a RAW cover-frame read back to the logical frame (issue #1230).
+
+    The full algebraic inverse of ``coordinator._to_cover_frame``, which maps
+    logical → wire as "interpolate, then invert". Undoing that means reversing
+    the order: **un-invert first**, then **un-interpolate**, then round to the
+    ``int`` the forward map also promises.
+
+    The un-inversion is stated for algebraic correctness rather than for any
+    live configuration: ``cover_types.base.axis_inverted`` suppresses position
+    inversion whenever the axis is interpolated, so *inverted* is always
+    ``False`` while a curve is configured — and that suppression is exactly why
+    #1230 was silent. With ``flip_if`` reduced to the identity, the judge was
+    comparing an untouched device number against a logical bound and nothing
+    looked wrong.
+
+    With ``curve=None`` this is ``flip_if`` composed with ``int(round(...))``,
+    which is the identity composition on the integer reads every caller
+    actually holds — that is what keeps an uncalibrated install byte-identical
+    after the registry swapped one call for the other.
+
+    Lives beside :func:`flip_if` and :func:`interpolate_position` in this pure
+    module (0 HA imports) so ``pipeline/registry.py`` can reach it: the curve
+    travels to the pipeline as data on ``PipelineSnapshot.interp_curve``, never
+    as a coordinator handle.
+    """
+    logical = flip_if(value, inverted=inverted)
+    if curve is not None:
+        logical = _un_interpolate(logical, curve)
+    return int(round(logical))
 
 
 class PositionConverter:

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -117,12 +117,31 @@ class InterpolationCurve:
     ``None`` everywhere — the all-default instance — expresses no curve at all,
     which is what lets ``PipelineSnapshot.interp_curve`` default to ``None``
     and leave every uncalibrated install byte-identical.
+
+    The control-point pair is coerced to ``tuple`` on construction, because the
+    caller hands it ``options.get(CONF_INTERP_LIST)`` verbatim — a ``list`` that
+    the config entry still owns. ``frozen=True`` freezes the *binding*, not the
+    object behind it, so without the copy the curve's samples could change under
+    it, and the synthesised ``__hash__`` would raise ``TypeError: unhashable
+    type: 'list'`` the first time anything put a curve in a set or memo dict.
+    Coercing here rather than at the one builder call site makes every
+    construction site safe, test fixtures included, and leaves
+    :func:`interpolate_position` alone — its callers pass the four values
+    straight off the coordinator and never build a curve object, so a coercion
+    on that signature would be a no-op with a wider blast radius.
     """
 
     start_value: float | None = None
     end_value: float | None = None
     normal_list: Sequence[float] | None = None
     new_list: Sequence[float] | None = None
+
+    def __post_init__(self) -> None:
+        """Copy the control-point sequences into tuples (see the class docstring)."""
+        for name in ("normal_list", "new_list"):
+            value = getattr(self, name)
+            if value is not None and not isinstance(value, tuple):
+                object.__setattr__(self, name, tuple(value))
 
 
 def _interp_ranges(
@@ -258,6 +277,21 @@ def from_cover_frame(
     which is the identity composition on the integer reads every caller
     actually holds — that is what keeps an uncalibrated install byte-identical
     after the registry swapped one call for the other.
+
+    **Round-trip bound.** ``interpolate_position(from_cover_frame(d)) == d``
+    holds exactly for a curve every leg of which CONTRACTS — one whose device
+    span is no wider than the logical span it maps from. Every ``start``/``end``
+    pair qualifies (``end - start <= 100`` by construction), which is the shape
+    ``coordinator._verdict_dispatch_target`` reasons about: the inverse of a
+    contraction expands, so the half-point this rounds away re-maps to less than
+    half a point and rounding recovers ``d``. A multi-point control-point list
+    can be locally EXPANSIVE — ``normal_list=[0, 50, 100]`` against
+    ``new_list=[0, 10, 100]`` runs at slope 1.8 on its upper leg — and there the
+    round trip can land one device point off. That is a rounding artefact of an
+    unusual calibration, not a frame error, and it is pinned by
+    ``test_from_cover_frame_round_trip_is_off_by_one_on_an_expanding_curve``
+    rather than corrected here: sub-integer positions are not dispatchable and
+    the delta gate swallows a one-point move.
 
     Lives beside :func:`flip_if` and :func:`interpolate_position` in this pure
     module (0 HA imports) so ``pipeline/registry.py`` can reach it: the curve

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -11,6 +11,7 @@ from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
     PipelineSnapshot,
 )
+from custom_components.adaptive_cover_pro.position_utils import InterpolationCurve
 
 
 def _make_mock_cover(
@@ -96,6 +97,7 @@ def make_snapshot(
     current_cover_position: int | None = None,
     cover_positions: Mapping[str, int | None] | None = None,
     position_axis_inverted: bool = False,
+    interp_curve: InterpolationCurve | None = None,
     default_tilt: int | None = None,
     sunset_tilt: int | None = None,
     min_tilt: int = 0,
@@ -182,6 +184,7 @@ def make_snapshot(
         current_cover_position=current_cover_position,
         cover_positions=cover_positions,
         position_axis_inverted=position_axis_inverted,
+        interp_curve=interp_curve,
         default_tilt=default_tilt,
         sunset_tilt=sunset_tilt,
         min_tilt=min_tilt,

--- a/tests/test_pipeline/test_hold_clamp_interpolated_frame.py
+++ b/tests/test_pipeline/test_hold_clamp_interpolated_frame.py
@@ -1,0 +1,460 @@
+"""A hold is judged on its LOGICAL position, calibration curve unwound (#1230).
+
+``_judge_position_axis`` compares a held cover's read against the user's
+configured floor/ceiling. The read is a RAW device-frame number and the bounds
+are logical user values, so the read is converted first — but until #1230 that
+conversion was ``flip_if`` alone, which knows about ``inverse_state`` and
+nothing about an interpolation calibration curve. Worse, ``axis_inverted``
+*suppresses* inversion whenever the position axis is interpolated
+(``cover_types/base.py``), so on a calibrated install ``flip_if`` is the
+identity and the judge compared the device number directly against a logical
+bound.
+
+The issue's own numbers: on a 20–80 curve a shade reading device 42 is
+logically at 36.67, which violates a 40 % floor — and the judge saw ``42 >= 40``
+and called it compliant. The floor never fired. The fix routes both conversion
+sites through ``position_utils.from_cover_frame``, the full algebraic inverse of
+``coordinator._to_cover_frame``: un-invert, then un-interpolate.
+
+The curve reaches the pure pipeline as plain data on
+``PipelineSnapshot.interp_curve`` — the registry never holds a coordinator.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_INTERP,
+    CONF_INTERP_END,
+    CONF_INTERP_START,
+    CUSTOM_POSITION_SLOTS,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    POSITION_AXIS,
+    TILT_AXIS,
+    CoverAxis,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.manual_override import (
+    ManualOverrideHandler,
+)
+from custom_components.adaptive_cover_pro.position_utils import InterpolationCurve
+
+from tests._helpers.priorities import ABOVE_HOLDER, BELOW_HOLDER
+from tests.test_pipeline.test_floor_composition import (
+    _climate_cover,
+    _cp_handler,
+    _registry_with_custom,
+)
+from tests.test_pipeline.test_hold_clamp_per_cover import (
+    _ABOVE_FLOOR_POSITIONS,
+    _FLOOR,
+    _TILT_FILL,
+    _TILT_FLOOR,
+    _CoupledStubPolicy,
+    _coupled_hold,
+    _dispatch_targets,
+    _floor_vs_hold,
+    _tilt_clamp_vs_hold,
+)
+from tests.test_pipeline.test_snapshot_builder import _make_builder
+
+#: The issue's worked example: a 20–80 device travel calibrated from 0–100.
+_CURVE = (20, 80)
+#: The device read that started it all, and the logical position it really is.
+_DEVICE_READ = 42
+_LOGICAL_READ = 37  # round((42 - 20) / 0.6) == round(36.67)
+#: Where the logical floor lands on the wire: 20 + 0.6 * 40.
+_FLOOR_ON_THE_WIRE = 44
+
+_SLOT_1 = CUSTOM_POSITION_SLOTS[1]
+_SLOT_2 = CUSTOM_POSITION_SLOTS[2]
+
+_ONLY_COVER = "cover.only"
+
+
+def _curve_options(**slot_keys: object) -> dict:
+    """Build a calibrated install's options, plus whatever slot keys a test needs."""
+    return {
+        CONF_INTERP: True,
+        CONF_INTERP_START: _CURVE[0],
+        CONF_INTERP_END: _CURVE[1],
+        **slot_keys,
+    }
+
+
+def _sensor_state(name: str = "on") -> MagicMock:
+    state = MagicMock()
+    state.state = name
+    state.attributes = {}
+    return state
+
+
+def _build_via_builder(
+    options: dict,
+    *,
+    cover_type: str,
+    sensors: tuple[str, ...],
+    current_cover_position: int,
+    cover_positions=None,
+):
+    """Build a snapshot the way production does — from options, through the builder.
+
+    The curve has to travel from ``config_entry.options`` to the snapshot for
+    the judge to see it at all, so these tests refuse the shortcut of handing
+    ``make_snapshot`` a ready-made curve: the option→snapshot binding is half of
+    what #1230 is about.
+    """
+    config_service = MagicMock()
+    config_service.get_glare_zones_config.return_value = None
+    builder, _, _ = _make_builder(
+        states={eid: _sensor_state() for eid in sensors},
+        policy=get_policy(cover_type),
+        config_service=config_service,
+    )
+    return builder.build(
+        options,
+        cover_data=_climate_cover(direct_sun_valid=False),
+        cover_type=cover_type,
+        climate_readings=None,
+        manual_override_active=True,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=current_cover_position,
+        cover_positions=cover_positions,
+        is_glare_zone_enabled=lambda idx: True,  # noqa: ARG005
+        effective_default=100,
+        is_sunset_active=False,
+    )
+
+
+def _calibrated_floor_hold(*, cover_positions=None):
+    """Evaluate a manual hold at device 42 against an outranking logical 40 % floor."""
+    options = _curve_options(
+        **{
+            _SLOT_1["sensor"]: "binary_sensor.floor",
+            _SLOT_1["position"]: _FLOOR,
+            _SLOT_1["min_mode"]: True,
+            _SLOT_1["priority"]: ABOVE_HOLDER,
+        }
+    )
+    snapshot = _build_via_builder(
+        options,
+        cover_type="cover_blind",
+        sensors=("binary_sensor.floor",),
+        current_cover_position=_DEVICE_READ,
+        cover_positions=cover_positions,
+    )
+    registry = _registry_with_custom(
+        [_cp_handler(1, _FLOOR, priority=ABOVE_HOLDER), ManualOverrideHandler()]
+    )
+    return registry.evaluate(snapshot)
+
+
+def _calibrated_tilt_clamp_hold():
+    """Evaluate a manual hold released by a TILT bound alone, on a calibrated install.
+
+    The position axis is inert — slot 1 fixes the slat angle only, slot 2 raises
+    it — so the command that goes out exists purely to carry the slats, and the
+    carriage must not move. ``cover_positions`` is deliberately absent: this is
+    the SINGULAR path, where no per-cover verdict stands between
+    ``result.position`` and the wire.
+    """
+    options = _curve_options(
+        **{
+            _SLOT_1["sensor"]: "binary_sensor.tilt_fill",
+            # A tilt-only slot claims nothing on the position axis
+            # (``position_mode`` is NONE), but the slot-configured gate wants a
+            # claim key present before the slot participates at all.
+            _SLOT_1["position"]: 0,
+            _SLOT_1["tilt"]: _TILT_FILL,
+            _SLOT_1["tilt_only"]: True,
+            _SLOT_1["priority"]: BELOW_HOLDER,
+            _SLOT_2["sensor"]: "binary_sensor.tilt_floor",
+            _SLOT_2["tilt_min"]: _TILT_FLOOR,
+            _SLOT_2["priority"]: ABOVE_HOLDER,
+        }
+    )
+    snapshot = _build_via_builder(
+        options,
+        cover_type="cover_venetian",
+        sensors=("binary_sensor.tilt_fill", "binary_sensor.tilt_floor"),
+        current_cover_position=_DEVICE_READ,
+    )
+    registry = _registry_with_custom(
+        [
+            CustomPositionHandler(
+                slot=1, position=None, priority=BELOW_HOLDER, tilt=_TILT_FILL
+            ),
+            CustomPositionHandler(slot=2, position=None, priority=ABOVE_HOLDER),
+            ManualOverrideHandler(),
+        ]
+    )
+    return registry.evaluate(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# The defect, end to end from options
+# ---------------------------------------------------------------------------
+
+
+def test_a_calibrated_floor_judges_the_logical_position_not_the_device_read() -> None:
+    """The issue verbatim: device 42 on a 20–80 curve violates a logical 40 floor.
+
+    ``42 >= 40`` is a comparison between two different frames. The cover is
+    logically at 36.67, below the floor, and the release has to fire.
+    """
+    result = _calibrated_floor_hold(cover_positions={_ONLY_COVER: _DEVICE_READ})
+
+    assert result.position == _FLOOR
+    assert result.position_constraint_applied is True
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts[_ONLY_COVER].released is True
+    assert verdicts[_ONLY_COVER].target == _FLOOR
+    # The verdict's held position stays RAW — the frame contract #1174 pinned
+    # and this fix deliberately does not touch.
+    assert verdicts[_ONLY_COVER].held_position == _DEVICE_READ
+
+
+@pytest.mark.asyncio
+async def test_a_calibrated_release_dispatches_the_floor_in_the_device_frame() -> None:
+    """The released cover reaches the floor's own device position, not the floor.
+
+    ``target`` is a logical bound edge, so the dispatch seam owes it the whole
+    calibration: 40 % logical is device 44 on a 20–80 travel.
+    """
+    result = _calibrated_floor_hold(cover_positions={_ONLY_COVER: _DEVICE_READ})
+
+    targets = await _dispatch_targets(
+        result,
+        [_ONLY_COVER],
+        "custom_position_1",
+        policy=get_policy("cover_blind"),
+        interp=_CURVE,
+    )
+
+    assert targets == {_ONLY_COVER: _FLOOR_ON_THE_WIRE}
+
+
+@pytest.mark.asyncio
+async def test_a_tilt_only_clamp_no_longer_drifts_the_singular_path_under_a_curve() -> (
+    None
+):
+    """The unclamped-fallback site, which per-cover verdicts do not protect.
+
+    Nothing claims the position axis, so ``_release_hold_for_tilt_clamp`` writes
+    ``effective_winner_pos`` into ``result.position`` and the singular dispatch
+    maps THAT through ``_to_cover_frame``. Feeding it the raw device read made
+    the round trip a double interpolation: ``20 + 0.6 * 42 == 45``, a three-point
+    phantom carriage move on a command that was only ever about the slats.
+    """
+    result = _calibrated_tilt_clamp_hold()
+
+    assert result.tilt == _TILT_FLOOR
+    assert result.skip_command is False
+    assert result.hold_clamp_verdicts is None
+    # The logical position the device read really names — what the wire mapping
+    # has to start from for the round trip to land back on 42.
+    assert result.position == _LOGICAL_READ
+
+    targets = await _dispatch_targets(
+        result, [_ONLY_COVER], "manual_override", interp=_CURVE
+    )
+
+    assert targets == {_ONLY_COVER: _DEVICE_READ}
+
+
+# ---------------------------------------------------------------------------
+# The judge's own contract, per cover
+# ---------------------------------------------------------------------------
+
+
+def test_per_cover_judgment_unwinds_the_curve_before_the_floor() -> None:
+    """Two covers, one curve: each is un-mapped on its own read, then judged.
+
+    ``cover.low`` reads device 42 — logically 36.67, under the floor. Its
+    sibling reads device 80, the top of the calibrated travel, which is
+    logically wide open. One is released and one is not, off a shared curve.
+    """
+    result = _floor_vs_hold(
+        cover_positions={"cover.low": 42, "cover.high": 80},
+        current_cover_position=61,
+        interp_curve=InterpolationCurve(start_value=_CURVE[0], end_value=_CURVE[1]),
+    )
+
+    assert result.position == _FLOOR
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.low"].released is True
+    assert verdicts["cover.low"].target == _FLOOR
+    assert verdicts["cover.high"].released is False
+    assert verdicts["cover.high"].target == 100
+    # Both held positions stay RAW — #1174's frame contract, untouched.
+    assert verdicts["cover.low"].held_position == 42
+    assert verdicts["cover.high"].held_position == 80
+
+
+def test_a_multi_point_curve_is_unwound_per_cover() -> None:
+    """The control-point curve shape reaches the judge through the same field.
+
+    Device 25 sits on the lower leg (logically 25, violating), device 65 on the
+    upper one (logically 75, compliant) — a split a simple start/end pair
+    cannot express, so the multi-point branch is genuinely exercised.
+    """
+    result = _floor_vs_hold(
+        cover_positions={"cover.low": 25, "cover.high": 65},
+        current_cover_position=45,
+        interp_curve=InterpolationCurve(
+            normal_list=[0, 50, 100], new_list=[10, 40, 90]
+        ),
+    )
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts["cover.low"].released is True
+    assert verdicts["cover.low"].target == _FLOOR
+    assert verdicts["cover.high"].released is False
+    assert verdicts["cover.high"].target == 75
+
+
+def test_a_non_monotonic_curve_leaves_the_judgment_on_the_device_read() -> None:
+    """A folded forward map has no inverse, so the judge keeps the raw read.
+
+    Pins the degraded path as a decision rather than an accident: the cover is
+    judged exactly as it was before #1230 — ``42 >= 40``, compliant — because
+    inventing a logical position for a non-injective curve would be worse than
+    reproducing today's answer.
+    """
+    result = _floor_vs_hold(
+        cover_positions={_ONLY_COVER: _DEVICE_READ},
+        current_cover_position=_DEVICE_READ,
+        interp_curve=InterpolationCurve(
+            normal_list=[0, 30, 60, 100], new_list=[0, 80, 60, 100]
+        ),
+    )
+
+    verdicts = result.hold_clamp_verdicts
+    assert verdicts is not None
+    assert verdicts[_ONLY_COVER].released is False
+    assert result.position_constraint_applied is False
+
+
+# ---------------------------------------------------------------------------
+# The #1229 interaction: a curve on the snapshot AND on the wire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_curve_snapshot_tilt_clamp_is_still_a_no_op_end_to_end() -> None:
+    """Nobody moves when the judge and the dispatch both know the curve.
+
+    #1229's ``own_read`` short-circuit exists because a verdict's ``target`` was
+    two frames at once. Now that every target is genuinely logical, the
+    short-circuit stops firing for a cover whose read differs from its own
+    logical value — and the fall-through has to land back on that read. Two
+    mechanisms carry the group, and both have to hold:
+
+    * ``cover.a`` / ``cover.b`` read device 80, logically 100. The short-circuit
+      does NOT fire (``100 != 80``) and ``_to_cover_frame(100)`` round-trips to
+      80. This is the contraction-curve exactness the fix rests on.
+    * ``cover.c`` reads device 0, *below* the calibrated travel, so un-mapping
+      clamps it to logical 0 and the round trip would open it to 20. The
+      short-circuit fires instead (``0 == 0``) and returns the read untouched —
+      which is precisely why #1229's branch must NOT be removed as redundant.
+    """
+    result = _tilt_clamp_vs_hold(
+        cover_positions=_ABOVE_FLOOR_POSITIONS,
+        interp_curve=InterpolationCurve(start_value=_CURVE[0], end_value=_CURVE[1]),
+    )
+
+    targets = await _dispatch_targets(
+        result, _ABOVE_FLOOR_POSITIONS, "manual_override", interp=_CURVE
+    )
+
+    assert targets == dict(_ABOVE_FLOOR_POSITIONS)
+
+
+# ---------------------------------------------------------------------------
+# The invariant: a policy's own reference is never un-mapped twice
+# ---------------------------------------------------------------------------
+#
+# ``CoverTypePolicy.hold_reference_position`` returns a value the policy has
+# already reduced to the frame ``PipelineResult.position`` speaks. Running the
+# new curve leg over it would un-interpolate a value that was never
+# interpolated, silently re-scaling a coupled instance's position. The hook's
+# own docstring reserves interpolation unwinding to #925; these tests make that
+# reservation a lock rather than a comment.
+
+
+class _CoupledTiltStubPolicy(_CoupledStubPolicy):
+    """The coupled reference stub, with a tilt axis so a tilt clamp can fire."""
+
+    cover_type: ClassVar[str] = "cover_reference_stub_tilt"
+    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS, TILT_AXIS)
+
+
+#: A reference deliberately OFF the curve's fixed point: ``from_cover_frame``
+#: maps 44 to 40 on a 20–80 travel, so "was it un-mapped?" has two different
+#: answers and the assertion cannot pass by coincidence. (50 would be useless
+#: here — it is a fixed point of this curve's inverse.)
+_REFERENCE = 44
+_REFERENCE_IF_WRONGLY_UNMAPPED = 40
+
+
+def test_a_policy_reference_is_never_uninterpolated_a_second_time() -> None:
+    """The judged number is the policy's reference verbatim, curve or no curve.
+
+    The floor sits at 60, above both candidates, so it clamps either way and
+    ``result.position`` cannot tell them apart. The trace's ``from_pos`` can:
+    it carries what the judge actually compared.
+    """
+    policy = _CoupledStubPolicy(reference=_REFERENCE)
+    result = _coupled_hold(
+        cover_type="cover_blind",
+        policy=policy,
+        cover_positions={"cover.x": 58, "cover.y": 70},
+        current_cover_position=64,
+        blend=None,
+        floor=60,
+        interp_curve=InterpolationCurve(start_value=_CURVE[0], end_value=_CURVE[1]),
+    )
+
+    assert policy.reference_calls == 1
+    steps = {s.handler: s for s in result.decision_trace}
+    from_pos = steps["floor_clamp"].reason_payload.params["from_pos"]
+    assert from_pos == _REFERENCE
+    assert from_pos != _REFERENCE_IF_WRONGLY_UNMAPPED
+
+
+def test_a_policy_reference_rides_the_tilt_release_un_curved() -> None:
+    """The unclamped-fallback arm keeps the same exemption.
+
+    Nothing binds the position axis, so a tilt clamp releases the hold and
+    ``effective_winner_pos`` — the reference — is written straight into
+    ``result.position``. That branch sits inside the expression #1230 changed,
+    so it is pinned here too.
+    """
+    policy = _CoupledTiltStubPolicy(reference=_REFERENCE)
+    result = _coupled_hold(
+        cover_type="cover_blind",
+        policy=policy,
+        cover_positions={"cover.x": 58, "cover.y": 70},
+        current_cover_position=64,
+        blend=_TILT_FILL,
+        tilt_min=_TILT_FLOOR,
+        interp_curve=InterpolationCurve(start_value=_CURVE[0], end_value=_CURVE[1]),
+    )
+
+    assert result.tilt == _TILT_FLOOR
+    assert result.skip_command is False
+    assert result.position == _REFERENCE
+    assert result.position != _REFERENCE_IF_WRONGLY_UNMAPPED

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -66,6 +66,7 @@ def _floor_vs_hold(
     floor: int = _FLOOR,
     floor_priority: int = ABOVE_HOLDER,
     position_axis_inverted: bool = False,
+    interp_curve=None,
 ):
     """Evaluate a manual hold against one min-mode custom-position floor."""
     registry = _registry_with_custom(
@@ -80,6 +81,7 @@ def _floor_vs_hold(
             default_position=100,
             direct_sun_valid=False,
             position_axis_inverted=position_axis_inverted,
+            interp_curve=interp_curve,
             custom_position_sensors=[
                 _cp_state(
                     "binary_sensor.floor",
@@ -435,7 +437,9 @@ async def _dispatch_targets(
     return {cover: sent.get(cover) for cover in covers}
 
 
-def _tilt_clamp_vs_hold(*, cover_positions=None, with_position_floor: bool = False):
+def _tilt_clamp_vs_hold(
+    *, cover_positions=None, with_position_floor: bool = False, interp_curve=None
+):
     """Evaluate a manual hold released by an outranking TILT bound.
 
     A FIXED tilt-only slot below the holder fills the tilt (#514); a tilt floor
@@ -444,6 +448,10 @@ def _tilt_clamp_vs_hold(*, cover_positions=None, with_position_floor: bool = Fal
     the shape the #1170 audit named when it ruled that a tilt clamp is a
     command. ``with_position_floor`` adds an outranking position floor so both
     axes clamp in the same cycle.
+
+    ``interp_curve`` puts a calibration curve on the SNAPSHOT — what the judge
+    reads (#1230), as distinct from ``_dispatch_coordinator``'s ``interp``,
+    which calibrates the write side alone.
     """
     sensors = [
         _slot(1, tilt=_TILT_FILL, tilt_only=True, priority=BELOW_HOLDER),
@@ -469,6 +477,7 @@ def _tilt_clamp_vs_hold(*, cover_positions=None, with_position_floor: bool = Fal
             cover_positions=cover_positions,
             default_position=100,
             direct_sun_valid=False,
+            interp_curve=interp_curve,
             custom_position_sensors=sensors,
         )
     )
@@ -728,6 +737,7 @@ def _coupled_hold(
     ceiling: int | None = None,
     tilt_min: int | None = None,
     position_axis_inverted: bool = False,
+    interp_curve=None,
 ):
     """Evaluate a manual hold on a dual-fabric shade with the named bounds active.
 
@@ -776,6 +786,7 @@ def _coupled_hold(
             default_position=100,
             direct_sun_valid=False,
             position_axis_inverted=position_axis_inverted,
+            interp_curve=interp_curve,
             custom_position_sensors=sensors,
         )
     )

--- a/tests/test_pipeline/test_hold_clamp_per_cover.py
+++ b/tests/test_pipeline/test_hold_clamp_per_cover.py
@@ -566,6 +566,14 @@ async def test_a_tilt_only_clamp_is_a_no_op_on_a_calibrated_install() -> None:
     (#1036). Sending both through ``_to_cover_frame`` re-maps the reads: on a
     20–80 curve the three shades at 80/80/0 were commanded to 68/68/20, which
     is the carriage move this whole path exists to prevent.
+
+    The curve here is on the DISPATCH coordinator only; the snapshot carries
+    ``interp_curve=None``. That combination is deliberately not a state
+    production reaches — both sides read the same ``CONF_INTERP`` since #1230 —
+    and it is the point: this pins the write-side #1229 behaviour against the
+    NO-CURVE judge path, holding one variable still. The consistent-state
+    equivalent, curve on both halves, is
+    ``test_hold_clamp_interpolated_frame.py::test_a_curve_snapshot_tilt_clamp_is_still_a_no_op_end_to_end``.
     """
     result = _tilt_clamp_vs_hold(cover_positions=_ABOVE_FLOOR_POSITIONS)
 
@@ -584,6 +592,12 @@ async def test_a_calibrated_floor_still_reaches_its_own_device_position() -> Non
     edge — a logical 40, which a 20–80 curve puts at device 44. Suppressing the
     curve for every verdict would under-close it, which is #469's defect in the
     opposite direction.
+
+    As above, the curve is on the DISPATCH coordinator only and the snapshot
+    carries ``interp_curve=None`` — a state production does not reach since
+    #1230, held deliberately so this pins the write-side mapping against the
+    no-curve judge path. The consistent-state equivalent is
+    ``test_hold_clamp_interpolated_frame.py::test_a_calibrated_release_dispatches_the_floor_in_the_device_frame``.
     """
     result = _tilt_clamp_vs_hold(
         cover_positions=_ABOVE_FLOOR_POSITIONS, with_position_floor=True

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -83,6 +83,7 @@ def _make_builder(
     states: dict | None = None,
     time_mgr=None,
     policy=None,
+    config_service=None,
 ):
     hass = MagicMock()
     states_map = states or {}
@@ -112,7 +113,7 @@ def _make_builder(
         climate_provider=climate_provider,
         toggles=toggles,
         policy=policy,
-        config_service=MagicMock(),
+        config_service=config_service if config_service is not None else MagicMock(),
         time_mgr=time_mgr,
     )
     return builder, climate_provider, hass
@@ -1765,6 +1766,71 @@ def test_build_carries_a_closed_gate_onto_the_snapshot():
         snapshot = _build_minimal(builder, opts)
     assert snapshot.enable_sun_tracking is True
     assert snapshot.sun_tracking_gate_closed is False
+
+
+@pytest.mark.unit
+def test_build_carries_the_interpolation_curve():
+    """The curve reaches the pure pipeline as data, not as a coordinator handle.
+
+    ``_judge_position_axis`` compares a held cover's RAW read against a logical
+    bound and needs the full inverse of ``_to_cover_frame`` to do it (#1230).
+    The curve lived only on the coordinator, which a 0-HA-import module cannot
+    reach — so this binding is the whole transport.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_INTERP,
+        CONF_INTERP_END,
+        CONF_INTERP_LIST,
+        CONF_INTERP_LIST_NEW,
+        CONF_INTERP_START,
+    )
+    from custom_components.adaptive_cover_pro.position_utils import InterpolationCurve
+
+    builder, _, _ = _make_builder()
+    snapshot = _build_minimal(
+        builder,
+        {CONF_INTERP: True, CONF_INTERP_START: 20, CONF_INTERP_END: 80},
+    )
+    assert snapshot.interp_curve == InterpolationCurve(start_value=20, end_value=80)
+
+    builder, _, _ = _make_builder()
+    snapshot = _build_minimal(
+        builder,
+        {
+            CONF_INTERP: True,
+            CONF_INTERP_LIST: [0, 50, 100],
+            CONF_INTERP_LIST_NEW: [10, 40, 90],
+        },
+    )
+    assert snapshot.interp_curve == InterpolationCurve(
+        normal_list=[0, 50, 100], new_list=[10, 40, 90]
+    )
+
+
+@pytest.mark.unit
+def test_build_without_interp_leaves_the_curve_none():
+    """No curve configured -> ``None``, even with stray start/end values stored.
+
+    ``coordinator._to_cover_frame`` gates the forward map on the master enable
+    alone, so the inverse has to be gated identically — a disabled curve whose
+    endpoints were never cleared must not start un-mapping reads. ``None`` is
+    also what keeps every uncalibrated snapshot byte-identical.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_INTERP,
+        CONF_INTERP_END,
+        CONF_INTERP_START,
+    )
+
+    builder, _, _ = _make_builder()
+    assert _build_minimal(builder, {}).interp_curve is None
+
+    builder, _, _ = _make_builder()
+    snapshot = _build_minimal(
+        builder,
+        {CONF_INTERP: False, CONF_INTERP_START: 20, CONF_INTERP_END: 80},
+    )
+    assert snapshot.interp_curve is None
 
 
 @pytest.mark.unit

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -113,7 +113,7 @@ def _make_builder(
         climate_provider=climate_provider,
         toggles=toggles,
         policy=policy,
-        config_service=config_service if config_service is not None else MagicMock(),
+        config_service=config_service or MagicMock(),
         time_mgr=time_mgr,
     )
     return builder, climate_provider, hass
@@ -1831,6 +1831,44 @@ def test_build_without_interp_leaves_the_curve_none():
         {CONF_INTERP: False, CONF_INTERP_START: 20, CONF_INTERP_END: 80},
     )
     assert snapshot.interp_curve is None
+
+
+@pytest.mark.unit
+def test_toggling_interpolation_reloads_rather_than_patching_a_live_coordinator():
+    """The builder reads ``CONF_INTERP`` per cycle; the coordinator caches it once.
+
+    ``coordinator._use_interpolation`` is assigned in ``__init__`` and never
+    refreshed — ``_update_options`` re-reads ``start_value``/``end_value``/
+    ``normal_list``/``new_list`` every cycle but not the enable flag — while
+    this builder now reads ``CONF_INTERP`` fresh out of ``options`` on every
+    build. Those two only stay in step because the option cannot change under a
+    live coordinator: it is not in ``_RUNTIME_APPLICABLE_OPTIONS``, so
+    ``_async_update_listener`` reloads the whole config entry and ``__init__``
+    re-reads it.
+
+    Without that, switching interpolation ON would have the judge un-map a
+    device read while ``_to_cover_frame`` declined to re-map the answer — 42
+    judged as 37 and then commanded as 37. Pinned here rather than left as a
+    comment because the divergence is silent and the rule lives in a different
+    module from either half of it.
+    """
+    from custom_components.adaptive_cover_pro import _RUNTIME_APPLICABLE_OPTIONS
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_INTERP,
+        CONF_INTERP_END,
+        CONF_INTERP_LIST,
+        CONF_INTERP_LIST_NEW,
+        CONF_INTERP_START,
+    )
+
+    for key in (
+        CONF_INTERP,
+        CONF_INTERP_START,
+        CONF_INTERP_END,
+        CONF_INTERP_LIST,
+        CONF_INTERP_LIST_NEW,
+    ):
+        assert key not in _RUNTIME_APPLICABLE_OPTIONS
 
 
 @pytest.mark.unit

--- a/tests/test_position_utils.py
+++ b/tests/test_position_utils.py
@@ -203,7 +203,7 @@ def test_from_cover_frame_inverts_a_multi_point_curve() -> None:
 @pytest.mark.unit
 @pytest.mark.parametrize(("start", "end"), [(20, 80), (30, 70), (0, 100), (10, 95)])
 def test_from_cover_frame_round_trips_with_to_cover_frame(start: int, end: int) -> None:
-    """Every reachable device read survives un-mapping and re-mapping.
+    """Every reachable device read survives un-mapping and re-mapping — on a CONTRACTION.
 
     This is the property the whole fix rests on. Once the judge emits truly
     logical targets, ``coordinator._verdict_dispatch_target``'s ``own_read``
@@ -212,11 +212,47 @@ def test_from_cover_frame_round_trips_with_to_cover_frame(start: int, end: int) 
     is exact for a contraction curve: the un-mapping expands, so rounding the
     logical value can move the re-mapped device value by less than half a
     point.
+
+    Every ``start``/``end`` pair contracts (``end - start <= 100``), which is
+    why all four parameter sets here do. The bound genuinely stops there — see
+    ``test_from_cover_frame_round_trip_is_off_by_one_on_an_expanding_curve``.
     """
     curve = InterpolationCurve(start_value=start, end_value=end)
     for device in range(start, end + 1):
         logical = from_cover_frame(device, inverted=False, curve=curve)
         assert round(interpolate_position(logical, start, end, None, None)) == device
+
+
+@pytest.mark.unit
+def test_from_cover_frame_round_trip_is_off_by_one_on_an_expanding_curve() -> None:
+    """The exactness above is a contraction property, not a universal one.
+
+    A multi-point control-point list can expand locally: ``[0, 50, 100]`` onto
+    ``[0, 10, 100]`` runs at slope 1.8 above the midpoint, so the half-point
+    ``from_cover_frame`` rounds away re-maps to nearly a full point and the
+    round trip misses. Device 11 un-maps to logical 51, which maps back to 12.
+
+    Pinned rather than fixed: sub-integer positions are not dispatchable, so
+    there is nothing to carry the lost precision, and a one-point move dies in
+    the delta gate. The reason this is written down is that
+    ``_verdict_dispatch_target`` leans on the exactness claim, and a claim no
+    test bounds is one that quietly grows.
+    """
+    normal_list = [0, 50, 100]
+    new_list = [0, 10, 100]
+    curve = InterpolationCurve(normal_list=normal_list, new_list=new_list)
+
+    logical = from_cover_frame(11, inverted=False, curve=curve)
+    assert logical == 51
+    assert round(interpolate_position(logical, None, None, normal_list, new_list)) == 12
+
+    # The contracting lower leg of the very same curve still round-trips exactly.
+    for device in range(0, 11):
+        back = from_cover_frame(device, inverted=False, curve=curve)
+        assert (
+            round(interpolate_position(back, None, None, normal_list, new_list))
+            == device
+        )
 
 
 @pytest.mark.unit
@@ -264,11 +300,59 @@ def test_from_cover_frame_un_inverts_before_un_interpolating() -> None:
     The combination is unsupported at runtime (the coordinator logs it and
     skips the inversion), but the helper is the stated algebraic inverse and
     has to compose in the right order to earn that description.
+
+    **The curve has to be asymmetric or this test proves nothing.** For a
+    ``start``/``end`` pair the two compositions are
+    ``(100 - x - s) * 100 / (e - s)`` and ``100 - (x - s) * 100 / (e - s)``,
+    which are algebraically equal exactly when ``s + e == 100``. ``_ISSUE_CURVE``
+    is 20-80, so it satisfies that and returns 40 either way round — a guard
+    that cannot fail. On the 10-95 curve below the correct order gives 40 and
+    the swapped one gives 46, which is what makes the assertion discriminate.
     """
-    assert from_cover_frame(56, inverted=True, curve=_ISSUE_CURVE) == 40
+    curve = InterpolationCurve(start_value=10, end_value=95)
+
+    assert from_cover_frame(56, inverted=True, curve=curve) == 40
+
+    # The swapped composition, spelled out, so the 40 above is pinned against a
+    # specific wrong answer instead of against nothing.
+    assert inverse_state(from_cover_frame(56, inverted=False, curve=curve)) == 46
 
 
 @pytest.mark.unit
 def test_from_cover_frame_ignores_an_empty_curve() -> None:
     """A curve object expressing no ranges is the same as no curve at all."""
     assert from_cover_frame(42, inverted=False, curve=InterpolationCurve()) == 42
+
+
+@pytest.mark.unit
+def test_curve_copies_its_control_points_and_stays_hashable() -> None:
+    """``frozen=True`` freezes the binding, not the list behind it.
+
+    The builder hands this ``options.get(CONF_INTERP_LIST)`` verbatim, so the
+    config entry still owns the object. Without the copy the samples could
+    change under a curve that advertises itself as immutable, and the
+    synthesised ``__hash__`` raised ``TypeError: unhashable type: 'list'`` the
+    moment anything put one in a set or a memo dict.
+    """
+    normal = [0, 50, 100]
+    new = [10, 40, 90]
+    curve = InterpolationCurve(normal_list=normal, new_list=new)
+
+    assert isinstance(curve.normal_list, tuple)
+    assert isinstance(curve.new_list, tuple)
+    # Hashable, which the frozen dataclass promised and could not deliver.
+    assert hash(curve) == hash(InterpolationCurve(normal_list=normal, new_list=new))
+    assert len({curve, InterpolationCurve(normal_list=normal, new_list=new)}) == 1
+
+    # The caller's list moving on does not move the curve.
+    normal.append(200)
+    new[0] = 99
+    assert curve.normal_list == (0, 50, 100)
+    assert curve.new_list == (10, 40, 90)
+    assert from_cover_frame(65, inverted=False, curve=curve) == 75
+
+    # A tuple-built curve is the same curve, so equality survives the coercion
+    # and every existing ``== InterpolationCurve(normal_list=[...])`` still holds.
+    assert InterpolationCurve(normal_list=(0, 50, 100)) == InterpolationCurve(
+        normal_list=[0, 50, 100]
+    )

--- a/tests/test_position_utils.py
+++ b/tests/test_position_utils.py
@@ -17,8 +17,11 @@ import pathlib
 import pytest
 
 from custom_components.adaptive_cover_pro.position_utils import (
+    InterpolationCurve,
     covered_fraction,
     flip_if,
+    from_cover_frame,
+    interpolate_position,
     inverse_state,
 )
 
@@ -151,3 +154,121 @@ def test_day_night_shade_engine_delegates_to_the_shared_primitive() -> None:
     ).read_text(encoding="utf-8")
     assert "covered_fraction(" in source
     assert "POSITION_OPEN - position" not in source
+
+
+# ---------------------------------------------------------------------------
+# from_cover_frame — the full inverse of coordinator._to_cover_frame (#1230)
+# ---------------------------------------------------------------------------
+#
+# ``_to_cover_frame`` maps logical -> wire as "interpolate, then invert". This
+# is the algebraic inverse, in reverse order: un-invert, then un-interpolate.
+# The registry needs it because a held cover's read is compared against a
+# user-configured logical bound, and ``flip_if`` alone left the calibration
+# curve on the value (#1230).
+
+#: The issue's worked example, as an explicit curve.
+_ISSUE_CURVE = InterpolationCurve(start_value=20, end_value=80)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("inverted", [True, False])
+def test_from_cover_frame_without_a_curve_matches_flip_if(inverted: bool) -> None:
+    """No curve configured -> exactly today's ``flip_if``, for every input.
+
+    This is what keeps every uncalibrated install byte-identical: the registry
+    swapped one call for the other, and on a snapshot carrying no curve the two
+    have to be the same function.
+    """
+    for value in range(101):
+        assert from_cover_frame(value, inverted=inverted) == flip_if(
+            value, inverted=inverted
+        )
+
+
+@pytest.mark.unit
+def test_from_cover_frame_inverts_the_simple_start_end_curve() -> None:
+    """The two numbers issue #1230 is about, on a 20-80 device travel."""
+    assert from_cover_frame(42, inverted=False, curve=_ISSUE_CURVE) == 37
+    assert from_cover_frame(44, inverted=False, curve=_ISSUE_CURVE) == 40
+
+
+@pytest.mark.unit
+def test_from_cover_frame_inverts_a_multi_point_curve() -> None:
+    """Both curve shapes go through one code path — the multi-point one too."""
+    curve = InterpolationCurve(normal_list=[0, 50, 100], new_list=[10, 40, 90])
+    assert from_cover_frame(25, inverted=False, curve=curve) == 25
+    assert from_cover_frame(65, inverted=False, curve=curve) == 75
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("start", "end"), [(20, 80), (30, 70), (0, 100), (10, 95)])
+def test_from_cover_frame_round_trips_with_to_cover_frame(start: int, end: int) -> None:
+    """Every reachable device read survives un-mapping and re-mapping.
+
+    This is the property the whole fix rests on. Once the judge emits truly
+    logical targets, ``coordinator._verdict_dispatch_target``'s ``own_read``
+    short-circuit stops firing on a calibrated install and every target goes
+    back out through ``_to_cover_frame``. That is only safe because the inverse
+    is exact for a contraction curve: the un-mapping expands, so rounding the
+    logical value can move the re-mapped device value by less than half a
+    point.
+    """
+    curve = InterpolationCurve(start_value=start, end_value=end)
+    for device in range(start, end + 1):
+        logical = from_cover_frame(device, inverted=False, curve=curve)
+        assert round(interpolate_position(logical, start, end, None, None)) == device
+
+
+@pytest.mark.unit
+def test_from_cover_frame_inverts_a_decreasing_curve() -> None:
+    """A curve whose device travel runs backwards is still injective.
+
+    ``np.interp`` needs its sample points ascending, so a descending curve is
+    inverted by reversing BOTH ranges rather than by refusing to unwind it.
+    """
+    curve = InterpolationCurve(start_value=80, end_value=20)
+    assert from_cover_frame(44, inverted=False, curve=curve) == 60
+    assert from_cover_frame(80, inverted=False, curve=curve) == 0
+    assert from_cover_frame(20, inverted=False, curve=curve) == 100
+
+
+@pytest.mark.unit
+def test_from_cover_frame_skips_a_non_monotonic_curve() -> None:
+    """A forward map that is not injective has no inverse — so none is invented.
+
+    This runs inside the judge on every update cycle, in a pure module. Raising
+    would brick the loop for an install whose curve has "worked" for years and
+    clamping would invent data, so the un-interpolation leg is skipped and the
+    value degrades to exactly its pre-#1230 treatment. No new failure mode.
+    """
+    curve = InterpolationCurve(normal_list=[0, 30, 60, 100], new_list=[0, 80, 60, 100])
+    assert from_cover_frame(42, inverted=False, curve=curve) == 42
+    assert from_cover_frame(42, inverted=True, curve=curve) == 58
+
+
+@pytest.mark.unit
+def test_from_cover_frame_clamps_reads_outside_the_curve() -> None:
+    """A read past either end of the calibrated travel lands on that end.
+
+    Mirrors the forward map, which clamps the same way — ``np.interp``'s native
+    endpoint behaviour, not a rule bolted on here.
+    """
+    assert from_cover_frame(10, inverted=False, curve=_ISSUE_CURVE) == 0
+    assert from_cover_frame(90, inverted=False, curve=_ISSUE_CURVE) == 100
+
+
+@pytest.mark.unit
+def test_from_cover_frame_un_inverts_before_un_interpolating() -> None:
+    """Order matters: ``_to_cover_frame`` interpolates first and inverts last.
+
+    The combination is unsupported at runtime (the coordinator logs it and
+    skips the inversion), but the helper is the stated algebraic inverse and
+    has to compose in the right order to earn that description.
+    """
+    assert from_cover_frame(56, inverted=True, curve=_ISSUE_CURVE) == 40
+
+
+@pytest.mark.unit
+def test_from_cover_frame_ignores_an_empty_curve() -> None:
+    """A curve object expressing no ranges is the same as no curve at all."""
+    assert from_cover_frame(42, inverted=False, curve=InterpolationCurve()) == 42


### PR DESCRIPTION
## Summary

`_judge_position_axis` compared a **raw device-frame** read against **logical** user-configured bounds. `flip_if` only undoes inverse-state, and on a calibrated install `axis_inverted` suppresses inversion outright — so the comparison ran entirely in the device frame with nothing unwinding the calibration curve.

On a 20–80 curve a cover reporting device 42 sits at logical 36.67, which violates a logical floor of 40. The judge saw `42 >= 40`, called it compliant, and no command went out — the floor was silently not enforced. A ceiling misfires by the same offset in the other direction, and `effective_winner_pos` reported a device number the user never configured, so the decision trace read plausibly while being wrong.

Uncalibrated installs were never affected: `flip_if` is the whole transform there.

### What changed

- **`position_utils.from_cover_frame`** — the algebraic inverse of `coordinator._to_cover_frame`: un-invert, then un-interpolate. Shares its range resolution with `interpolate_position` via a new `_interp_ranges` helper rather than mirroring it.
- **`PipelineSnapshot.interp_curve`** — a new frozen `InterpolationCurve` field carrying the curve into the pure pipeline, filled by the snapshot builder from the existing `CONF_INTERP*` options. Defaults to `None`, which reduces `from_cover_frame` to exactly the old `flip_if`, so every uncalibrated install is byte-identical.
- **`pipeline/registry.py`** — the judge's `entries` construction and its unclamped-fallback arm now convert through it.

### Deliberately not changed

- The coupled-type `reference` branch stays un-converted — that value is already logical, and un-interpolating it a second time would be silent corruption. `hold_reference_position` reserves that to #925. Two new tests pin the invariant, which nothing guarded before.
- The `own_read` short-circuit from #1229 stays. It turns out to be load-bearing, not merely redundant: a read *outside* the calibrated travel endpoint-clamps, so the round trip does not return the original device position (device 0 on a 20–80 curve re-maps to 20). Removing it would put a phantom carriage move back into the tilt-only path.
- Non-monotonic `interp_list_new` curves have no inverse. The helper skips the un-interpolation leg rather than raising inside the update loop, degrading to exactly today's behaviour.

## Testing

- ✅ 15157 tests passing (4 skipped, 1 xfailed)
- 27 new tests: `from_cover_frame` unit coverage, three builder-route defect reproductions, judge-level contract tests, and two guards for the reference invariant
- Nine named regression guards re-run individually and green, covering #1229, #1174 and #1179
- Patch coverage 100% on the diff

Reviewed by two automated audit passes; the second closed all seven findings of the first.

## Follow-ups (not in this change)

- `motion_timeout` and `group_lock` publish `flip_if(raw_read)` into `PipelineResult.position` and drift the same way under a curve. Both reserve it to #925, and neither has coverage under a curve — worth one issue covering all three sites so they move together.
- The config flow accepts a non-monotonic `interp_list_new` that has no inverse.

## Related Issues

Refs #1230
