### PR TITLE
fix: replace deprecated registry mapping scans with indexed lookups

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -631,11 +631,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     else:
         # No device association — remove our config entry from any physical device that
         # still has it (left over from a previous association that was cleared).
-        for device in list(device_reg.devices.values()):
-            if (
-                entry.entry_id in device.config_entries
-                and (DOMAIN, entry.entry_id) not in device.identifiers
-            ):
+        # The registry's own config-entry index replaces a full scan of every device
+        # in the install (deprecated, removed in HA 2027.9.0 — issue #1339); it also
+        # makes the old "entry.entry_id in device.config_entries" test redundant, and
+        # it returns a fresh list, so the body may mutate the registry as it goes.
+        for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
+            if (DOMAIN, entry.entry_id) not in device.identifiers:
                 _LOGGER.debug(
                     "Removing stale config entry link from physical device %s",
                     device.id,

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -36,6 +36,13 @@ from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntr
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER, Platform
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import area_registry as ar
+
+# ``dr`` is imported for its EVENT_DEVICE_REGISTRY_UPDATED name only — an event
+# constant, not a registry read. The device<->area registry *hop* still lives
+# solely in ``state.area_resolver`` (issue #786); that invariant is about who
+# reads the registry, and this file reads none of it. ``ar`` above is here on
+# exactly the same terms: its only use is EVENT_AREA_REGISTRY_UPDATED.
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_state_change_event
@@ -127,7 +134,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         self._unsub_registry: list[CALLBACK_TYPE] = []
         self._unsub_entry_state: CALLBACK_TYPE | None = None
         self._member_subs: dict[str, _MemberSubscription] = {}
-        self._roster_snapshot: tuple[tuple[str, ...], tuple[str, ...]] | None = None
+        self._roster_snapshot: tuple[frozenset[str], frozenset[str]] | None = None
         self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
         self._grace_mgr = GracePeriodManager(_LOGGER)
         self._cmd_svc = CoverCommandService(
@@ -167,13 +174,18 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
           ``async_entries_for_device`` drops disabled entries unless told
           otherwise. Omitting the flag would silently strip disabled covers
           from area rosters.
-        - ``reg_entry.area_id is None`` on the device pass preserves
+        - ``not reg_entry.area_id`` on the device pass preserves
           :meth:`_entity_area_id`'s entity-over-device precedence: a cover
           whose own area names a *different* area must not be collected via
-          its device.
-        - The passes are disjoint by construction — pass 1 requires a non-None
-          own area, pass 2 requires ``None`` — and an entity has exactly one
-          device, so no dedup is needed.
+          its device. The test is falsiness, not ``is None``, so that it
+          agrees with :meth:`_entity_area_id` on a blank ``area_id``: HA
+          indexes an entity's own area on ``is not None``, so an ``""`` would
+          be filed under ``""`` — invisible to pass 1 — and ``is None`` would
+          reject it here too, losing a cover the old full scan collected.
+        - The passes are disjoint by construction — pass 1 requires an own
+          area equal to a real (non-empty) ``area_id``, pass 2 requires a
+          falsy one — and an entity has exactly one device, so no dedup is
+          needed.
         """
         ent_reg = er.async_get(self.hass)
         entity_ids = [
@@ -187,7 +199,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
                 for reg_entry in er.async_entries_for_device(
                     ent_reg, device_id, include_disabled_entities=True
                 )
-                if reg_entry.domain == Platform.COVER and reg_entry.area_id is None
+                if reg_entry.domain == Platform.COVER and not reg_entry.area_id
             )
         return entity_ids
 
@@ -649,9 +661,16 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """Subscribe to member-state and (with an area) registry changes.
 
         The registry subscriptions keep area membership live: covers moved
-        into or out of the area re-resolve the rosters. The config-entry
-        subscription keeps the *member coordinator* subscriptions live — see
-        :meth:`_handle_config_entry_change`.
+        into or out of the area re-resolve the rosters. All three registries
+        matter — a cover joins an area by its own ``area_id`` (entity), by its
+        *device's* (device), or because the area itself changed (area) — and a
+        device move touches neither of the other two, so it needs its own
+        listener. The config-entry subscription keeps the *member coordinator*
+        subscriptions live — see :meth:`_handle_config_entry_change`.
+
+        All three fire on any attribute change, not only area moves;
+        :meth:`_handle_registry_change`'s snapshot comparison is what keeps
+        that chatter from turning into reloads.
         """
         entities = self.member_cover_entities()
         if entities:
@@ -671,11 +690,23 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
                 self.hass.bus.async_listen(
                     ar.EVENT_AREA_REGISTRY_UPDATED, self._handle_registry_change
                 ),
+                self.hass.bus.async_listen(
+                    dr.EVENT_DEVICE_REGISTRY_UPDATED, self._handle_registry_change
+                ),
             ]
 
-    def _current_roster_snapshot(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
-        """Return a comparable snapshot of the effective rosters."""
-        return (tuple(self.member_entry_ids()), tuple(self.generic_cover_ids()))
+    def _current_roster_snapshot(self) -> tuple[frozenset[str], frozenset[str]]:
+        """Return a comparable snapshot of the effective rosters.
+
+        Membership, not order. The rosters are a union of an own-area pass and
+        a device-inherited pass, so clearing a cover's own area while its
+        device already sits in the same area shuffles it between the two
+        without changing who is in the group — an ordered comparison would
+        read that as a roster change and reload for nothing. Order is not
+        load-bearing here: it is recomputed from the registries on every read,
+        and a reload would reproduce exactly the same order.
+        """
+        return (frozenset(self.member_entry_ids()), frozenset(self.generic_cover_ids()))
 
     @callback
     def _handle_registry_change(self, _event: Event) -> None:

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -77,7 +77,7 @@ from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
 from .pipeline.types import GroupIntent
 from .position_utils import flip_if
-from .state.area_resolver import device_area_id
+from .state.area_resolver import area_device_ids, device_area_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,14 +155,41 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         return device_area_id(self.hass, reg_entry.device_id)
 
     def _cover_entities_in_area(self, area_id: str) -> list[str]:
-        """Every ``cover.`` entity in the area (own or device-inherited)."""
+        """Every ``cover.`` entity in the area (own or device-inherited).
+
+        Two passes over the registries' own indexes, replacing a scan of every
+        entity in the install — deprecated, and removed in HA 2027.9.0
+        (issue #1339). Three things about it are load-bearing:
+
+        - ``include_disabled_entities=True`` on the per-device pass is
+          deliberate and *not* the default. The two accessors are asymmetric:
+          ``async_entries_for_area`` applies no ``disabled_by`` filter, while
+          ``async_entries_for_device`` drops disabled entries unless told
+          otherwise. Omitting the flag would silently strip disabled covers
+          from area rosters.
+        - ``reg_entry.area_id is None`` on the device pass preserves
+          :meth:`_entity_area_id`'s entity-over-device precedence: a cover
+          whose own area names a *different* area must not be collected via
+          its device.
+        - The passes are disjoint by construction — pass 1 requires a non-None
+          own area, pass 2 requires ``None`` — and an entity has exactly one
+          device, so no dedup is needed.
+        """
         ent_reg = er.async_get(self.hass)
-        return [
+        entity_ids = [
             reg_entry.entity_id
-            for reg_entry in ent_reg.entities.values()
+            for reg_entry in er.async_entries_for_area(ent_reg, area_id)
             if reg_entry.domain == Platform.COVER
-            and self._entity_area_id(reg_entry.entity_id) == area_id
         ]
+        for device_id in area_device_ids(self.hass, area_id):
+            entity_ids.extend(
+                reg_entry.entity_id
+                for reg_entry in er.async_entries_for_device(
+                    ent_reg, device_id, include_disabled_entities=True
+                )
+                if reg_entry.domain == Platform.COVER and reg_entry.area_id is None
+            )
+        return entity_ids
 
     def member_entry_ids(self) -> list[str]:
         """Effective ACP member entry ids: static roster ∪ area members.

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -202,13 +202,14 @@ def _resolve_targets(
     device_ids: list[str] = cv.ensure_list(call.data.get("device_id"))
     area_ids: list[str] = cv.ensure_list(call.data.get("area_id"))
 
-    # Expand area_ids → device_ids
+    # Expand area_ids → device_ids via the registry's own area index. Scanning
+    # every device in the install is deprecated and stops working in HA
+    # 2027.9.0 (issue #1339); the index also makes an area_id re-check redundant.
     if area_ids:
         dev_reg = dr.async_get(hass)
         for area_id in area_ids:
-            for device in dev_reg.devices.values():
-                if device.area_id == area_id:
-                    device_ids.append(device.id)
+            for device in dr.async_entries_for_area(dev_reg, area_id):
+                device_ids.append(device.id)
 
     # No target at all → all coordinators, no filter
     if not entity_ids and not device_ids and not area_ids:

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -208,8 +208,9 @@ def _resolve_targets(
     if area_ids:
         dev_reg = dr.async_get(hass)
         for area_id in area_ids:
-            for device in dr.async_entries_for_area(dev_reg, area_id):
-                device_ids.append(device.id)
+            device_ids.extend(
+                device.id for device in dr.async_entries_for_area(dev_reg, area_id)
+            )
 
     # No target at all → all coordinators, no filter
     if not entity_ids and not device_ids and not area_ids:

--- a/custom_components/adaptive_cover_pro/services/group_service.py
+++ b/custom_components/adaptive_cover_pro/services/group_service.py
@@ -97,13 +97,14 @@ def resolve_group_targets(
     if not entity_ids and not device_ids and not area_ids:
         return list(groups.values())
 
+    # Expand area_ids → device_ids via the registry's own area index. Scanning
+    # every device in the install is deprecated and stops working in HA
+    # 2027.9.0 (issue #1339); the index also makes an area_id re-check redundant.
     if area_ids:
         dev_reg = dr.async_get(hass)
         for area_id in area_ids:
             device_ids.extend(
-                device.id
-                for device in dev_reg.devices.values()
-                if device.area_id == area_id
+                device.id for device in dr.async_entries_for_area(dev_reg, area_id)
             )
 
     resolved: dict[str, GroupCoordinator] = {}

--- a/custom_components/adaptive_cover_pro/state/area_resolver.py
+++ b/custom_components/adaptive_cover_pro/state/area_resolver.py
@@ -1,10 +1,12 @@
 """Area-based sensor resolution — cover area → configured sensor entity.
 
-Part of the ``state/`` boundary: this is the only place the device and area
-registries are read to derive a cover's indoor temperature sensor from its
-Home Assistant area (issue #786). Home Assistant's area registry stores a
-per-area ``temperature_entity_id`` (added HA 2024.11); when a cover has no
-explicit temp sensor configured, we fall back to its area's configured one.
+Part of the ``state/`` boundary: this module owns the device<->area registry
+hop in both directions — :func:`device_area_id` for the temperature resolver
+below (issue #786), :func:`area_device_ids` for the cover-group coordinator's
+area rosters (issue #1339) — so no caller outside ``state/`` needs a device
+registry import of its own. Home Assistant's area registry stores a per-area
+``temperature_entity_id`` (added HA 2024.11); when a cover has no explicit
+temp sensor configured, we fall back to its area's configured one.
 
 The resolver is named generically (``resolve_temperature_entity``) so a future
 device-class-scan resolver for motion/wind can be a sibling method — but only
@@ -64,6 +66,23 @@ def device_area_id(hass: HomeAssistant, device_id: str | None) -> str | None:
     if device is None:
         return None
     return device.area_id
+
+
+def area_device_ids(hass: HomeAssistant, area_id: str | None) -> list[str]:
+    """Return the ids of every device in an area, or ``[]``.
+
+    The inverse of :func:`device_area_id`, kept beside it so the whole
+    device<->area registry hop lives in exactly one place (issue #786) and the
+    cover-group coordinator needs no device registry import of its own.
+    Reads the registry's own area index rather than scanning
+    ``registry.devices`` as a mapping - that scan is deprecated and stops
+    working in HA 2027.9.0 (issue #1339). Fail-open: no area yields ``[]``.
+    """
+    if not area_id:
+        return []
+    return [
+        device.id for device in dr.async_entries_for_area(dr.async_get(hass), area_id)
+    ]
 
 
 class AreaSensorResolver:

--- a/custom_components/adaptive_cover_pro/state/area_resolver.py
+++ b/custom_components/adaptive_cover_pro/state/area_resolver.py
@@ -3,8 +3,11 @@
 Part of the ``state/`` boundary: this module owns the device<->area registry
 hop in both directions — :func:`device_area_id` for the temperature resolver
 below (issue #786), :func:`area_device_ids` for the cover-group coordinator's
-area rosters (issue #1339) — so no caller outside ``state/`` needs a device
-registry import of its own. Home Assistant's area registry stores a per-area
+area rosters (issue #1339) — so no caller outside ``state/`` *reads* the
+device registry itself. (``group_coordinator.py`` does import
+``device_registry`` for its ``EVENT_DEVICE_REGISTRY_UPDATED`` name; an event
+constant is not a registry read, and it still resolves every area through the
+two functions here.) Home Assistant's area registry stores a per-area
 ``temperature_entity_id`` (added HA 2024.11); when a cover has no explicit
 temp sensor configured, we fall back to its area's configured one.
 
@@ -73,7 +76,7 @@ def area_device_ids(hass: HomeAssistant, area_id: str | None) -> list[str]:
 
     The inverse of :func:`device_area_id`, kept beside it so the whole
     device<->area registry hop lives in exactly one place (issue #786) and the
-    cover-group coordinator needs no device registry import of its own.
+    cover-group coordinator never reads the device registry itself.
     Reads the registry's own area index rather than scanning
     ``registry.devices`` as a mapping - that scan is deprecated and stops
     working in HA 2027.9.0 (issue #1339). Fail-open: no area yields ``[]``.

--- a/tests/test_area_temp_resolution.py
+++ b/tests/test_area_temp_resolution.py
@@ -15,6 +15,7 @@ from custom_components.adaptive_cover_pro.state.area_resolver import (
     SENSOR_SOURCE_AREA,
     SENSOR_SOURCE_EXPLICIT,
     SENSOR_SOURCE_NONE,
+    area_device_ids,
 )
 
 _MOD = "custom_components.adaptive_cover_pro.state.area_resolver"
@@ -136,3 +137,58 @@ class TestResolveTemperatureEntity:
         )
         dev.assert_not_called()
         area.assert_not_called()
+
+
+class TestAreaDeviceIds:
+    """The inverse hop: area → the ids of the devices in it (issue #1339)."""
+
+    @pytest.mark.unit
+    def test_returns_device_ids_in_area(self, hass):
+        """Every device the area index holds contributes its id, in index order."""
+        first = MagicMock()
+        first.id = "dev1"
+        second = MagicMock()
+        second.id = "dev2"
+        registry = MagicMock()
+        registry.devices.get_devices_for_area_id.return_value = [first, second]
+
+        with patch(f"{_MOD}.dr.async_get", return_value=registry):
+            assert area_device_ids(hass, "area_x") == ["dev1", "dev2"]
+
+    @pytest.mark.unit
+    def test_uses_the_indexed_accessor_not_a_mapping_scan(self, hass):
+        """The area index is read directly — never a scan over every device.
+
+        This is the API-shape pin that outlives the AST guard in
+        ``test_registry_index_guard.py``: the registry's ``devices`` container
+        is spec'd without ``values``/``items``/``keys``/``get``, so a mapping
+        scan raises ``AttributeError`` instead of quietly working.
+        """
+        device = MagicMock()
+        device.id = "dev1"
+        registry = MagicMock()
+        registry.devices = MagicMock(spec=["get_devices_for_area_id"])
+        registry.devices.get_devices_for_area_id.return_value = [device]
+
+        with patch(f"{_MOD}.dr.async_get", return_value=registry):
+            assert area_device_ids(hass, "area_x") == ["dev1"]
+
+        registry.devices.get_devices_for_area_id.assert_called_once_with("area_x")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("area_id", [None, ""], ids=["none", "empty_string"])
+    def test_empty_area_returns_empty_list(self, hass, area_id):
+        """No area → no devices, and the registry is never touched (fail-open)."""
+        with patch(f"{_MOD}.dr.async_get") as async_get:
+            assert area_device_ids(hass, area_id) == []
+
+        async_get.assert_not_called()
+
+    @pytest.mark.unit
+    def test_unknown_area_returns_empty_list(self, hass):
+        """An area the index does not know resolves to no devices."""
+        registry = MagicMock()
+        registry.devices.get_devices_for_area_id.return_value = []
+
+        with patch(f"{_MOD}.dr.async_get", return_value=registry):
+            assert area_device_ids(hass, "area_missing") == []

--- a/tests/test_device_association.py
+++ b/tests/test_device_association.py
@@ -1,15 +1,21 @@
 """Tests for optional device association feature."""
 
+import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.helpers import device_registry as dr
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_DEVICE_ID,
     CONF_ENTITIES,
     CONF_SENSOR_TYPE,
     DOMAIN,
+    CoverType,
 )
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -311,3 +317,109 @@ def test_options_device_step_removal_clears_device_id():
         options.pop(CONF_DEVICE_ID, None)
 
     assert CONF_DEVICE_ID not in options
+
+
+# ---------------------------------------------------------------------------
+# async_setup_entry: stale config-entry link cleanup
+# ---------------------------------------------------------------------------
+#
+# These two characterise the loop in ``async_setup_entry`` that strips this
+# entry's id off physical devices it no longer owns.  They use the real
+# ``hass`` fixture and a real device registry — a mock would only re-pin
+# whichever registry API the production code happens to call today, which is
+# exactly what issue #1339 changes.  They deliberately carry no ``integration``
+# mark so the guard runs in every ``scripts/test`` mode.
+
+
+async def _setup_acp_entry_owning_device(
+    hass,
+    *,
+    identifiers: set[tuple[str, str]],
+    entry_id: str,
+) -> tuple[MockConfigEntry, str]:
+    """Link a foreign-owned device to a fresh ACP entry, then set that entry up.
+
+    The ACP entry's options carry no ``CONF_DEVICE_ID``, so ``async_setup_entry``
+    takes the "no device association" branch and runs the stale-link loop.
+    Returns the ACP entry and the device id.
+    """
+    owner = MockConfigEntry(domain="demo", entry_id=f"{entry_id}_owner")
+    owner.add_to_hass(hass)
+
+    acp_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Stale Link", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id=entry_id,
+        title="Stale Link",
+    )
+    acp_entry.add_to_hass(hass)
+
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get_or_create(
+        config_entry_id=owner.entry_id,
+        identifiers=identifiers,
+        name="Physical Cover",
+    )
+    device_reg.async_update_device(device.id, add_config_entry_id=acp_entry.entry_id)
+    assert acp_entry.entry_id in device_reg.async_get(device.id).config_entries
+
+    now = datetime.datetime.now(datetime.UTC).isoformat()
+    hass.states.async_set(
+        "sun.sun",
+        "above_horizon",
+        {
+            "azimuth": 180.0,
+            "elevation": 45.0,
+            "rising": True,
+            "next_rising": now,
+            "next_setting": now,
+        },
+    )
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"current_position": 100, "supported_features": 143},
+    )
+
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(acp_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return acp_entry, device.id
+
+
+@pytest.mark.asyncio
+async def test_stale_config_entry_link_removed_from_physical_device(hass):
+    """Setup strips this entry's id off a physical device it does not identify.
+
+    The device carries our config entry id but not our ``(DOMAIN, entry_id)``
+    identifier — the leftover of a device association the user has since
+    cleared.  Setting up with no ``CONF_DEVICE_ID`` must unlink it.
+    """
+    acp_entry, device_id = await _setup_acp_entry_owning_device(
+        hass,
+        identifiers={("demo", "physical-cover-1")},
+        entry_id="stale_link_removed",
+    )
+
+    device = dr.async_get(hass).async_get(device_id)
+    assert acp_entry.entry_id not in device.config_entries
+
+
+@pytest.mark.asyncio
+async def test_own_virtual_device_link_preserved(hass):
+    """A device carrying our own identifier keeps the link.
+
+    The control for the test above: it pins the surviving condition
+    (``(DOMAIN, entry_id) not in device.identifiers``), so a change to the way
+    the loop enumerates devices cannot quietly unlink our own virtual device.
+    """
+    acp_entry, device_id = await _setup_acp_entry_owning_device(
+        hass,
+        identifiers={(DOMAIN, "virtual_device_kept")},
+        entry_id="virtual_device_kept",
+    )
+
+    device = dr.async_get(hass).async_get(device_id)
+    assert acp_entry.entry_id in device.config_entries

--- a/tests/test_global_services.py
+++ b/tests/test_global_services.py
@@ -278,9 +278,15 @@ def test_resolve_string_area_id_normalized():
     config_device.area_id = None
 
     dev_reg_mock = MagicMock()
-    # devices.values() used for area expansion
-    dev_reg_mock.devices = MagicMock()
-    dev_reg_mock.devices.values = MagicMock(return_value=[area_device])
+    # The registry's own area index backs area expansion — dr.async_entries_for_area
+    # is a thin wrapper over devices.get_devices_for_area_id (issue #1339). The
+    # spec deliberately omits values()/items()/keys()/get(), so a mapping scan
+    # would raise AttributeError here rather than quietly passing, and the
+    # side_effect is area-aware so the mock encodes the index's contract.
+    dev_reg_mock.devices = MagicMock(spec=["get_devices_for_area_id"])
+    dev_reg_mock.devices.get_devices_for_area_id.side_effect = lambda area_id: (
+        [area_device] if area_id == "area_living" else []
+    )
     # async_get called for device_id resolution
     dev_reg_mock.async_get = MagicMock(return_value=config_device)
     config_device.config_entries = ["entry_abc"]

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -1078,6 +1078,195 @@ async def test_area_membership_via_device_area(hass) -> None:
     assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
 
 
+def _area_group(hass, area_id: str, entry_id: str) -> GroupCoordinator:
+    """Build an area-scoped group with empty static rosters."""
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: [],
+            CONF_GROUP_AREA: area_id,
+        },
+        entry_id=entry_id,
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    return GroupCoordinator(hass, group_entry)
+
+
+def _device_in_area(hass, area_id: str, *, unique: str) -> str:
+    """Register a device that belongs to ``area_id`` and return its id."""
+    from homeassistant.helpers import device_registry as dr
+
+    helper_entry = MockConfigEntry(domain="test", entry_id=f"helper_{unique}")
+    helper_entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=helper_entry.entry_id,
+        identifiers={("test", unique)},
+    )
+    dr.async_get(hass).async_update_device(device.id, area_id=area_id)
+    return device.id
+
+
+async def test_area_roster_includes_disabled_cover_inheriting_device_area(
+    hass,
+) -> None:
+    """A DISABLED cover that inherits its device's area still joins the roster.
+
+    The registry's per-device index defaults to excluding disabled entities,
+    so this is the semantic a naive rewrite of ``_cover_entities_in_area``
+    drops silently.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Disabled Device Area")
+    device_id = _device_in_area(hass, area.id, unique="disabled_dev")
+
+    reg = er.async_get(hass)
+    reg_entry = reg.async_get_or_create(
+        "cover",
+        "test",
+        "disabled_dev_cover",
+        suggested_object_id="disabled_dev_cover",
+        device_id=device_id,
+    )
+    reg.async_update_entity(
+        reg_entry.entity_id, disabled_by=er.RegistryEntryDisabler.USER
+    )
+
+    coordinator = _area_group(hass, area.id, "group_disabled_dev")
+
+    assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
+
+
+async def test_area_roster_includes_disabled_cover_with_own_area(hass) -> None:
+    """The own-area twin: a DISABLED cover with its own area also joins.
+
+    The entity registry's area index carries disabled entries, so this holds
+    with no extra flag — it is here so a rewrite cannot start filtering them.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Disabled Own Area")
+
+    reg = er.async_get(hass)
+    reg_entry = reg.async_get_or_create(
+        "cover",
+        "test",
+        "disabled_own_cover",
+        suggested_object_id="disabled_own_cover",
+    )
+    reg.async_update_entity(
+        reg_entry.entity_id,
+        area_id=area.id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    coordinator = _area_group(hass, area.id, "group_disabled_own")
+
+    assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
+
+
+async def test_entity_own_area_overrides_device_area_in_roster(hass) -> None:
+    """An entity's own area wins over its device's — for the roster too.
+
+    The device sits in area A, the entity names area B. It belongs to B only.
+    A device-derived roster that skipped this check would over-collect into A.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area_a = ar.async_get(hass).async_get_or_create("Override Area A")
+    area_b = ar.async_get(hass).async_get_or_create("Override Area B")
+    device_id = _device_in_area(hass, area_a.id, unique="override_dev")
+
+    reg = er.async_get(hass)
+    reg_entry = reg.async_get_or_create(
+        "cover",
+        "test",
+        "override_cover",
+        suggested_object_id="override_cover",
+        device_id=device_id,
+    )
+    reg.async_update_entity(reg_entry.entity_id, area_id=area_b.id)
+
+    scoped_to_a = _area_group(hass, area_a.id, "group_override_a")
+    scoped_to_b = _area_group(hass, area_b.id, "group_override_b")
+
+    assert reg_entry.entity_id not in scoped_to_a.generic_cover_ids()
+    assert scoped_to_b.generic_cover_ids() == [reg_entry.entity_id]
+
+
+async def test_member_entry_joins_area_via_device_area(hass) -> None:
+    """An ACP member joins the area when its cover only inherits the device's.
+
+    ``member_entry_ids`` walks each candidate entry's configured covers through
+    :meth:`_entity_area_id`, whose device fallback is the hop under test here.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Member Device Area")
+    device_id = _device_in_area(hass, area.id, unique="member_dev")
+
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "cover",
+        "test",
+        "member_dev_cover",
+        suggested_object_id="member_dev_cover",
+        device_id=device_id,
+    )
+    member = _member_entry(
+        hass, "dev_area_member", CoverType.BLIND, [reg_entry.entity_id]
+    )
+    member.runtime_data = _mock_member_coordinator()
+
+    coordinator = _area_group(hass, area.id, "group_member_dev_area")
+
+    assert coordinator.member_entry_ids() == ["dev_area_member"]
+
+
+async def test_area_roster_mixes_own_area_and_device_area_covers(hass) -> None:
+    """Both membership paths contribute to one roster.
+
+    Asserted on set membership plus length rather than exact list order: the
+    roster is a union of an own-area pass and a device-inherited pass, so the
+    ordering is own-area-first, not registry-insertion order.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Mixed Area")
+    device_id = _device_in_area(hass, area.id, unique="mixed_dev")
+
+    reg = er.async_get(hass)
+    device_cover = reg.async_get_or_create(
+        "cover",
+        "test",
+        "mixed_device_cover",
+        suggested_object_id="mixed_device_cover",
+        device_id=device_id,
+    )
+    own_cover = reg.async_get_or_create(
+        "cover",
+        "test",
+        "mixed_own_cover",
+        suggested_object_id="mixed_own_cover",
+    )
+    reg.async_update_entity(own_cover.entity_id, area_id=area.id)
+
+    coordinator = _area_group(hass, area.id, "group_mixed")
+
+    roster = coordinator.generic_cover_ids()
+    assert set(roster) == {own_cover.entity_id, device_cover.entity_id}
+    assert len(roster) == 2
+
+
 async def test_no_area_behaves_statically(group_setup) -> None:
     """Without an area, the effective rosters equal the stored rosters."""
     coordinator, _, _ = group_setup

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -1267,6 +1267,39 @@ async def test_area_roster_mixes_own_area_and_device_area_covers(hass) -> None:
     assert len(roster) == 2
 
 
+async def test_area_roster_includes_cover_whose_own_area_is_blank(hass) -> None:
+    """A blank own ``area_id`` still inherits the device's area.
+
+    HA indexes an entity's own area on ``is not None``, so an ``area_id`` of
+    ``""`` is filed under ``""`` and never appears in a real area's bucket —
+    the own-area pass cannot see it. :meth:`_entity_area_id` treats ``""`` as
+    falsy and falls through to the device, so the device pass has to agree:
+    it rejects on ``not reg_entry.area_id``, not on ``is None``.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Blank Area")
+    device_id = _device_in_area(hass, area.id, unique="blank_dev")
+
+    reg = er.async_get(hass)
+    reg_entry = reg.async_get_or_create(
+        "cover",
+        "test",
+        "blank_area_cover",
+        suggested_object_id="blank_area_cover",
+        device_id=device_id,
+    )
+    reg.async_update_entity(reg_entry.entity_id, area_id="")
+
+    coordinator = _area_group(hass, area.id, "group_blank_area")
+
+    # The precondition the two filters disagree about.
+    assert reg.async_get(reg_entry.entity_id).area_id == ""
+    assert coordinator._entity_area_id(reg_entry.entity_id) == area.id
+    assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
+
+
 async def test_no_area_behaves_statically(group_setup) -> None:
     """Without an area, the effective rosters equal the stored rosters."""
     coordinator, _, _ = group_setup
@@ -1301,6 +1334,104 @@ async def test_registry_change_reloads_when_roster_changes(hass, area_setup) -> 
     await coordinator.async_shutdown()
 
 
+async def test_registry_change_ignores_a_pure_roster_reorder(hass) -> None:
+    """Reordering the roster without changing it must not reload the entry.
+
+    Clearing a cover's own area while its device already sits in the same
+    area leaves membership identical — the cover just moves from the own-area
+    pass to the device pass, which reorders the list. The snapshot compares
+    membership, not order, so that shuffle is free.
+    """
+    from unittest.mock import patch
+
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Reorder Area")
+    # Registered first, so the device pass reaches this one first.
+    device_b = _device_in_area(hass, area.id, unique="reorder_dev_b")
+    device_a = _device_in_area(hass, area.id, unique="reorder_dev_a")
+
+    reg = er.async_get(hass)
+    cover_b = reg.async_get_or_create(
+        "cover",
+        "test",
+        "reorder_cover_b",
+        suggested_object_id="reorder_cover_b",
+        device_id=device_b,
+    )
+    cover_a = reg.async_get_or_create(
+        "cover",
+        "test",
+        "reorder_cover_a",
+        suggested_object_id="reorder_cover_a",
+        device_id=device_a,
+    )
+    reg.async_update_entity(cover_a.entity_id, area_id=area.id)
+
+    coordinator = _area_group(hass, area.id, "group_reorder")
+    await coordinator._async_setup()
+    before = coordinator.generic_cover_ids()
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock:
+        reg.async_update_entity(cover_a.entity_id, area_id=None)
+        await hass.async_block_till_done()
+        reload_mock.assert_not_awaited()
+
+    after = coordinator.generic_cover_ids()
+    # The shuffle really happened — without this the test would pass vacuously.
+    assert before != after
+    assert set(before) == set(after) == {cover_a.entity_id, cover_b.entity_id}
+
+    await coordinator.async_shutdown()
+
+
+async def test_device_registry_change_reloads_when_roster_changes(hass) -> None:
+    """Moving a *device* between areas re-resolves an area-scoped roster.
+
+    Covers inherit their device's area, so a device move changes membership
+    without touching the entity or area registries — it needs its own
+    subscription. Device events fire on every device attribute change, so the
+    first half pins that the roster-snapshot guard still absorbs the noise.
+    """
+    from unittest.mock import patch
+
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+
+    area = ar.async_get(hass).async_get_or_create("Device Move Area")
+    elsewhere = ar.async_get(hass).async_get_or_create("Device Move Elsewhere")
+    device_id = _device_in_area(hass, elsewhere.id, unique="moving_dev")
+
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "cover",
+        "test",
+        "moving_cover",
+        suggested_object_id="moving_cover",
+        device_id=device_id,
+    )
+
+    coordinator = _area_group(hass, area.id, "group_device_move")
+    await coordinator._async_setup()
+    assert coordinator.generic_cover_ids() == []
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock:
+        # A device change with no roster impact must not reload.
+        dr.async_get(hass).async_update_device(device_id, name_by_user="Renamed")
+        await hass.async_block_till_done()
+        reload_mock.assert_not_awaited()
+
+        # The device moves into the area → its cover joins → reload once.
+        dr.async_get(hass).async_update_device(device_id, area_id=area.id)
+        await hass.async_block_till_done()
+        reload_mock.assert_awaited_once_with("group_device_move")
+
+    assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
+
+    await coordinator.async_shutdown()
+
+
 async def test_registry_listener_absent_without_area(hass, group_setup) -> None:
     """Static-only groups subscribe to no registry events."""
     from unittest.mock import patch
@@ -1312,6 +1443,10 @@ async def test_registry_listener_absent_without_area(hass, group_setup) -> None:
         hass.bus.async_fire(
             "entity_registry_updated", {"action": "create", "entity_id": "cover.x"}
         )
+        hass.bus.async_fire(
+            "device_registry_updated", {"action": "update", "device_id": "dev_x"}
+        )
+        hass.bus.async_fire("area_registry_updated", {"action": "update"})
         await hass.async_block_till_done()
         reload_mock.assert_not_awaited()
 

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -109,6 +109,47 @@ async def test_cover_target_resolution_excludes_groups(hass, loaded_pair) -> Non
     assert group_coord not in targets
 
 
+async def test_cover_target_resolution_by_area(hass, loaded_pair) -> None:
+    """An area target expands through the real device registry to the cover entry.
+
+    The behavioural witness for ``_resolve_targets``' area expansion. The only
+    other coverage is mock-based, so without this the expansion could be
+    rewritten against any registry API at all and nothing would notice.
+    """
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+
+    cover_coord, group_coord = loaded_pair
+    area = ar.async_get(hass).async_get_or_create("Cover Service Area")
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id="cover_entry",
+        identifiers={(DOMAIN, "cover_entry_device")},
+    )
+    dr.async_get(hass).async_update_device(device.id, area_id=area.id)
+
+    call = MagicMock()
+    call.data = {"area_id": [area.id]}
+    targets = _resolve_targets(hass, call)
+
+    assert cover_coord in targets
+    assert group_coord not in targets
+
+
+async def test_cover_target_resolution_by_empty_area(hass, loaded_pair) -> None:
+    """An area holding no devices resolves to no coordinators."""
+    from homeassistant.helpers import area_registry as ar
+
+    cover_coord, group_coord = loaded_pair
+    area = ar.async_get(hass).async_get_or_create("Empty Service Area")
+
+    call = MagicMock()
+    call.data = {"area_id": [area.id]}
+    targets = _resolve_targets(hass, call)
+
+    assert cover_coord not in targets
+    assert group_coord not in targets
+
+
 async def test_group_target_resolution_no_target_all_groups(hass, loaded_pair) -> None:
     cover_coord, group_coord = loaded_pair
 

--- a/tests/test_registry_index_guard.py
+++ b/tests/test_registry_index_guard.py
@@ -1,0 +1,190 @@
+"""Static backstop: no integration code may treat a registry's items as a mapping.
+
+Home Assistant's device and entity registries expose their contents through
+``registry.devices`` / ``registry.entities``, which are ``BaseRegistryItems``
+(a ``UserDict`` subclass, ``homeassistant/helpers/registry.py``).  Treating
+those as plain mappings — ``.values()``, ``.items()``, ``.keys()``, ``.get()``
+or ``registry.devices[device_id]`` — is deprecated by HA and **stops working in
+Home Assistant 2027.9.0** (issue #1339).  HA's ``helpers/frame.py`` reports the
+usage today and removes the mapping surface at that version.
+
+This test parses every ``.py`` file under ``custom_components/adaptive_cover_pro``
+with the ``ast`` module, enumerates each such mapping access, and compares the
+discovered ``<relative/path.py>::<enclosing_function>`` names against a
+hard-coded exemption list.  That list is empty: issue #1339 converted the last
+four sites, and nothing in the integration may reintroduce the pattern.
+
+What to use instead
+-------------------
+The registries already maintain purpose-built indexes, and HA exposes them
+through module-level ``@callback`` helpers that are *not* deprecated:
+
+- ``dr.async_entries_for_area(registry, area_id)``
+- ``dr.async_entries_for_config_entry(registry, config_entry_id)``
+- ``er.async_entries_for_area(registry, area_id)``
+- ``er.async_entries_for_device(registry, device_id, include_disabled_entities=...)``
+- ``er.async_entries_for_config_entry(registry, config_entry_id)``
+- ``registry.async_get(device_id)`` / ``registry.async_get(entity_id)`` for a
+  single known id — this is the sanctioned replacement for
+  ``registry.devices.get(...)`` and ``registry.devices[...]``.
+
+⚠️  ``dr.async_entries_for_area`` / ``er.async_entries_for_area`` apply **no**
+``disabled_by`` filter, but ``er.async_entries_for_device`` defaults to
+``include_disabled_entities=False`` and silently drops disabled entities.  The
+two accessors are asymmetric — pass the kwarg explicitly when a full-mapping
+scan is what you are replacing.
+
+Why bare iteration is not flagged (and still not used here)
+------------------------------------------------------------
+``for device in registry.devices:`` is sanctioned by HA and is deliberately not
+flagged by this scan.  This repo still avoids it: ``UserDict.__iter__`` yields
+*keys*, so every hit needs a follow-up ``registry.async_get(key)`` — an O(n)
+scan plus O(n) redundant lookups, strictly worse than the O(1)-per-hit indexed
+accessors above.
+
+Why the container must itself be an attribute
+-----------------------------------------------
+The scan only flags a mapping access whose container is an ``ast.Attribute``
+named ``devices``/``entities`` (``some_reg.devices.values()``), never a bare
+name (``devices[key] = ...``).  A bare name is a local dict — ``config_flow.py``
+builds two of those and they are correctly excluded.
+
+How to respond when this test fails
+-------------------------------------
+1. Find the reported ``path.py::function``.  It contains a new
+   ``registry.devices``/``registry.entities`` mapping access.
+2. Replace it with the matching indexed accessor from the list above.  If you
+   need every entity for a device, remember the ``include_disabled_entities``
+   asymmetry.
+3. Only if no accessor fits, add the ``path.py::function`` string to
+   ``MAPPING_SCAN_EXEMPTIONS`` below **with a comment saying why** — and know
+   that the exemption expires when HA 2027.9.0 removes the mapping surface.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Exemptions
+# ---------------------------------------------------------------------------
+
+# Every ``<relative/path.py>::<enclosing_function>`` in the integration that is
+# allowed to access ``registry.devices`` / ``registry.entities`` as a mapping.
+# Empty since issue #1339 converted the last four sites.  The constant stays so
+# a future author who genuinely needs an exception has a documented place to
+# justify it — one entry, one comment saying why — instead of deleting the
+# guard.  Any exemption expires when HA 2027.9.0 removes the mapping surface.
+MAPPING_SCAN_EXEMPTIONS: frozenset[str] = frozenset()
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+_INTEGRATION_ROOT = (
+    pathlib.Path(__file__).parent.parent / "custom_components" / "adaptive_cover_pro"
+)
+
+# ``UserDict`` methods that HA's deprecation covers.  Bare iteration is absent
+# deliberately — see the module docstring.
+_MAPPING_METHODS = frozenset({"values", "items", "keys", "get"})
+
+# The registry container attributes themselves.
+_REGISTRY_ITEMS_ATTRS = frozenset({"devices", "entities"})
+
+
+def _enclosing_function(node: ast.AST, tree: ast.Module) -> str | None:
+    """Return the name of the innermost function/async-function containing node.
+
+    Walks the full tree and builds a parent map (there is no parent pointer in
+    the standard ast node).  The innermost enclosing FunctionDef or
+    AsyncFunctionDef wins (handles nested closures).
+    """
+    parent: dict[int, ast.AST] = {}
+    for n in ast.walk(tree):
+        for child in ast.iter_child_nodes(n):
+            parent[id(child)] = n
+
+    current = parent.get(id(node))
+    while current is not None:
+        if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef):
+            return current.name
+        current = parent.get(id(current))
+    return None
+
+
+def _is_registry_items(node: ast.AST) -> bool:
+    """Report whether node is ``<registry>.devices`` / ``<registry>.entities``.
+
+    Requiring an attribute access — rather than accepting a bare name — is what
+    keeps a plain local dict called ``devices`` or ``entities`` out of the scan.
+    """
+    return isinstance(node, ast.Attribute) and node.attr in _REGISTRY_ITEMS_ATTRS
+
+
+def _is_mapping_access(node: ast.AST) -> bool:
+    """Report whether node reads a registry-items container as a mapping."""
+    if isinstance(node, ast.Call):
+        func = node.func
+        return (
+            isinstance(func, ast.Attribute)
+            and func.attr in _MAPPING_METHODS
+            and _is_registry_items(func.value)
+        )
+    if isinstance(node, ast.Subscript):
+        return _is_registry_items(node.value)
+    return False
+
+
+def _find_mapping_scan_sites() -> list[str]:
+    """Return ``<relative/path.py>::<function>`` for every registry mapping access."""
+    hits: list[str] = []
+
+    for path in sorted(_INTEGRATION_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not _is_mapping_access(node):
+                continue
+            relative = path.relative_to(_INTEGRATION_ROOT).as_posix()
+            hits.append(f"{relative}::{_enclosing_function(node, tree)}")
+
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# The test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_registry_mapping_scans_outside_the_exemption_list():
+    """No integration code may read ``registry.devices``/``.entities`` as a mapping.
+
+    If this test fails, a new ``.values()``/``.items()``/``.keys()``/``.get()``
+    call or a ``[...]`` subscript was added against a registry-items container.
+    Follow the instructions in the module docstring to resolve the failure.
+    """
+    discovered = set(_find_mapping_scan_sites())
+
+    unknown = discovered - MAPPING_SCAN_EXEMPTIONS
+    stale = MAPPING_SCAN_EXEMPTIONS - discovered
+
+    messages = []
+    if unknown:
+        messages.append(
+            "New registry mapping scans found in the integration "
+            f"(deprecated, removed in HA 2027.9.0): {sorted(unknown)}.\n"
+            "Replace each with the matching indexed accessor — see the module "
+            "docstring of this file for the list and the disabled-entity caveat."
+        )
+    if stale:
+        messages.append(
+            f"Exempted sites no longer scan a registry as a mapping: {sorted(stale)}.\n"
+            "Remove the stale entries from MAPPING_SCAN_EXEMPTIONS in this file."
+        )
+
+    assert not messages, "\n\n".join(messages)

--- a/tests/test_registry_index_guard.py
+++ b/tests/test_registry_index_guard.py
@@ -42,12 +42,39 @@ flagged by this scan.  This repo still avoids it: ``UserDict.__iter__`` yields
 scan plus O(n) redundant lookups, strictly worse than the O(1)-per-hit indexed
 accessors above.
 
-Why the container must itself be an attribute
------------------------------------------------
-The scan only flags a mapping access whose container is an ``ast.Attribute``
-named ``devices``/``entities`` (``some_reg.devices.values()``), never a bare
-name (``devices[key] = ...``).  A bare name is a local dict — ``config_flow.py``
-builds two of those and they are correctly excluded.
+Why the container must sit on something registry-shaped
+---------------------------------------------------------
+The scan flags ``<receiver>.devices`` / ``<receiver>.entities`` only when the
+receiver itself looks like a registry: a name or attribute ending in ``reg`` /
+``registry`` (``dev_reg``, ``ent_reg``, ``self._registry``), or a call to
+``async_get`` (``er.async_get(hass).entities``).  Both narrowings matter.
+Dropping the receiver test entirely would flag a bare ``devices[key] = ...``
+local dict — ``config_flow.py`` builds two of those.  Accepting *any*
+attribute would flag this integration's own ``coordinator.entities``, a plain
+``list[str]`` read in a dozen places (``sensor.py``, ``binary_sensor.py``,
+``services/``, ``building_overview.py``'s ``record.entities``): none of them
+subscript or ``.get()`` it today, but the first one that does would fail this
+test for no reason and push the author into a bogus exemption.
+
+What this guard does NOT catch
+--------------------------------
+It is a cheap syntactic backstop, not a type checker.  Deliberately outside
+its reach, in rough order of likelihood:
+
+- ``device_id in dev_reg.devices`` — ``__contains__`` is a mapping read too.
+- ``len(reg.devices)`` and ``dict(reg.devices)`` — any coercion or builtin
+  that consumes the mapping without naming one of its methods.
+- ``reg.entities.data.values()`` — the receiver attribute is ``data``, so the
+  ``devices``/``entities`` test never sees it.
+- Aliasing: ``items = reg.entities`` followed by ``items.values()`` — the
+  scan has no dataflow, only shapes.
+- A registry reached through a subscript or an unconventionally named local
+  (``hass.data[SOMETHING].devices.values()``, ``r.devices.values()``).
+
+Closing these needs type inference and is not worth it: the realistic
+regression is someone copy-pasting the old ``dev_reg.devices.values()`` line,
+which the scan does catch.  HA's own runtime deprecation warning stays the
+backstop for the rest.
 
 How to respond when this test fails
 -------------------------------------
@@ -96,6 +123,14 @@ _MAPPING_METHODS = frozenset({"values", "items", "keys", "get"})
 # The registry container attributes themselves.
 _REGISTRY_ITEMS_ATTRS = frozenset({"devices", "entities"})
 
+# What a registry is called when it is a local, an argument or an attribute:
+# ``dev_reg``, ``ent_reg``, ``device_reg``, ``registry``, ``self._registry``.
+_REGISTRY_NAME_SUFFIXES = ("reg", "registry")
+
+# ...and how one is produced inline, where there is no name to match on:
+# ``dr.async_get(hass).devices`` / ``er.async_get(hass).entities``.
+_REGISTRY_GETTER = "async_get"
+
 
 def _enclosing_function(node: ast.AST, tree: ast.Module) -> str | None:
     """Return the name of the innermost function/async-function containing node.
@@ -117,13 +152,37 @@ def _enclosing_function(node: ast.AST, tree: ast.Module) -> str | None:
     return None
 
 
+def _is_registry_receiver(node: ast.AST) -> bool:
+    """Report whether node evaluates to something shaped like a registry.
+
+    Name/attribute suffix, or an inline ``async_get(hass)`` call.  A positive
+    test rather than a denylist of known-innocent receivers: it cannot go
+    stale as this integration grows new ``*.entities`` attributes of its own,
+    and every realistic way a registry is written here matches it.
+    """
+    if isinstance(node, ast.Name):
+        return node.id.lower().endswith(_REGISTRY_NAME_SUFFIXES)
+    if isinstance(node, ast.Attribute):
+        return node.attr.lower().endswith(_REGISTRY_NAME_SUFFIXES)
+    if isinstance(node, ast.Call):
+        func = node.func
+        return isinstance(func, ast.Attribute) and func.attr == _REGISTRY_GETTER
+    return False
+
+
 def _is_registry_items(node: ast.AST) -> bool:
     """Report whether node is ``<registry>.devices`` / ``<registry>.entities``.
 
-    Requiring an attribute access — rather than accepting a bare name — is what
-    keeps a plain local dict called ``devices`` or ``entities`` out of the scan.
+    Requiring an attribute access on a registry-shaped receiver — rather than
+    accepting any ``devices``/``entities`` — is what keeps both a plain local
+    dict and this integration's own ``coordinator.entities`` list out of the
+    scan.  See the module docstring.
     """
-    return isinstance(node, ast.Attribute) and node.attr in _REGISTRY_ITEMS_ATTRS
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr in _REGISTRY_ITEMS_ATTRS
+        and _is_registry_receiver(node.value)
+    )
 
 
 def _is_mapping_access(node: ast.AST) -> bool:
@@ -156,8 +215,82 @@ def _find_mapping_scan_sites() -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# The test
+# The tests
 # ---------------------------------------------------------------------------
+
+
+def _matches(source: str) -> bool:
+    """Whether the matcher flags ``source``, parsed as a single expression."""
+    return _is_mapping_access(ast.parse(source, mode="eval").body)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        "dev_reg.devices.values()",
+        "ent_reg.entities.values()",
+        "device_reg.devices.items()",
+        "registry.entities.keys()",
+        "self._registry.devices.get(device_id)",
+        "DEVICE_REG.devices[device_id]",
+        "er.async_get(hass).entities.values()",
+        "dr.async_get(self.hass).devices[device_id]",
+    ],
+)
+def test_matcher_flags_every_way_a_registry_scan_is_written(source):
+    """Every shape a real registry mapping scan takes here must be flagged.
+
+    The receiver narrowing this matcher does is only as good as the names it
+    recognises — pin them, so a future tightening cannot quietly turn the
+    whole guard into a no-op that passes forever.
+    """
+    assert _matches(source)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        "self.coordinator.entities[0]",
+        "coord.entities[0]",
+        "record.entities[0]",
+        "self.entities[0]",
+        "devices[device_id]",
+    ],
+)
+def test_matcher_ignores_containers_that_are_not_registries(source):
+    """ACP's own ``entities`` lists and local dicts must never be flagged.
+
+    ``coordinator.entities`` is a ``list[str]`` read across a dozen modules; a
+    false positive here would fail this guard for no reason and pressure the
+    next author into a bogus exemption.
+    """
+    assert not _matches(source)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        "hass.data[DOMAIN].devices.values()",
+        "r.devices.values()",
+        "items.values()",
+        "device_id in dev_reg.devices",
+        "len(dev_reg.devices)",
+        "dict(dev_reg.devices)",
+        "ent_reg.entities.data.values()",
+    ],
+)
+def test_matcher_misses_these_and_the_docstring_says_so(source):
+    """Pin the accepted blind spots so the module docstring stays honest.
+
+    Each of these is a real registry mapping read the scan cannot see — an
+    unrecognised receiver, an alias, ``__contains__``, a builtin, or the
+    underlying ``.data`` dict.  Listed in the docstring's "What this guard
+    does NOT catch"; if you ever close one, delete its line from both.
+    """
+    assert not _matches(source)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Home Assistant deprecated using `device_registry.devices` and `entity_registry.entities` as mappings; the pattern stops working in HA 2027.9.0. I replaced all four full-registry scans in the integration with the registries' own indexed accessors, which also lets the now-redundant filter conditions go and turns a linear scan over every device in the install into an index lookup.

