### PR TITLE
fix: guard venetian tilt-only sends with a publish-lag window (#1329)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -953,15 +953,21 @@ class VenetianPolicy(CoverTypePolicy, register=True):
     def is_in_tilt_suppression(self, entity_id: str, delta: float = 0.0) -> bool:
         """Suppress back-rotate drift only when ``delta`` is plausibly motor drift.
 
-        This is the TILT-axis gate — the real gate consulted by
-        :meth:`secondary_axis_check`'s ``suppression`` callback. It ORs two
-        independent windows so a tilt-only send is never left unguarded
-        (issue #1329):
+        This is the TILT-axis gate — wired to :meth:`secondary_axis_check`'s
+        ``single_axis_suppression`` callback, NOT ``suppression=`` (which
+        stays :meth:`primary_axis_suppression`; see that wiring's docstring
+        for why the two must stay separate — issue #930 finding #2). It ORs
+        two windows so a tilt-only send is never left unguarded (issue
+        #1329):
 
-        * :meth:`primary_axis_suppression` — the position-anchored window
-          (motor back-rotate cap + command grace) shared with the position
-          axis. Unmodified by this method; a tilt-only send that never
-          stamped a position command simply finds this term closed.
+        * :meth:`primary_axis_suppression` — the position-anchored window,
+          re-evaluated here so this method is correct as a standalone
+          predicate. In the one production call path this disjunct is
+          always False by the time ``evaluate`` reaches
+          ``single_axis_suppression``: it already tried the identical call
+          as ``suppression=`` and falls through to this method only when
+          that returned False. Retained for correctness when this method is
+          called directly, not because the production wiring needs it.
         * ``sequencer.is_in_tilt_publish_lag`` — a SEPARATE window anchored to
           ACP's own last tilt dispatch (``_tilt_sent_at``), delta-capped at
           ``VENETIAN_TILT_VERIFY_TOLERANCE``. This is what actually protects
@@ -972,7 +978,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         and fall through to the manual-override numeric path (issue #33
         follow-on). The ``delta`` default matches the base signature so the
         method is interchangeable with other policies when passed as a
-        ``SecondaryAxisCheck.suppression`` callback.
+        ``SecondaryAxisCheck.single_axis_suppression`` callback.
         """
         if self._sequencer is None:
             return False
@@ -1206,14 +1212,17 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         ``single_axis_suppression`` wires :meth:`is_in_tilt_suppression`
         (issue #1329) — the tilt-only publish-lag window, anchored to ACP's
         own last tilt DISPATCH (``_tilt_sent_at``) rather than a position
-        command. A tilt-only send never touches the carriage, so unlike
-        ``suppression`` above a True result here must NOT blind the position
-        axis: ``evaluate`` consults it only as a narrower, single-axis
-        fallback right before it would otherwise declare a tilt manual move,
-        and its match does not consume the cycle (issue #930 finding #2 — the
-        position axis must keep evaluating independently). At the point
-        ``evaluate`` reaches it, ``suppression`` above has already returned
-        False, so in practice this behaves as
+        command. A tilt-only send does not *command* the carriage — though
+        real motors briefly back-drive it (``VENETIAN_POST_TILT_REBASE_DELAY_SECONDS``)
+        — so unlike ``suppression`` above a True result here must NOT blind
+        the position axis: because this suppression is non-consuming, the
+        position axis' own check still runs on that same publish, so a
+        back-driven ``current_position`` is evaluated on its own merits
+        rather than being blinded (issue #930 finding #2). ``evaluate``
+        consults ``single_axis_suppression`` only as a narrower, single-axis
+        fallback right before it would otherwise declare a tilt manual move.
+        At the point ``evaluate`` reaches it, ``suppression`` above has
+        already returned False, so in practice this behaves as
         ``sequencer.is_in_tilt_publish_lag`` alone.
 
         ``excursion_match`` wires the drift-reset endpoint guard (issue #927)

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -953,16 +953,32 @@ class VenetianPolicy(CoverTypePolicy, register=True):
     def is_in_tilt_suppression(self, entity_id: str, delta: float = 0.0) -> bool:
         """Suppress back-rotate drift only when ``delta`` is plausibly motor drift.
 
-        Delegates to the sequencer's delta-aware gate. Large deltas inside the
-        window are user moves, not motor drift, and fall through to the
-        manual-override numeric path (issue #33 follow-on). The ``delta``
-        default matches the base signature so the method is interchangeable
-        with other policies when passed as a ``SecondaryAxisCheck.suppression``
-        callback.
+        This is the TILT-axis gate — the real gate consulted by
+        :meth:`secondary_axis_check`'s ``suppression`` callback. It ORs two
+        independent windows so a tilt-only send is never left unguarded
+        (issue #1329):
+
+        * :meth:`primary_axis_suppression` — the position-anchored window
+          (motor back-rotate cap + command grace) shared with the position
+          axis. Unmodified by this method; a tilt-only send that never
+          stamped a position command simply finds this term closed.
+        * ``sequencer.is_in_tilt_publish_lag`` — a SEPARATE window anchored to
+          ACP's own last tilt dispatch (``_tilt_sent_at``), delta-capped at
+          ``VENETIAN_TILT_VERIFY_TOLERANCE``. This is what actually protects
+          a routine tilt-only send once the position window is closed (or was
+          never opened at all).
+
+        Large deltas outside both windows are user moves, not motor drift,
+        and fall through to the manual-override numeric path (issue #33
+        follow-on). The ``delta`` default matches the base signature so the
+        method is interchangeable with other policies when passed as a
+        ``SecondaryAxisCheck.suppression`` callback.
         """
         if self._sequencer is None:
             return False
-        return self._sequencer.is_in_suppression_with_cap(entity_id, delta)
+        return self.primary_axis_suppression(
+            entity_id, delta
+        ) or self._sequencer.is_in_tilt_publish_lag(entity_id, delta)
 
     def primary_axis_suppression(self, entity_id: str, delta: float = 0.0) -> bool:
         """Apply the tilt-axis publish-lag window to the position axis too.
@@ -1182,7 +1198,23 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         (issue #33 Phase 5 cross-axis): the motor back-rotate window
         OR'd with the command-grace period. Sharing one callback across
         both axes keeps the publish-lag and grace logic from drifting per
-        CODING_GUIDELINES.md § "No Code Duplication".
+        CODING_GUIDELINES.md § "No Code Duplication". A True result here
+        means the POSITION axis may be co-drifting from the same physical
+        motor action, so ``SecondaryAxisCheck.evaluate`` consumes (blinds)
+        both axes' checks together for this cycle.
+
+        ``single_axis_suppression`` wires :meth:`is_in_tilt_suppression`
+        (issue #1329) — the tilt-only publish-lag window, anchored to ACP's
+        own last tilt DISPATCH (``_tilt_sent_at``) rather than a position
+        command. A tilt-only send never touches the carriage, so unlike
+        ``suppression`` above a True result here must NOT blind the position
+        axis: ``evaluate`` consults it only as a narrower, single-axis
+        fallback right before it would otherwise declare a tilt manual move,
+        and its match does not consume the cycle (issue #930 finding #2 — the
+        position axis must keep evaluating independently). At the point
+        ``evaluate`` reaches it, ``suppression`` above has already returned
+        False, so in practice this behaves as
+        ``sequencer.is_in_tilt_publish_lag`` alone.
 
         ``excursion_match`` wires the drift-reset endpoint guard (issue #927)
         onto the TILT axis only. It is value-based (matches the raw published
@@ -1201,6 +1233,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             attribute="current_tilt_position",
             label="tilt",
             suppression=self.primary_axis_suppression,
+            single_axis_suppression=self.is_in_tilt_suppression,
             excursion_match=(
                 self._sequencer.is_reset_excursion_publish
                 if self._sequencer is not None

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -474,6 +474,48 @@ class DualAxisSequencer:
             return True
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
 
+    def is_in_tilt_publish_lag(self, entity_id: str, delta: float) -> bool:
+        """Absorb an actuator's late re-publish of the tilt ACP itself just commanded.
+
+        Issue #1329: a tilt-ONLY send (``update_tilt_only``) deliberately never
+        calls ``stamp_position_command`` — that stamp is shared with the
+        position axis via ``is_in_suppression_with_cap`` and popping
+        ``_settled_at`` would corrupt the ``moving → settled`` anchor
+        ``run_sequence`` depends on (issue #33 follow-on). So a routine
+        tilt-only send has no position-axis window to fall back on; once the
+        5s command grace expires it is otherwise completely unguarded against
+        the actuator's own late re-publish of the tilt it just settled at.
+
+        This is a SEPARATE window, anchored to ``_tilt_sent_at`` (ACP's own
+        last tilt dispatch) rather than ``_suppression_at`` (the position
+        command stamp), so it can never widen the position axis' suppression.
+        Two conditions must BOTH hold — this is a strict AND, not an OR — for
+        the caller to treat a publish as ACP's own settling rather than a
+        manual move:
+
+        * ``_seconds_since(_tilt_sent_at[entity_id]) < self._backrotate_publish_lag_seconds``
+          — the publish must land within the user's configured
+          ``venetian_backrotate_publish_lag`` window of ACP's own tilt send.
+        * ``delta <= VENETIAN_TILT_VERIFY_TOLERANCE`` — the cap is
+          deliberately the *verify* tolerance, not the looser
+          ``VENETIAN_BACKROTATE_MAX_DELTA_PERCENT`` the position-axis window
+          uses: ``_verify_and_record_tilt`` already declares a publish within
+          this band "arrived on target", so ACP cannot distinguish a small
+          user nudge from its own settling even in principle. Six times
+          tighter than the position axis' 30% cap.
+
+        Returns ``False`` (not suppressed) when no tilt has ever been sent for
+        this entity, when the window has elapsed, or when the delta exceeds
+        the verify tolerance — in every one of those cases the manual-override
+        path runs as normal.
+        """
+        stamp = self._tilt_sent_at.get(entity_id)
+        if stamp is None:
+            return False
+        if self._seconds_since(stamp) >= self._backrotate_publish_lag_seconds:
+            return False
+        return delta <= VENETIAN_TILT_VERIFY_TOLERANCE
+
     def is_reset_excursion_publish(self, entity_id: str, new_value: float) -> bool:
         """Suppress the late state publishes of a drift-reset excursion trajectory (#927/#930).
 
@@ -820,7 +862,6 @@ class DualAxisSequencer:
         # confirms it lands on the actuator (issue #33). Discard preemptively
         # in case a prior cycle marked the entity verified.
         self._tilt_targets_verified.discard(entity_id)
-        self._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
         # Restart the grace window so the tilt-axis change isn't read as a
         # user touch by manual_override detection.
         self._grace_mgr.start_command_grace_period(entity_id)
@@ -858,6 +899,14 @@ class DualAxisSequencer:
                 trigger=reason,
             )
             return False
+
+        # Issue #1329: record the publish-lag anchor only once the move really
+        # went out — matching the #927 precedent for the drift-reset endpoint
+        # stamp. Written here (after the successful async_call), not before
+        # it, so a failed send leaves no stale stamp that would open
+        # ``is_in_tilt_publish_lag``'s window for a tilt ACP never actually
+        # commanded.
+        self._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
 
         # A tilt frame keys the radio and the command queue never gated it
         # (issue #1189). The post-settle tail runs OUTSIDE the slot on purpose —

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -138,6 +138,21 @@ class SecondaryAxisCheck:
     time-based grace window happens to be open at the same instant. The record
     is trajectory-tracked, not one-shot-popped: an endpoint publish marks it and
     a target-return publish consumes it (#930).
+
+    ``single_axis_suppression`` (issue #1329) is an optional, narrower
+    suppression callback consulted only as a last resort, right before
+    ``evaluate`` would otherwise declare a manual move on THIS axis alone.
+    Unlike ``suppression`` — whose True result implies the OTHER axis may be
+    co-drifting from the same physical command and therefore consumes
+    (blinds) both axes' checks for the cycle — a True result here suppresses
+    only this axis's own delta verdict and does NOT consume: the caller's
+    independent axis check still runs afterward. This matters for a
+    suppression source that is anchored to THIS axis's own dispatch alone
+    (e.g. venetian's tilt-only publish-lag window) with no coupling to the
+    other axis at all — folding it into ``suppression`` would silently blind
+    the other axis's manual detection any time this axis happened to verify
+    near its last commanded value, reintroducing the cross-axis blinding
+    issue #930 (finding #2) fixed.
     """
 
     # ``None`` (issue #1006) means ACP has no DISPATCHED value to police on this
@@ -154,6 +169,10 @@ class SecondaryAxisCheck:
     # one-shot-popped): endpoint publish marks, target-return consumes
     # (issue #927/#930).
     excursion_match: Callable[[str, float], bool] | None = None
+    # Non-consuming counterpart to ``suppression`` — see the class docstring
+    # (issue #1329). Checked only immediately before the numeric manual
+    # verdict would otherwise fire.
+    single_axis_suppression: Callable[[str, float], bool] | None = None
     # AUTHORITATIVE note on the wire/logical mismatch (issue #1227) — callers
     # (``VenetianPolicy``/``DayNightShadePolicy.secondary_axis_check``) should
     # point back here rather than re-deriving this explanation.
@@ -298,6 +317,29 @@ class SecondaryAxisCheck:
         # must not simultaneously read as a user touch. This axis used ``>=``,
         # which made the two axes return opposite verdicts on that one value.
         if delta > effective_threshold:
+            # Issue #1329: a narrower, non-consuming fallback checked only
+            # right before declaring this axis manual. Unlike ``suppression``
+            # above, a True result here does NOT imply the other axis is
+            # co-drifting (e.g. venetian's tilt-only publish-lag window never
+            # touches the position axis at all) — consumed stays False so the
+            # caller's independent axis check still runs this cycle (#930
+            # finding #2: a genuine move on the OTHER axis must still trip).
+            if (
+                self.single_axis_suppression is not None
+                and self.single_axis_suppression(entity_id, delta)
+            ):
+                return SecondaryAxisResult(
+                    event_name="manual_override_rejected_tilt_suppression",
+                    event_kwargs={
+                        "our_state": self.expected,
+                        "new_position": reported,
+                        "effective_threshold": effective_threshold,
+                        "reason": (
+                            f"{self.label} delta {delta:.1f}% within venetian "
+                            "tilt-only publish-lag window; suppressing tilt check only"
+                        ),
+                    },
+                )
             return SecondaryAxisResult(
                 consumed=True,
                 is_manual=True,

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -147,12 +147,13 @@ class SecondaryAxisCheck:
     (blinds) both axes' checks for the cycle — a True result here suppresses
     only this axis's own delta verdict and does NOT consume: the caller's
     independent axis check still runs afterward. This matters for a
-    suppression source that is anchored to THIS axis's own dispatch alone
-    (e.g. venetian's tilt-only publish-lag window) with no coupling to the
-    other axis at all — folding it into ``suppression`` would silently blind
-    the other axis's manual detection any time this axis happened to verify
-    near its last commanded value, reintroducing the cross-axis blinding
-    issue #930 (finding #2) fixed.
+    suppression source anchored to THIS axis's own dispatch alone (e.g.
+    venetian's tilt-only publish-lag window): a tilt-only send does not
+    *command* the other axis, though mechanical back-drive can still move it
+    slightly, so folding this source into ``suppression`` would blind the
+    other axis's check on that same publish instead of letting it evaluate a
+    back-driven value on its own merits — reintroducing the cross-axis
+    blinding issue #930 (finding #2) fixed.
     """
 
     # ``None`` (issue #1006) means ACP has no DISPATCHED value to police on this

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -575,26 +575,44 @@ async def test_tilt_on_target_plus_position_back_drive_does_not_trip_manual_over
 async def test_tilt_only_update_does_not_stamp_suppression_window(
     svc, hass, attached_policy
 ):
-    """Issue #33 follow-on: tilt-only updates must NOT extend the back-rotate window.
+    """Issue #33 follow-on / #1329: the POSITION window stays untouched, the
+    axis' OWN publish-lag window opens.
 
-    The window protects the *position-axis* settle and the tilt-induced back-drive
-    that follows. A tilt-only send from ``maybe_update_tilt_only`` doesn't move
-    the carriage, so it must not refresh the window — otherwise a user opening
-    the blind during the (now extended) window is silently consumed as motor
-    drift, stranding reconciliation at the user-driven position.
+    The POSITION-axis window protects the position-axis settle and the
+    tilt-induced back-drive that follows a POSITION command. A tilt-only send
+    from ``maybe_update_tilt_only`` doesn't move the carriage, so it must not
+    refresh that window — otherwise a user opening the blind during the (now
+    extended) window is silently consumed as motor drift, stranding
+    reconciliation at the user-driven position.
+
+    Separately (issue #1329), a tilt-only send DOES open its own narrower
+    publish-lag window — anchored to ``_tilt_sent_at``, delta-capped at
+    ``VENETIAN_TILT_VERIFY_TOLERANCE`` — so the actuator's own delayed
+    republish of the tilt it just settled at isn't misread as a manual
+    override. ``is_in_tilt_suppression`` (the combined predicate) reflects
+    that window immediately after dispatch.
     """
     entity_id = "cover.venetian_morning"
     hass.states.get.return_value = _state_with_position(50)
 
     # Seed _last_tilt so maybe_update_tilt_only doesn't short-circuit on None.
     attached_policy._last_tilt = 70
+    # Grace already expired: isolates the second assertion below to the NEW
+    # tilt-only publish-lag window rather than the (also-true, unrelated) 5s
+    # command grace this send also (re)starts.
+    attached_policy._grace_mgr.is_in_command_grace_period = MagicMock(
+        return_value=False
+    )
 
     await attached_policy.maybe_update_tilt_only(
         entity_id, current_position=50, context=None, reason="solar"
     )
 
-    # New contract: tilt-only path leaves the window untouched.
-    assert attached_policy.is_in_tilt_suppression(entity_id, delta=0.0) is False
+    # The POSITION-axis window is untouched — a tilt-only send never stamps it.
+    assert attached_policy._sequencer.is_in_suppression(entity_id) is False
+    # But the axis' OWN tilt-only publish-lag window (issue #1329) is now
+    # open, protecting against the actuator's own delayed republish.
+    assert attached_policy.is_in_tilt_suppression(entity_id, delta=0.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_issue_1329_tilt_only_publish_lag.py
+++ b/tests/test_issue_1329_tilt_only_publish_lag.py
@@ -34,8 +34,13 @@ from homeassistant.exceptions import HomeAssistantError
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import VENETIAN_TILT_VERIFY_TOLERANCE
 from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
     VenetianPolicy,
+)
+from custom_components.adaptive_cover_pro.managers.manual_override import (
+    AdaptiveCoverManager,
+    SecondaryAxisCheck,
 )
 
 # Zero the real-motor sleep delays — update_tilt_only drives the real
@@ -79,6 +84,41 @@ def _make_attached_policy(
         backrotate_publish_lag_seconds=backrotate_publish_lag_seconds,
     )
     return policy, hass
+
+
+def _pin_elapsed(seq, seconds: float) -> None:
+    """Pin a sequencer's elapsed-time formula to an exact value for boundary tests.
+
+    Wall-clock offsets (``stamp -= timedelta(seconds=N)``) always drift a few
+    microseconds past ``N`` by the time the assertion runs — enough to prove
+    "past the boundary" but never the EXACT boundary itself, which is what
+    actually distinguishes ``<`` from ``<=`` (or ``>`` from ``>=``).
+    ``DualAxisSequencer._seconds_since`` is a ``staticmethod`` — a non-data
+    descriptor — so assigning a plain callable directly on the INSTANCE
+    shadows it for every ``self._seconds_since(...)`` call on this sequencer
+    only, without touching the class or any other instance.
+    """
+    seq._seconds_since = lambda _stamp: seconds
+
+
+async def _dispatch_tilt_and_build_check(
+    policy: VenetianPolicy, entity_id: str, *, tilt_target: int = 85
+) -> SecondaryAxisCheck:
+    """Dispatch a real tilt-only send, then build the check via production wiring.
+
+    Populates BOTH sequencer anchors a real cycle would: ``_tilt_targets``
+    (the issue #1006 dispatched-value anchor ``expected`` resolves to) and
+    ``_tilt_sent_at`` (the issue #1329 publish-lag anchor). Building the
+    ``SecondaryAxisCheck`` via ``policy.secondary_axis_check`` — not by
+    hand — means these tests break if production's wiring (``suppression=``
+    / ``single_axis_suppression=``) is ever mis-pointed.
+    """
+    await policy._sequencer.update_tilt_only(
+        entity_id, tilt_target=tilt_target, current_position=19, reason="solar_tracking"
+    )
+    return policy.secondary_axis_check(
+        SimpleNamespace(tilt=tilt_target), None, entity_id=entity_id
+    )
 
 
 async def test_tilt_only_publish_after_grace_within_verify_tolerance_is_suppressed() -> (
@@ -164,3 +204,224 @@ async def test_failed_tilt_send_opens_no_publish_lag_window() -> None:
     )
 
     assert policy._sequencer.is_in_tilt_publish_lag(entity_id, delta=0.0) is False
+
+
+# ---------------------------------------------------------------------------
+# MUST-FIX 1 (post-merge audit): pin BOTH False branches of
+# ``is_in_tilt_publish_lag`` and the exact boundaries, from the predicate
+# directly AND from the production call path (BINDING_GUIDELINES §4 —
+# "pin the boundary from both call sites").
+# ---------------------------------------------------------------------------
+
+
+def test_is_in_tilt_publish_lag_delta_above_verify_tolerance_returns_false() -> None:
+    """Delta cap, general case: a delta past ``VENETIAN_TILT_VERIFY_TOLERANCE``
+    is a real user move, not settle-lag — the predicate must NOT suppress it,
+    even with a freshly-stamped, well-inside-the-window dispatch.
+    """
+    entity_id = "cover.venetian_delta_above_tolerance"
+    policy, _hass = _make_attached_policy()
+    policy._sequencer._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
+
+    assert (
+        policy._sequencer.is_in_tilt_publish_lag(
+            entity_id, delta=VENETIAN_TILT_VERIFY_TOLERANCE + 1
+        )
+        is False
+    )
+
+
+def test_is_in_tilt_publish_lag_delta_at_verify_tolerance_boundary_returns_true() -> (
+    None
+):
+    """Boundary pin: ``delta == VENETIAN_TILT_VERIFY_TOLERANCE`` IS suppressed.
+
+    Pins the docstring's ``<=`` — not ``<``. Flipping the operator in
+    ``is_in_tilt_publish_lag`` to ``<`` makes this fail.
+    """
+    entity_id = "cover.venetian_delta_at_tolerance_boundary"
+    policy, _hass = _make_attached_policy()
+    policy._sequencer._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
+
+    assert (
+        policy._sequencer.is_in_tilt_publish_lag(
+            entity_id, delta=VENETIAN_TILT_VERIFY_TOLERANCE
+        )
+        is True
+    )
+
+
+def test_is_in_tilt_publish_lag_time_elapsed_at_lag_boundary_returns_false() -> None:
+    """Boundary pin: elapsed == ``_backrotate_publish_lag_seconds`` is EXPIRED.
+
+    Pins the ``>=`` in ``if self._seconds_since(stamp) >= lag: return False``
+    — not ``>``. Uses ``_pin_elapsed`` because a wall-clock offset can never
+    land on the exact boundary (see that helper's docstring). Flipping the
+    operator to ``>`` makes this fail.
+    """
+    entity_id = "cover.venetian_time_at_lag_boundary"
+    policy, _hass = _make_attached_policy(backrotate_publish_lag_seconds=90)
+    policy._sequencer._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
+    _pin_elapsed(policy._sequencer, 90.0)
+
+    assert policy._sequencer.is_in_tilt_publish_lag(entity_id, delta=0.0) is False
+
+
+def test_is_in_tilt_publish_lag_time_elapsed_just_under_lag_boundary_returns_true() -> (
+    None
+):
+    """Contrast case: a hair under the lag boundary is still inside the window.
+
+    Paired with the boundary test above so the boundary is actually pinned
+    from both sides — this alone can't distinguish ``>`` from ``>=``, but
+    together with the exact-boundary test it proves the transition happens
+    exactly at ``lag_seconds``, not one tick either side of it.
+    """
+    entity_id = "cover.venetian_time_under_lag_boundary"
+    policy, _hass = _make_attached_policy(backrotate_publish_lag_seconds=90)
+    policy._sequencer._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
+    _pin_elapsed(policy._sequencer, 89.999)
+
+    assert policy._sequencer.is_in_tilt_publish_lag(entity_id, delta=0.0) is True
+
+
+async def test_tilt_only_publish_delta_above_verify_tolerance_trips_override() -> None:
+    """Call-path pin: delta above the verify tolerance is NOT suppressed.
+
+    Companion to ``test_is_in_tilt_publish_lag_delta_above_verify_tolerance_returns_false``
+    — pins the same boundary through ``VenetianPolicy.secondary_axis_check``'s
+    real wiring instead of the bare predicate.
+    """
+    entity_id = "cover.venetian_call_path_delta_above"
+    policy, _hass = _make_attached_policy()
+    check = await _dispatch_tilt_and_build_check(policy, entity_id)
+
+    reported = 85 - (VENETIAN_TILT_VERIFY_TOLERANCE + 1)
+    new_state = SimpleNamespace(attributes={"current_tilt_position": reported})
+    result = check.evaluate(entity_id, new_state, manual_threshold=3)
+
+    assert result.is_manual is True
+    assert result.consumed is True
+    assert result.event_name == "manual_override_set"
+
+
+async def test_tilt_only_publish_delta_at_verify_tolerance_boundary_is_suppressed() -> (
+    None
+):
+    """Call-path boundary pin: ``delta == VENETIAN_TILT_VERIFY_TOLERANCE`` IS suppressed.
+
+    Companion to ``test_is_in_tilt_publish_lag_delta_at_verify_tolerance_boundary_returns_true``,
+    pinned through ``secondary_axis_check(...).evaluate(...)`` — the actual
+    production call path (BINDING_GUIDELINES §4).
+    """
+    entity_id = "cover.venetian_call_path_delta_boundary"
+    policy, _hass = _make_attached_policy()
+    check = await _dispatch_tilt_and_build_check(policy, entity_id)
+
+    reported = 85 - VENETIAN_TILT_VERIFY_TOLERANCE
+    new_state = SimpleNamespace(attributes={"current_tilt_position": reported})
+    result = check.evaluate(entity_id, new_state, manual_threshold=3)
+
+    assert result.is_manual is False
+    assert result.consumed is False
+    assert result.event_name == "manual_override_rejected_tilt_suppression"
+
+
+async def test_tilt_only_publish_at_lag_boundary_trips_override() -> None:
+    """Call-path time-boundary pin: elapsed == lag_seconds is EXPIRED, not suppressed.
+
+    Companion to ``test_is_in_tilt_publish_lag_time_elapsed_at_lag_boundary_returns_false``,
+    pinned through the production call path. Delta is 4% (the exact reported
+    issue #1329 value) — comfortably inside ``VENETIAN_TILT_VERIFY_TOLERANCE``
+    (5) so ONLY the time boundary is under test; if the lag window were still
+    open this delta would have been suppressed.
+    """
+    entity_id = "cover.venetian_call_path_time_boundary"
+    policy, _hass = _make_attached_policy(backrotate_publish_lag_seconds=90)
+    check = await _dispatch_tilt_and_build_check(policy, entity_id)
+    _pin_elapsed(policy._sequencer, 90.0)
+
+    new_state = SimpleNamespace(attributes={"current_tilt_position": 81})  # delta 4%
+    result = check.evaluate(entity_id, new_state, manual_threshold=3)
+
+    assert result.is_manual is True
+    assert result.consumed is True
+    assert result.event_name == "manual_override_set"
+
+
+# ---------------------------------------------------------------------------
+# MUST-FIX 3 (post-merge audit): the deviation's own contract — a tilt
+# publish inside the lag window must suppress ONLY the tilt axis. A
+# simultaneous genuine POSITION move must still trip (issue #930 finding #2 —
+# this is the entire reason ``single_axis_suppression`` is non-consuming
+# rather than repointing ``suppression=`` outright).
+# ---------------------------------------------------------------------------
+
+
+async def test_position_axis_still_trips_manual_override_inside_tilt_publish_lag_window() -> (
+    None
+):
+    """Drive the real manual-override entry point with both axes moving at once.
+
+    The tilt axis reports a value inside the fresh tilt-only publish-lag
+    window (delta 4%, <= ``VENETIAN_TILT_VERIFY_TOLERANCE``) — suppressed,
+    non-consumed. The SAME state change also reports a POSITION delta far
+    above ``manual_threshold``, with no position command ever stamped for
+    this entity (a tilt-only send never touches
+    ``primary_axis_suppression``'s anchor). ``AdaptiveCoverManager.handle_state_change``
+    is the same production entry point the coordinator calls.
+
+    This is the property that distinguishes ``single_axis_suppression``
+    (``consumed=False``) from the rejected ``consumed=True`` design: if the
+    tilt-only publish-lag suppression ever blinded the position axis too,
+    this test would fail with the cover NOT marked manual.
+    """
+    entity_id = "cover.venetian_dual_axis_trip"
+    policy, _hass = _make_attached_policy()
+    check = await _dispatch_tilt_and_build_check(policy, entity_id)
+
+    mgr = AdaptiveCoverManager(
+        hass=MagicMock(), reset_duration={"hours": 2}, logger=MagicMock()
+    )
+    mgr.add_covers([entity_id])
+    mgr.hass.states.get = MagicMock(return_value=None)
+
+    event = MagicMock()
+    event.entity_id = entity_id
+    event.new_state = MagicMock()
+    event.new_state.state = "stopped"
+    # Tilt: delta 4% from the commanded 85 -> above manual_threshold=3 (so the
+    # numeric branch is even reached) but inside VENETIAN_TILT_VERIFY_TOLERANCE
+    # (5) and the fresh publish-lag window -> suppressed. Position: our_state
+    # 19 (the last commanded position, never stamped by the tilt-only send)
+    # vs reported 60 -> delta 41%, far past manual_threshold=3 -> must trip.
+    event.new_state.attributes = {
+        "current_tilt_position": 81,
+        "current_position": 60,
+    }
+    event.new_state.last_updated = dt.datetime.now(dt.UTC)
+    event.old_state = None
+
+    mgr.handle_state_change(
+        states_data=event,
+        our_state=19,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=3,
+        secondary_axis_check=check,
+    )
+
+    assert mgr.is_cover_manual(entity_id), (
+        "the position axis must still trip manual override even though the "
+        "tilt axis's own publish-lag window suppressed the tilt check "
+        "(issue #930 finding #2 / the consumed=False contract this fix relies on)"
+    )
+    events = mgr.get_event_buffer()
+    assert any(
+        evt.get("event") == "manual_override_rejected_tilt_suppression"
+        for evt in events
+    ), f"expected the tilt axis to be suppressed too, got {events}"
+    assert any(
+        evt.get("event") == "manual_override_set" for evt in events
+    ), f"expected the position axis to trip manual_override_set, got {events}"

--- a/tests/test_issue_1329_tilt_only_publish_lag.py
+++ b/tests/test_issue_1329_tilt_only_publish_lag.py
@@ -262,7 +262,10 @@ def test_is_in_tilt_publish_lag_time_elapsed_at_lag_boundary_returns_false() -> 
     entity_id = "cover.venetian_time_at_lag_boundary"
     policy, _hass = _make_attached_policy(backrotate_publish_lag_seconds=90)
     policy._sequencer._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
-    _pin_elapsed(policy._sequencer, 90.0)
+    # Derived from the sequencer's own window, not a second hardcoded ``90``,
+    # so the pin and the configured window can't drift apart by hand.
+    lag_seconds = policy._sequencer._backrotate_publish_lag_seconds
+    _pin_elapsed(policy._sequencer, lag_seconds)
 
     assert policy._sequencer.is_in_tilt_publish_lag(entity_id, delta=0.0) is False
 
@@ -276,11 +279,27 @@ def test_is_in_tilt_publish_lag_time_elapsed_just_under_lag_boundary_returns_tru
     from both sides — this alone can't distinguish ``>`` from ``>=``, but
     together with the exact-boundary test it proves the transition happens
     exactly at ``lag_seconds``, not one tick either side of it.
+
+    ``_tilt_sent_at`` is set to real "now" just above, so REAL elapsed time
+    at assertion time is also ~0s — comfortably under the window even if
+    ``_pin_elapsed`` silently stopped shadowing ``_seconds_since``. That would
+    make the behavioural assertion below pass for the wrong reason, so the
+    guard assertion proves the pin actually took effect before trusting it.
     """
     entity_id = "cover.venetian_time_under_lag_boundary"
     policy, _hass = _make_attached_policy(backrotate_publish_lag_seconds=90)
     policy._sequencer._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
-    _pin_elapsed(policy._sequencer, 89.999)
+    # Derived from the sequencer's own window, not a second hardcoded ``90``,
+    # so the pin and the configured window can't drift apart by hand.
+    lag_seconds = policy._sequencer._backrotate_publish_lag_seconds
+    pinned_elapsed = lag_seconds - 0.001
+    _pin_elapsed(policy._sequencer, pinned_elapsed)
+
+    # Guard: prove the shadow is live before trusting the assertion below.
+    assert (
+        policy._sequencer._seconds_since(policy._sequencer._tilt_sent_at[entity_id])
+        == pinned_elapsed
+    )
 
     assert policy._sequencer.is_in_tilt_publish_lag(entity_id, delta=0.0) is True
 
@@ -339,7 +358,9 @@ async def test_tilt_only_publish_at_lag_boundary_trips_override() -> None:
     entity_id = "cover.venetian_call_path_time_boundary"
     policy, _hass = _make_attached_policy(backrotate_publish_lag_seconds=90)
     check = await _dispatch_tilt_and_build_check(policy, entity_id)
-    _pin_elapsed(policy._sequencer, 90.0)
+    # Derived from the sequencer's own window, not a second hardcoded ``90``,
+    # so the pin and the configured window can't drift apart by hand.
+    _pin_elapsed(policy._sequencer, policy._sequencer._backrotate_publish_lag_seconds)
 
     new_state = SimpleNamespace(attributes={"current_tilt_position": 81})  # delta 4%
     result = check.evaluate(entity_id, new_state, manual_threshold=3)

--- a/tests/test_issue_1329_tilt_only_publish_lag.py
+++ b/tests/test_issue_1329_tilt_only_publish_lag.py
@@ -1,0 +1,166 @@
+"""Regression tests for issue #1329 — tilt-only publish-lag suppression gap.
+
+A venetian **tilt-only** command (``update_tilt_only``, the dispatch path used
+whenever the position axis is delta-gated but the tilt axis keeps solar
+tracking — the normal steady state on a slow-changing sun day) opens **no**
+back-rotate suppression window at all: ``update_tilt_only`` deliberately never
+calls ``stamp_position_command`` (issue #33 follow-on — that stamp is shared
+with the position axis and pops ``_settled_at``). Once the 5s command-grace
+tail expires, an ordinary tilt-only send is completely unguarded against the
+actuator's own late re-publish of the tilt it just settled at, and that late
+publish trips a false ``manual_override_set``.
+
+Reproduces the reporter's diagnostics timeline: ``update_tilt_only`` dispatches
+tilt=85, the actuator republishes tilt=81 (delta 4%) 16s later — past the 5s
+grace, well inside the user's configured 90s ``venetian_backrotate_publish_lag``
+— and (pre-fix) nothing suppresses it because the position-axis suppression
+window (``is_in_suppression``) was never opened by a tilt-only send.
+
+Wired through ``VenetianPolicy.secondary_axis_check`` exactly as production
+composes it — this test builds a real ``DualAxisSequencer`` via
+``VenetianPolicy.attach`` (mirroring the wiring helper in
+``tests/test_manual_override_venetian.py``) but, deliberately, never seeds a
+position command: issue #1329 is exclusively about the tilt-only path, which
+never stamps the position-axis window in the first place.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.exceptions import HomeAssistantError
+
+import pytest
+
+from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
+    VenetianPolicy,
+)
+
+# Zero the real-motor sleep delays — update_tilt_only drives the real
+# sequencer's post-tilt verify/rebase waits, which otherwise add real idle
+# time to this suite.
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
+
+
+def _make_attached_policy(
+    *,
+    grace_expired: bool = True,
+    backrotate_publish_lag_seconds: float = 90,
+    async_call: AsyncMock | None = None,
+) -> tuple[VenetianPolicy, MagicMock]:
+    """Build a ``VenetianPolicy`` wired to a real ``DualAxisSequencer``.
+
+    Mirrors ``tests/test_manual_override_venetian.py``'s
+    ``_make_sequencer_suppression`` wiring, but goes through
+    ``VenetianPolicy.attach`` (so ``is_in_tilt_suppression`` runs exactly as
+    production composes it) and deliberately seeds NO position command — no
+    ``stamp_position_command`` call anywhere. ``grace_expired=True`` (the
+    default) models the state every routine tilt-only send is dispatched
+    into: ``maybe_update_tilt_only`` only ever fires once the suppression
+    window is already closed (issue #756), so by the time a tilt-only send's
+    own publish lands, the shared 5s command grace has normally elapsed too.
+    """
+    hass = MagicMock()
+    hass.services.async_call = async_call if async_call is not None else AsyncMock()
+    grace_mgr = MagicMock()
+    grace_mgr.is_in_command_grace_period = MagicMock(return_value=not grace_expired)
+    policy = VenetianPolicy()
+    policy.attach(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=grace_mgr,
+        get_current_position=lambda _eid: 19,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_state=lambda _eid: "stopped",
+        backrotate_publish_lag_seconds=backrotate_publish_lag_seconds,
+    )
+    return policy, hass
+
+
+async def test_tilt_only_publish_after_grace_within_verify_tolerance_is_suppressed() -> (
+    None
+):
+    """A tilt-only send's own late publish must be absorbed within the publish-lag window.
+
+    ``update_tilt_only(tilt_target=85)`` dispatches with no position command
+    in flight. The actuator republishes ``current_tilt_position=81`` (delta
+    4%, exactly the reported issue #1329 delta) 16s later — past the 5s
+    command grace, inside the user's 90s ``venetian_backrotate_publish_lag``
+    — and within ``VENETIAN_TILT_VERIFY_TOLERANCE`` (5) of the commanded
+    value, the same band ``_verify_and_record_tilt`` already treats as
+    "arrived". That publish must be suppressed as ACP's own tilt settling,
+    not read as a manual override.
+    """
+    entity_id = "cover.venetian_tilt_only"
+    policy, hass = _make_attached_policy()
+
+    await policy._sequencer.update_tilt_only(
+        entity_id, tilt_target=85, current_position=19, reason="solar_tracking"
+    )
+    assert hass.services.async_call.call_count == 1
+
+    # Advance the clock to T+16s past the tilt dispatch — past the 5s grace
+    # (mocked expired via grace_mgr above), still inside the 90s publish-lag
+    # window.
+    policy._sequencer._tilt_sent_at[entity_id] -= dt.timedelta(seconds=16)
+
+    # Built via the real production wiring (not hand-rolled) so this test
+    # breaks if VenetianPolicy.secondary_axis_check is mis-wired.
+    check = policy.secondary_axis_check(
+        SimpleNamespace(tilt=85), None, entity_id=entity_id
+    )
+    new_state = SimpleNamespace(attributes={"current_tilt_position": 81})
+
+    result = check.evaluate(entity_id, new_state, manual_threshold=3)
+
+    assert result.is_manual is False
+    # NOT consumed (issue #930 finding #2): a tilt-only send never touches
+    # the position axis, so unlike the position-anchored suppression window
+    # this rejection must not blind the position axis' own independent
+    # manual-override check for the cycle.
+    assert result.consumed is False
+    assert result.event_name == "manual_override_rejected_tilt_suppression"
+
+
+async def test_tilt_only_dispatch_leaves_position_suppression_closed() -> None:
+    """Shape lock: the fix must never call ``stamp_position_command`` from the tilt path.
+
+    That stamp is shared with the position axis via ``primary_axis_suppression``
+    and pops ``_settled_at`` (issue #33 follow-on) — a tilt-only send that
+    reached for it would blind the position axis' own manual-override
+    detection for the full suppression window. This must hold both before and
+    after the fix.
+    """
+    entity_id = "cover.venetian_tilt_only_shape_lock"
+    policy, _hass = _make_attached_policy()
+
+    await policy._sequencer.update_tilt_only(
+        entity_id, tilt_target=85, current_position=19, reason="solar_tracking"
+    )
+
+    assert policy._sequencer.is_in_suppression(entity_id) is False
+
+
+async def test_failed_tilt_send_opens_no_publish_lag_window() -> None:
+    """A failed ``set_cover_tilt_position`` call must not open the publish-lag window.
+
+    Matches the #927 precedent that a dispatch-anchored stamp records only
+    once the move really went out: ``_tilt_sent_at`` must be written AFTER a
+    successful ``services.async_call``, not before it. Otherwise a
+    ``HomeAssistantError`` would still leave a stale stamp behind, opening a
+    publish-lag window for a tilt command that was never actually sent.
+    """
+    entity_id = "cover.venetian_tilt_only_failed_send"
+    policy, _hass = _make_attached_policy(
+        async_call=AsyncMock(side_effect=HomeAssistantError("boom"))
+    )
+
+    await policy._sequencer.update_tilt_only(
+        entity_id, tilt_target=85, current_position=19, reason="solar_tracking"
+    )
+
+    assert policy._sequencer.is_in_tilt_publish_lag(entity_id, delta=0.0) is False

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
-from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -87,14 +86,23 @@ def _make_sequencer_suppression(
     stamp_age_seconds: float = 0.0,
     settled_now: bool = False,
     settled_age_seconds: float = 0.0,
-) -> Callable[[str, float], bool]:
-    """Build a real ``DualAxisSequencer`` and return its bound delta-cap gate.
+) -> DualAxisSequencer:
+    """Build a real ``DualAxisSequencer`` wired for the tilt-suppression gate.
 
     Closes the integration gap the lambda-stub helpers leave open (issue #33
     follow-on): wires ``stamp_position_command`` and the ``_get_state``
-    callback together so the cap behaves exactly as ``VenetianPolicy.is_in_tilt_suppression``
-    does in production. ``state`` should be ``"opening"``/``"closing"`` to
-    model an in-transit cycle, or ``"stopped"`` to model a settled cycle.
+    callback together so ``seq.is_in_suppression_with_cap`` behaves exactly as
+    ``VenetianPolicy.is_in_tilt_suppression``'s position-anchored term does in
+    production. ``state`` should be ``"opening"``/``"closing"`` to model an
+    in-transit cycle, or ``"stopped"`` to model a settled cycle.
+
+    Returns the sequencer itself (not a bound method) so callers can wire
+    BOTH halves of production's OR onto ``SecondaryAxisCheck`` — the shared
+    ``suppression=seq.is_in_suppression_with_cap`` term AND the tilt-only
+    ``single_axis_suppression=seq.is_in_tilt_publish_lag`` term (issue #1329)
+    — exactly as ``VenetianPolicy.secondary_axis_check`` composes them.
+    Without the second half these tests exercise only the position-anchored
+    term and silently stop reaching ``is_in_tilt_publish_lag`` at all.
 
     ``stamp_age_seconds`` backdates the suppression stamp so callers can land
     outside the post-settle cap-grace tail while still inside the overall
@@ -125,7 +133,7 @@ def _make_sequencer_suppression(
         seq._stamp_settled(entity_id)
         if settled_age_seconds > 0:
             seq._settled_at[entity_id] -= dt.timedelta(seconds=settled_age_seconds)
-    return seq.is_in_suppression_with_cap
+    return seq
 
 
 def test_tilt_drift_inside_suppression_window_is_ignored() -> None:
@@ -293,7 +301,7 @@ def test_tilt_drift_during_in_transit_close_is_ignored_regardless_of_delta() -> 
     entity_id = "cover.venetian_kitchen_close"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(entity_id=entity_id, state="closing")
+    seq = _make_sequencer_suppression(entity_id=entity_id, state="closing")
 
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=86, tilt=0),
@@ -306,7 +314,8 @@ def test_tilt_drift_during_in_transit_close_is_ignored_regardless_of_delta() -> 
             expected=100,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=suppression,
+            suppression=seq.is_in_suppression_with_cap,
+            single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
 
@@ -325,7 +334,7 @@ def test_tilt_drift_during_in_transit_open_is_ignored_regardless_of_delta() -> N
     entity_id = "cover.venetian_office_open"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(entity_id=entity_id, state="opening")
+    seq = _make_sequencer_suppression(entity_id=entity_id, state="opening")
 
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=17, tilt=100),
@@ -338,7 +347,8 @@ def test_tilt_drift_during_in_transit_open_is_ignored_regardless_of_delta() -> N
             expected=60,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=suppression,
+            suppression=seq.is_in_suppression_with_cap,
+            single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
 
@@ -356,7 +366,7 @@ def test_tilt_drift_inside_post_settle_grace_is_ignored() -> None:
     entity_id = "cover.venetian_post_settle_grace"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(entity_id=entity_id, state="stopped")
+    seq = _make_sequencer_suppression(entity_id=entity_id, state="stopped")
 
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=50, tilt=0),
@@ -369,7 +379,8 @@ def test_tilt_drift_inside_post_settle_grace_is_ignored() -> None:
             expected=80,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=suppression,
+            suppression=seq.is_in_suppression_with_cap,
+            single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
 
@@ -396,7 +407,7 @@ def test_tilt_drift_after_settle_grace_with_large_delta_trips_override() -> None
     entity_id = "cover.venetian_post_settle_user_move"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(
+    seq = _make_sequencer_suppression(
         entity_id=entity_id,
         state="stopped",
         stamp_age_seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 5.0,
@@ -415,7 +426,14 @@ def test_tilt_drift_after_settle_grace_with_large_delta_trips_override() -> None
             expected=80,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=suppression,
+            # Issue #1329 (MUST-FIX 2): wired so this guard genuinely reaches
+            # ``is_in_tilt_publish_lag`` — see the module docstring's note on
+            # ``_make_sequencer_suppression``. ``_tilt_sent_at`` is never
+            # populated here (no ``update_tilt_only`` call), so this term is
+            # always False and the assertion below is unchanged: the delta=95
+            # user-twist must still trip on the position-anchored cap alone.
+            suppression=seq.is_in_suppression_with_cap,
+            single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
 
@@ -462,7 +480,7 @@ def test_late_publish_burst_after_real_settle_does_not_trip_override() -> None:
     entity_id = "cover.venetian_publish_lag"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(
+    seq = _make_sequencer_suppression(
         entity_id=entity_id,
         state="stopped",
         stamp_age_seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0,
@@ -480,7 +498,8 @@ def test_late_publish_burst_after_real_settle_does_not_trip_override() -> None:
             expected=100,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=suppression,
+            suppression=seq.is_in_suppression_with_cap,
+            single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
 
@@ -508,7 +527,7 @@ def test_real_user_twist_after_publish_lag_still_trips_override() -> None:
     entity_id = "cover.venetian_real_user_twist"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(
+    seq = _make_sequencer_suppression(
         entity_id=entity_id,
         state="stopped",
         stamp_age_seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0,
@@ -527,7 +546,14 @@ def test_real_user_twist_after_publish_lag_still_trips_override() -> None:
             expected=100,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=suppression,
+            # Issue #1329 (MUST-FIX 2): wired so this guard genuinely reaches
+            # ``is_in_tilt_publish_lag`` (see ``_make_sequencer_suppression``'s
+            # docstring). ``_tilt_sent_at`` is never populated here (no
+            # ``update_tilt_only`` call), so this term is always False — the
+            # delta=95 user-twist trips solely on the position-anchored cap
+            # having expired, unchanged from before this wiring.
+            suppression=seq.is_in_suppression_with_cap,
+            single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
 

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -100,9 +100,16 @@ def _make_sequencer_suppression(
     BOTH halves of production's OR onto ``SecondaryAxisCheck`` — the shared
     ``suppression=seq.is_in_suppression_with_cap`` term AND the tilt-only
     ``single_axis_suppression=seq.is_in_tilt_publish_lag`` term (issue #1329)
-    — exactly as ``VenetianPolicy.secondary_axis_check`` composes them.
-    Without the second half these tests exercise only the position-anchored
-    term and silently stop reaching ``is_in_tilt_publish_lag`` at all.
+    — the same effective terms ``VenetianPolicy.secondary_axis_check`` wires
+    in production (``suppression=self.primary_axis_suppression``,
+    ``single_axis_suppression=self.is_in_tilt_suppression``), not the
+    identical callables: by the point ``evaluate`` reaches
+    ``single_axis_suppression``, ``primary_axis_suppression`` has already run
+    once via ``suppression=`` and returned False, so ``is_in_tilt_suppression``'s
+    only live disjunct there is ``is_in_tilt_publish_lag`` — the callable this
+    helper wires directly. Without the second half these tests exercise only
+    the position-anchored term and silently stop reaching
+    ``is_in_tilt_publish_lag`` at all.
 
     ``stamp_age_seconds`` backdates the suppression stamp so callers can land
     outside the post-settle cap-grace tail while still inside the overall
@@ -315,6 +322,10 @@ def test_tilt_drift_during_in_transit_close_is_ignored_regardless_of_delta() -> 
             attribute="current_tilt_position",
             label="tilt",
             suppression=seq.is_in_suppression_with_cap,
+            # No `update_tilt_only` call here, so `_tilt_sent_at` is unset and
+            # this term is always False — it does not exercise the #1329
+            # tilt-only window; that bound coverage lives in
+            # tests/test_issue_1329_tilt_only_publish_lag.py.
             single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
@@ -348,6 +359,10 @@ def test_tilt_drift_during_in_transit_open_is_ignored_regardless_of_delta() -> N
             attribute="current_tilt_position",
             label="tilt",
             suppression=seq.is_in_suppression_with_cap,
+            # No `update_tilt_only` call here, so `_tilt_sent_at` is unset and
+            # this term is always False — it does not exercise the #1329
+            # tilt-only window; that bound coverage lives in
+            # tests/test_issue_1329_tilt_only_publish_lag.py.
             single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
@@ -380,6 +395,10 @@ def test_tilt_drift_inside_post_settle_grace_is_ignored() -> None:
             attribute="current_tilt_position",
             label="tilt",
             suppression=seq.is_in_suppression_with_cap,
+            # No `update_tilt_only` call here, so `_tilt_sent_at` is unset and
+            # this term is always False — it does not exercise the #1329
+            # tilt-only window; that bound coverage lives in
+            # tests/test_issue_1329_tilt_only_publish_lag.py.
             single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )
@@ -499,6 +518,10 @@ def test_late_publish_burst_after_real_settle_does_not_trip_override() -> None:
             attribute="current_tilt_position",
             label="tilt",
             suppression=seq.is_in_suppression_with_cap,
+            # No `update_tilt_only` call here, so `_tilt_sent_at` is unset and
+            # this term is always False — it does not exercise the #1329
+            # tilt-only window; that bound coverage lives in
+            # tests/test_issue_1329_tilt_only_publish_lag.py.
             single_axis_suppression=seq.is_in_tilt_publish_lag,
         ),
     )


### PR DESCRIPTION
## Summary

A venetian **tilt-only** send opened no back-rotate suppression window at all. `update_tilt_only` deliberately never calls `stamp_position_command` (#33 follow-on — that stamp is shared with the position axis and pops `_settled_at`), so once the 5s command grace expired the tilt axis was completely unguarded against the actuator's own late re-publish of the tilt it had just settled at. The reporter's cover sat falsely overridden for nearly two hours on a 4% delta, and their configured 90s `venetian_backrotate_publish_lag` never reached this path.

Compounding it: `VENETIAN_TILT_VERIFY_TOLERANCE` (5) sits above the manual-override floor `POSITION_TOLERANCE_PERCENT` (3), so a publish with delta in `(3, 5]` is simultaneously "verified on target" and "a manual override".

The fix gives the tilt axis its own window, anchored to `_tilt_sent_at` (ACP's own last tilt dispatch) and capped at the verify tolerance — the same band `_verify_and_record_tilt` already treats as arrived, so ACP cannot distinguish a nudge that small from its own settling even in principle. `_tilt_sent_at` already existed and was written on every dispatch but read nowhere; that write moved to after the successful service call so a failed send leaves no stale stamp.

It is wired through a new **non-consuming** `single_axis_suppression` callback rather than repointing `suppression=`. A tilt-only send does not command the carriage, so blinding the position axis for the cycle would have reintroduced the cross-axis blinding addressed in #930.

No new constant, no new config option. The position axis is untouched.

## Testing

- ✅ 15171 tests passing (4 skipped, 1 xfailed)
- New `tests/test_issue_1329_tilt_only_publish_lag.py` pins both `False` branches of the new predicate and both exact boundaries, from the predicate directly and through the production call path
- The anti-widening guards in `tests/test_manual_override_venetian.py` were re-wired to production's real OR composition — they had stopped reaching the tilt gate
- A cross-axis test drives the real `handle_state_change` with a suppressed tilt publish plus a 41% position delta and asserts the position axis still trips
- Two audit rounds; final re-audit clean, with the production files verified AST-identical apart from docstrings

## Related Issues

Refs #1329

Remaining tail of the reopened half of #930, which closed against a release epic without a PR landing for that variant.