- `__init__.py`: `dr.async_entries_for_config_entry` for the stale config-entry-link cleanup.
- `services/__init__.py` and `services/group_service.py`: `dr.async_entries_for_area` for area expansion.
- `group_coordinator.py`: a two-pass union over the entity registry's area and device indexes. Two details there are load-bearing and documented in the docstring. `include_disabled_entities=True` is non-default and necessary because the two HA accessors are asymmetric (`get_entries_for_area_id` applies no `disabled_by` filter, `get_entries_for_device_id` does), and the falsy `area_id` test on the device pass preserves entity-over-device area precedence.

The area to devices hop lives in `state/area_resolver.py` as `area_device_ids()`, the inverse sibling of `device_area_id()`, so `group_coordinator.py` still reads no registry directly and the hop stays in one place (issue #786).

While fixing the area rosters I found a related gap and fixed it in the second commit: an area-scoped group never heard about a device moving between areas, because HA's `EntityRegistry.async_device_modified` only emits for remove/disable. Device-inherited membership could go stale indefinitely. The coordinator now also subscribes to `EVENT_DEVICE_REGISTRY_UPDATED`, and its roster snapshot compares membership rather than order so a cover shuffling between the two passes no longer triggers a pointless reload.

A new AST backstop, `tests/test_registry_index_guard.py`, fails on any future mapping-shape scan added under `custom_components/`. The deprecation warning cannot be reproduced against the pinned HA, so the other tests pin the API shape with spec'd mocks plus real-registry behavioral tests for the disabled-entity and area-override semantics.

Note for review: `tests/test_global_services.py` swaps a mock that pinned the deprecated `.devices.values()` shape for one pinning the indexed accessor. That mock edit is a required co-change, not scope creep.

## Testing
- ✅ 15257 tests passing

## Related Issues
Refs #1339